### PR TITLE
ci: build only APK for Android release (skip AAB)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           echo "password=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
           echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
       - name: Build Android (Tauri)
-        run: pnpm -C apps/webui exec tauri android build --target aarch64
+        run: pnpm -C apps/webui exec tauri android build --target aarch64 --apk
         env:
           VITE_GATEWAY_URL: https://api.mobvibe.net
       - name: Prepare Android artifacts
@@ -127,11 +127,6 @@ jobs:
           apk=$(find apps/webui/src-tauri/gen/android/app/build/outputs/apk -name "*.apk" -path "*release*" ! -name "*unsigned*" | head -1)
           if [ -n "$apk" ]; then
             cp "$apk" "dist/mobvibe-${VERSION}.apk"
-          fi
-          # Copy and rename AAB
-          aab=$(find apps/webui/src-tauri/gen/android/app/build/outputs/bundle -name "*.aab" -path "*release*" | head -1)
-          if [ -n "$aab" ]; then
-            cp "$aab" "dist/mobvibe-${VERSION}.aab"
           fi
           ls -la dist/
       - name: Upload Android artifacts


### PR DESCRIPTION
## 变更内容

在 Tauri Android 构建命令中添加 `--apk` 标志，使 CI 只生成 APK 而不再同时生成 AAB。

### 修改

- `ci.yml`: `tauri android build --target aarch64` → `tauri android build --target aarch64 --apk`

### 原因

Release 流程中只需要 APK（publish.yml 也只上传 APK），生成 AAB 是不必要的资源浪费。