### PR TITLE
fix(webui): add safe-area-inset padding for mobile fullscreen dialogs

### DIFF
--- a/apps/webui/src/components/app/BranchSelector.tsx
+++ b/apps/webui/src/components/app/BranchSelector.tsx
@@ -67,7 +67,7 @@ export function BranchSelector({
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent
 				side="bottom"
-				className="sm:inset-x-auto sm:bottom-auto sm:top-1/2 sm:left-1/2 sm:h-auto sm:max-h-[70vh] sm:w-[28rem] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:border"
+				className="sm:inset-x-auto sm:bottom-auto sm:top-1/2 sm:left-1/2 sm:h-auto sm:max-h-[70vh] sm:w-[28rem] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:border sm:pb-0"
 			>
 				<SheetHeader>
 					<SheetTitle className="flex items-center gap-2">

--- a/apps/webui/src/components/app/CommandPalette.tsx
+++ b/apps/webui/src/components/app/CommandPalette.tsx
@@ -277,7 +277,7 @@ export function CommandPalette({
 
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
-			<AlertDialogContent className="flex h-[100svh] w-[100vw] !max-w-none flex-col overflow-hidden translate-x-0 translate-y-0 rounded-none p-0 top-0 left-0 sm:h-auto sm:max-h-[28rem] sm:!w-[36rem] sm:!max-w-[36rem] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:top-1/2 sm:left-1/2">
+			<AlertDialogContent className="flex h-[100svh] w-[100vw] !max-w-none flex-col overflow-hidden translate-x-0 translate-y-0 rounded-none p-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0 top-0 left-0 sm:h-auto sm:max-h-[28rem] sm:!w-[36rem] sm:!max-w-[36rem] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:top-1/2 sm:left-1/2">
 				{/* Search input */}
 				<div className="border-b px-4 py-3">
 					<div className="flex items-center gap-2">

--- a/apps/webui/src/components/app/FileExplorerDialog.tsx
+++ b/apps/webui/src/components/app/FileExplorerDialog.tsx
@@ -448,7 +448,7 @@ export function FileExplorerDialog({
 	return (
 		<>
 			<AlertDialog open={open} onOpenChange={onOpenChange}>
-				<AlertDialogContent className="grid h-[100svh] w-[100vw] !max-w-none min-h-0 min-w-0 grid-rows-[auto_1fr_auto] overflow-hidden translate-x-0 translate-y-0 rounded-none p-4 sm:h-[82vh] sm:!w-[98vw] sm:!max-w-[98vw] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-none top-0 left-0 sm:top-1/2 sm:left-1/2">
+				<AlertDialogContent className="grid h-[100svh] w-[100vw] !max-w-none min-h-0 min-w-0 grid-rows-[auto_1fr_auto] overflow-hidden translate-x-0 translate-y-0 rounded-none px-4 pt-[calc(1rem+env(safe-area-inset-top))] pb-[calc(1rem+env(safe-area-inset-bottom))] sm:pt-4 sm:pb-4 sm:h-[82vh] sm:!w-[98vw] sm:!max-w-[98vw] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-none top-0 left-0 sm:top-1/2 sm:left-1/2">
 					<AlertDialogHeader className="gap-2">
 						{/* Row 1: Icon + Tabs + Git Branch */}
 						<div className="flex w-full items-center gap-2">

--- a/apps/webui/src/components/app/WorkingDirectoryDialog.tsx
+++ b/apps/webui/src/components/app/WorkingDirectoryDialog.tsx
@@ -29,7 +29,7 @@ export function WorkingDirectoryDialog({
 
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
-			<AlertDialogContent className="flex h-[100svh] w-[100vw] max-w-none min-h-0 min-w-0 flex-col gap-4 overflow-hidden translate-x-0 translate-y-0 rounded-none p-4 sm:h-[80vh] sm:max-w-5xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-none top-0 left-0 sm:top-1/2 sm:left-1/2">
+			<AlertDialogContent className="flex h-[100svh] w-[100vw] max-w-none min-h-0 min-w-0 flex-col gap-4 overflow-hidden translate-x-0 translate-y-0 rounded-none px-4 pt-[calc(1rem+env(safe-area-inset-top))] pb-[calc(1rem+env(safe-area-inset-bottom))] sm:pt-4 sm:pb-4 sm:h-[80vh] sm:max-w-5xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-none top-0 left-0 sm:top-1/2 sm:left-1/2">
 				<AlertDialogHeader>
 					<AlertDialogTitle>
 						{t("workingDirectory.dialogTitle")}

--- a/apps/webui/src/components/ui/sheet.tsx
+++ b/apps/webui/src/components/ui/sheet.tsx
@@ -60,7 +60,7 @@ function SheetContent({
 				data-slot="sheet-content"
 				data-side={side}
 				className={cn(
-					"bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col bg-clip-padding text-xs/relaxed shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+					"bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col bg-clip-padding text-xs/relaxed shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-[side=bottom]:pb-[env(safe-area-inset-bottom)] data-[side=top]:pt-[env(safe-area-inset-top)] data-[side=left]:pl-[env(safe-area-inset-left)] data-[side=right]:pr-[env(safe-area-inset-right)]",
 					className,
 				)}
 				{...props}
@@ -70,7 +70,7 @@ function SheetContent({
 					<SheetPrimitive.Close data-slot="sheet-close" asChild>
 						<Button
 							variant="ghost"
-							className="absolute top-3 right-3"
+							className="absolute top-3 right-3 in-data-[side=top]:top-[calc(0.75rem+env(safe-area-inset-top))]"
 							size="icon-sm"
 						>
 							<HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />


### PR DESCRIPTION
## Summary

- **Sheet 基础组件**统一添加四方向 `env(safe-area-inset-*)` padding，所有 Sheet 实例自动受益
- **FileExplorerDialog / WorkingDirectoryDialog / CommandPalette** 三个全屏 AlertDialog 添加顶部/底部 safe-area padding
- **BranchSelector** 桌面端覆盖多余的 bottom padding（`sm:pb-0`）
- 桌面端通过 `sm:` 断点重置为原始值，`env()` 在非沉浸式环境自动回退为 0

## Test plan

- [ ] iOS 真机验证 FileExplorerDialog 顶部按钮不与状态栏重叠
- [ ] iOS 真机验证 CommandPalette 搜索框不与状态栏重叠
- [ ] iOS 真机验证 WorkingDirectoryDialog 标题不与状态栏重叠
- [ ] iOS 真机验证 BranchSelector 底部列表不被 home indicator 遮挡
- [ ] Android 真机同上验证
- [ ] 桌面端验证无多余间距（`env()` 回退为 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)