### PR TITLE
fix(webui): sync editor DOM after command/resource selection

### DIFF
--- a/apps/webui/src/components/app/ChatFooter.tsx
+++ b/apps/webui/src/components/app/ChatFooter.tsx
@@ -512,6 +512,16 @@ export function ChatFooter({
 		[],
 	);
 
+	const syncEditorDOM = useCallback(
+		(blocks: ContentBlock[], cursor: number) => {
+			const editor = editorRef.current;
+			if (editor) {
+				renderEditorContents(editor, blocks, cursor);
+			}
+		},
+		[renderEditorContents],
+	);
+
 	const handleCommandClick = useCallback(
 		(result: FuzzySearchResult<AvailableCommand>) => {
 			const nextValue = `/${result.item.name}`;
@@ -521,15 +531,12 @@ export function ChatFooter({
 				setInputContents(activeSessionId, nextBlocks);
 				setInputCursor(nextValue.length);
 				// 程序化变更——浏览器 DOM 不会自动反映，需显式重建
-				const editor = editorRef.current;
-				if (editor) {
-					renderEditorContents(editor, nextBlocks, nextValue.length);
-				}
+				syncEditorDOM(nextBlocks, nextValue.length);
 			}
 			setCommandHighlight(0);
 			setCommandPickerSuppressed(true);
 		},
-		[activeSessionId, setInput, setInputContents, renderEditorContents],
+		[activeSessionId, setInput, setInputContents, syncEditorDOM],
 	);
 
 	const handleResourceNavigate = useCallback(
@@ -589,10 +596,7 @@ export function ChatFooter({
 			const nextCursor = resourceTrigger.start + tokenLabel.length;
 			updateFromEditor(nextContents, nextCursor);
 			// 程序化变更——浏览器 DOM 不会自动反映，需显式重建
-			const editor = editorRef.current;
-			if (editor) {
-				renderEditorContents(editor, nextContents, nextCursor);
-			}
+			syncEditorDOM(nextContents, nextCursor);
 			setResourceHighlight(0);
 			setResourcePickerSuppressed(true);
 			return true;
@@ -603,7 +607,7 @@ export function ChatFooter({
 			resourceTrigger,
 			resourceTokens,
 			updateFromEditor,
-			renderEditorContents,
+			syncEditorDOM,
 		],
 	);
 


### PR DESCRIPTION
## Problem

选择 command（`/` 触发）或 resource（`@` 触发）后，输入框视觉上仍显示旧文本，但发送内容正确。

## Root Cause

`ddea8e2` 的性能优化让 `useLayoutEffect` 在编辑器聚焦时跳过 DOM 重建（用户打字时浏览器 DOM 已正确，无需全量 rebuild）。但 command/resource 选择是**程序化状态变更**，浏览器 DOM 不会自动反映。由于两个 Combobox 的 `onMouseDown` 调用了 `preventDefault()` 阻止失焦，编辑器始终保持焦点，`useLayoutEffect` 永远走跳过分支。

## Fix

在 `handleCommandClick` 和 `applyResourceSelection` 中，store 更新后显式调用 `renderEditorContents`，与 `handleEditorBeforeInput` / `handleEditorPaste` 中的既有模式一致。

同时将 `renderEditorContents` 声明前移以解决 block-scoped 变量的声明顺序问题。

## Changes

- `apps/webui/src/components/app/ChatFooter.tsx`
  - Hoist `renderEditorContents` before `handleCommandClick`
  - Add explicit `renderEditorContents` call in `handleCommandClick`
  - Add explicit `renderEditorContents` call in `applyResourceSelection`