### PR TITLE
feat(webui): group consecutive tool_call messages into collapsible cards

### DIFF
--- a/apps/webui/src/components/chat/tool-call-group.tsx
+++ b/apps/webui/src/components/chat/tool-call-group.tsx
@@ -1,0 +1,136 @@
+import { ArrowDown01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+	getStatusDotColor,
+	ThoughtItemContent,
+	ToolCallItemContent,
+} from "@/components/chat/MessageItem";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import type { ToolCallStatus } from "@/lib/acp";
+import type { ChatMessage } from "@/lib/chat-store";
+import type { ToolCallGroupDisplayItem } from "@/lib/group-tool-calls";
+import { cn } from "@/lib/utils";
+
+type ToolCallGroupProps = {
+	group: ToolCallGroupDisplayItem;
+	onOpenFilePreview?: (path: string) => void;
+};
+
+type StatusCounts = {
+	completed: number;
+	failed: number;
+	pending: number;
+};
+
+function countStatuses(group: ToolCallGroupDisplayItem): StatusCounts {
+	const counts: StatusCounts = { completed: 0, failed: 0, pending: 0 };
+	for (const item of group.items) {
+		if (item.kind !== "tool_call") continue;
+		const status = (item as Extract<ChatMessage, { kind: "tool_call" }>).status;
+		if (status === "completed") counts.completed++;
+		else if (status === "failed") counts.failed++;
+		else counts.pending++;
+	}
+	return counts;
+}
+
+function resolveOverallStatus(
+	counts: StatusCounts,
+): ToolCallStatus | undefined {
+	if (counts.failed > 0) return "failed";
+	if (counts.pending > 0) return undefined;
+	return "completed";
+}
+
+export function ToolCallGroup({
+	group,
+	onOpenFilePreview,
+}: ToolCallGroupProps) {
+	const { t } = useTranslation();
+	const [open, setOpen] = useState(false);
+
+	const counts = countStatuses(group);
+	const overallStatus = resolveOverallStatus(counts);
+
+	return (
+		<Card size="sm" className="max-w-full border-border bg-background">
+			<Collapsible open={open} onOpenChange={setOpen}>
+				<CardHeader className="p-0">
+					<CollapsibleTrigger className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors rounded-t-[inherit]">
+						<HugeiconsIcon
+							icon={open ? ArrowDown01Icon : ArrowRight01Icon}
+							strokeWidth={2}
+							className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
+							aria-hidden="true"
+						/>
+						<span
+							className={cn(
+								"size-2 shrink-0 rounded-full",
+								getStatusDotColor(overallStatus),
+							)}
+						/>
+						<span className="text-sm text-foreground">
+							{t("toolCall.toolCallGroup", {
+								count: group.toolCallCount,
+							})}
+						</span>
+						<div className="ml-auto flex items-center gap-1.5">
+							{counts.completed > 0 ? (
+								<Badge variant="secondary" className="text-[10px]">
+									{t("toolCall.toolCallGroupCompleted", {
+										count: counts.completed,
+									})}
+								</Badge>
+							) : null}
+							{counts.failed > 0 ? (
+								<Badge variant="destructive" className="text-[10px]">
+									{t("toolCall.toolCallGroupFailed", {
+										count: counts.failed,
+									})}
+								</Badge>
+							) : null}
+							{counts.pending > 0 ? (
+								<Badge variant="secondary" className="text-[10px]">
+									{t("toolCall.toolCallGroupPending", {
+										count: counts.pending,
+									})}
+								</Badge>
+							) : null}
+						</div>
+					</CollapsibleTrigger>
+				</CardHeader>
+				<CollapsibleContent>
+					<CardContent className="flex flex-col gap-3 pt-0">
+						{group.items.map((item) => {
+							if (item.kind === "tool_call") {
+								return (
+									<ToolCallItemContent
+										key={item.id}
+										message={
+											item as Extract<ChatMessage, { kind: "tool_call" }>
+										}
+										onOpenFilePreview={onOpenFilePreview}
+									/>
+								);
+							}
+							return (
+								<ThoughtItemContent
+									key={item.id}
+									message={item as Extract<ChatMessage, { kind: "thought" }>}
+								/>
+							);
+						})}
+					</CardContent>
+				</CollapsibleContent>
+			</Collapsible>
+		</Card>
+	);
+}

