### PR TITLE
fix(webui): show copy button on mobile devices

### DIFF
--- a/apps/webui/src/components/chat/MessageItem.tsx
+++ b/apps/webui/src/components/chat/MessageItem.tsx
@@ -908,7 +908,7 @@ const MessageItemInner = ({
 					{!message.isStreaming && (
 						<button
 							type="button"
-							className="shrink-0 flex items-center justify-center size-6 rounded-full border border-border bg-background text-muted-foreground shadow-sm transition-all hover:text-foreground hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 opacity-0 group-hover/user-msg:opacity-100 focus-visible:opacity-100"
+							className="shrink-0 flex items-center justify-center size-6 rounded-full border border-border bg-background text-muted-foreground shadow-sm transition-all hover:text-foreground hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 md:opacity-0 group-hover/user-msg:opacity-100 focus-visible:opacity-100"
 							onClick={(e) => {
 								e.stopPropagation();
 								handleCopy();


### PR DESCRIPTION
## Problem

User message copy button uses `opacity-0 group-hover/user-msg:opacity-100` which relies on hover — unavailable on mobile browsers. The button is completely invisible on touch devices.

## Solution

Replace `opacity-0` with `md:opacity-0` so the button is always visible on screens < 768px (mobile), while preserving the hover-to-show behavior on desktop.

This follows the same pattern already used in `sidebar.tsx` (`SidebarMenuAction`'s `showOnHover` mode).

## Changes

- `apps/webui/src/components/chat/MessageItem.tsx`: `opacity-0` → `md:opacity-0`

## Testing

- Mobile browser / DevTools mobile mode: copy button visible next to user messages
- Desktop browser: button still hidden by default, appears on hover