--- a/apps/webui/src/components/ui/collapsible.tsx
+++ b/apps/webui/src/components/ui/collapsible.tsx
@@ -1,0 +1,36 @@
+import { Collapsible as CollapsiblePrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Collapsible({
+	...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+	return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+	...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+	return (
+		<CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+	);
+}
+
+function CollapsibleContent({
+	className,
+	...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Content>) {
+	return (
+		<CollapsiblePrimitive.Content
+			data-slot="collapsible-content"
+			className={cn(
+				"overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -212,7 +212,11 @@
 		"statusCompleted": "Completed",
 		"statusFailed": "Failed",
 		"statusUnknown": "Unknown",
-		"details": "Details"
+		"details": "Details",
+		"toolCallGroup": "{{count}} tool calls",
+		"toolCallGroupCompleted": "{{count}} completed",
+		"toolCallGroupFailed": "{{count}} failed",
+		"toolCallGroupPending": "{{count}} pending"
 	},
 	"languageSwitcher": {
 		"label": "Language",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -212,7 +212,11 @@
 		"statusCompleted": "完成",
 		"statusFailed": "失败",
 		"statusUnknown": "未知",
-		"details": "详情"
+		"details": "详情",
+		"toolCallGroup": "{{count}} 个工具调用",
+		"toolCallGroupCompleted": "{{count}} 完成",
+		"toolCallGroupFailed": "{{count}} 失败",
+		"toolCallGroupPending": "{{count}} 进行中"
 	},
 	"languageSwitcher": {
 		"label": "语言",

--- a/apps/webui/src/index.css
+++ b/apps/webui/src/index.css
@@ -119,6 +119,8 @@
 	--radius-2xl: calc(var(--radius) + 8px);
 	--radius-3xl: calc(var(--radius) + 12px);
 	--radius-4xl: calc(var(--radius) + 16px);
+	--animate-collapsible-down: collapsible-down 150ms ease-out;
+	--animate-collapsible-up: collapsible-up 150ms ease-out;
 }
 
 @layer base {
@@ -147,6 +149,24 @@ html.qr-scanning,
 html.qr-scanning body,
 html.qr-scanning .app-root {
 	background: transparent !important;
+}
+
+@keyframes collapsible-down {
+	from {
+		height: 0;
+	}
+	to {
+		height: var(--radix-collapsible-content-height);
+	}
+}
+
+@keyframes collapsible-up {
+	from {
+		height: var(--radix-collapsible-content-height);
+	}
+	to {
+		height: 0;
+	}
 }
 
 @keyframes sparkle-breathing {

--- a/apps/webui/src/lib/group-tool-calls.ts
+++ b/apps/webui/src/lib/group-tool-calls.ts
@@ -1,0 +1,162 @@
+import type { ChatMessage } from "@/lib/chat-store";
+
+// --- Display item types ---
+
+type ToolCallMessage = Extract<ChatMessage, { kind: "tool_call" }>;
+type ThoughtMessage = Extract<ChatMessage, { kind: "thought" }>;
+
+export type SingleDisplayItem = {
+	type: "single";
+	message: ChatMessage;
+	messageIndex: number;
+};
+
+export type ToolCallGroupDisplayItem = {
+	type: "tool_call_group";
+	items: (ToolCallMessage | ThoughtMessage)[];
+	toolCallCount: number;
+	messageIndex: number;
+	messageEndIndex: number;
+};
+
+export type DisplayItem = SingleDisplayItem | ToolCallGroupDisplayItem;
+
+// --- Grouping algorithm ---
+
+/** Message kinds that break a running tool_call group. */
+const BREAKING_KINDS = new Set(["text", "permission", "status"]);
+
+/**
+ * Groups consecutive tool_call messages into collapsible display items.
+ *
+ * Rules:
+ * - `tool_call` messages start or extend a group.
+ * - `thought` messages are "transparent": they are absorbed into the current
+ *   group only when a `tool_call` follows (lookahead).
+ * - `text`, `permission`, `status`, and `user` messages break the group.
+ * - A group with only 1 tool_call is emitted as a `single` item.
+ */
+export function groupMessages(messages: ChatMessage[]): DisplayItem[] {
+	const result: DisplayItem[] = [];
+	let i = 0;
+
+	while (i < messages.length) {
+		const msg = messages[i];
+
+		// User messages always break groups, regardless of kind.
+		if (msg.role === "user" || BREAKING_KINDS.has(msg.kind)) {
+			result.push({ type: "single", message: msg, messageIndex: i });
+			i++;
+			continue;
+		}
+
+		if (msg.kind === "tool_call") {
+			// Start collecting a potential group.
+			const groupStart = i;
+			const collected: (ToolCallMessage | ThoughtMessage)[] = [
+				msg as ToolCallMessage,
+			];
+			let toolCallCount = 1;
+			i++;
+
+			while (i < messages.length) {
+				const next = messages[i];
+
+				// User messages always break groups.
+				if (next.role === "user") break;
+
+				if (next.kind === "tool_call") {
+					collected.push(next as ToolCallMessage);
+					toolCallCount++;
+					i++;
+					continue;
+				}
+
+				if (next.kind === "thought") {
+					// Lookahead: absorb thought only if a tool_call follows.
+					if (hasToolCallAhead(messages, i + 1)) {
+						collected.push(next as ThoughtMessage);
+						i++;
+						continue;
+					}
+					// No tool_call ahead — end the group, thought becomes standalone.
+					break;
+				}
+
+				// Any other kind breaks the group.
+				break;
+			}
+
+			if (toolCallCount >= 2) {
+				result.push({
+					type: "tool_call_group",
+					items: collected,
+					toolCallCount,
+					messageIndex: groupStart,
+					messageEndIndex: groupStart + collected.length - 1,
+				});
+			} else {
+				// Single tool_call (+ possibly no absorbed thoughts): emit individually.
+				for (let j = 0; j < collected.length; j++) {
+					result.push({
+						type: "single",
+						message: collected[j],
+						messageIndex: groupStart + j,
+					});
+				}
+			}
+			continue;
+		}
+
+		// Standalone thought (not preceded by tool_call).
+		result.push({ type: "single", message: msg, messageIndex: i });
+		i++;
+	}
+
+	return result;
+}
+
+/**
+ * Checks whether a `tool_call` message exists at or after `startIndex`,
+ * skipping over consecutive `thought` messages.
+ */
+function hasToolCallAhead(
+	messages: ChatMessage[],
+	startIndex: number,
+): boolean {
+	for (let k = startIndex; k < messages.length; k++) {
+		const m = messages[k];
+		if (m.role === "user") return false;
+		if (m.kind === "tool_call") return true;
+		if (m.kind === "thought") continue;
+		return false;
+	}
+	return false;
+}
+
+// --- Index mapping for search ---
+
+/**
+ * Maps a raw message index to the corresponding displayItem index.
+ * Used by the search bar to scroll to the correct virtualizer position.
+ */
+export function messageIndexToDisplayIndex(
+	items: DisplayItem[],
+	msgIndex: number,
+): number {
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		if (item.type === "single" && item.messageIndex === msgIndex) {
+			return i;
+		}
+		if (
+			item.type === "tool_call_group" &&
+			msgIndex >= item.messageIndex &&
+			msgIndex <= item.messageEndIndex
+		) {
+			return i;
+		}
+	}
+	// Fallback: return last index.
+	return Math.max(0, items.length - 1);
+}


### PR DESCRIPTION
## Summary

- Consecutive `tool_call` messages are now grouped into a single collapsible card, reducing visual noise when AI performs multiple sequential operations
- Groups default to collapsed state showing a summary with status badge counts (completed/failed/pending)
- `thought` messages between tool_calls are transparently absorbed into groups via lookahead; single tool_calls remain ungrouped

## Changes

| File | Action |
|------|--------|
| `components/ui/collapsible.tsx` | **New** — shadcn/ui Collapsible component (radix-ui based) |
| `lib/group-tool-calls.ts` | **New** — `groupMessages()` pure function + `messageIndexToDisplayIndex()` |
| `components/chat/tool-call-group.tsx` | **New** — ToolCallGroup card (Card + Collapsible + Badge) |
| `components/chat/MessageItem.tsx` | **Modified** — Extract `ToolCallItemContent` / `ThoughtItemContent` for reuse |
| `components/app/ChatMessageList.tsx` | **Modified** — Virtualizer based on `displayItems` with index mapping |
| `i18n/locales/{en,zh}/translation.json` | **Modified** — Add group summary translation keys |
| `index.css` | **Modified** — Add collapsible animation keyframes |

## Design Decisions

- **View-layer only**: grouping is computed via `useMemo` in the render path; `chat-store` is unchanged
- **Thought transparency**: thoughts don't break groups but are only absorbed when a tool_call follows (lookahead)
- **Search compatibility**: `scrollToIndex` maps message indices to display indices internally

## Test plan

- [ ] `pnpm -C apps/webui build` passes
- [ ] `pnpm format && pnpm lint` clean (no new warnings)
- [ ] Trigger multiple consecutive tool calls → verify grouped into collapsible card
- [ ] Single tool call → verify rendered normally (no card wrapper)
- [ ] Click group summary → verify expands/collapses with animation
- [ ] Search for a tool name → verify scrolls to correct group position
- [ ] Streaming tool calls → verify group grows as new calls arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)