### PR TITLE
feat(website): reorganize sidebar into 3 logical sections

### DIFF
--- a/apps/website/src/App.tsx
+++ b/apps/website/src/App.tsx
@@ -3,10 +3,11 @@ import { DemoFooter } from "@/components/DemoFooter";
 import { DemoHeader } from "@/components/DemoHeader";
 import { DemoMessageList } from "@/components/DemoMessageList";
 import { DemoSidebar } from "@/components/DemoSidebar";
-import { useFeatures } from "@/data/features";
+import { useFeatureGroups, useFeatures } from "@/data/features";
 import { useStreamingDemo } from "@/hooks/use-streaming-demo";
 
 export default function App() {
+	const featureGroups = useFeatureGroups();
 	const features = useFeatures();
 	const [sidebarOpen, setSidebarOpen] = useState(false);
 	const { activeFeatureId, setActiveFeatureId, displayMessages } =
@@ -28,7 +29,7 @@ export default function App() {
 	return (
 		<div className="app-root flex">
 			<DemoSidebar
-				features={features}
+				groups={featureGroups}
 				activeFeatureId={activeFeatureId}
 				onFeatureSelect={setActiveFeatureId}
 				open={sidebarOpen}

--- a/apps/website/src/components/DemoSidebar.tsx
+++ b/apps/website/src/components/DemoSidebar.tsx
@@ -16,12 +16,12 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Separator } from "@/components/ui/separator";
-import type { DemoFeature } from "@/data/features";
+import type { FeatureGroup } from "@/data/features";
 import { supportedLanguages } from "@/i18n";
 import { cn } from "@/lib/utils";
 
 interface DemoSidebarProps {
-	features: DemoFeature[];
+	groups: FeatureGroup[];
 	activeFeatureId: string;
 	onFeatureSelect: (id: string) => void;
 	open: boolean;
@@ -29,7 +29,7 @@ interface DemoSidebarProps {
 }
 
 export function DemoSidebar({
-	features,
+	groups,
 	activeFeatureId,
 	onFeatureSelect,
 	open,
@@ -65,30 +65,38 @@ export function DemoSidebar({
 
 				<Separator />
 
-				{/* Feature list */}
+				{/* Feature list — grouped */}
 				<nav className="flex-1 overflow-y-auto p-2">
 					<div className="flex flex-col gap-0.5">
-						{features.map((feature) => {
-							const isActive = feature.id === activeFeatureId;
-							return (
-								<button
-									key={feature.id}
-									type="button"
-									onClick={() => {
-										onFeatureSelect(feature.id);
-										onClose();
-									}}
-									className={cn(
-										"flex items-center gap-2 rounded-none border p-2 text-left text-xs transition-colors",
-										isActive
-											? "border-primary/40 bg-muted"
-											: "border-transparent hover:bg-muted/50",
-									)}
-								>
-									<span className="truncate">{feature.title}</span>
-								</button>
-							);
-						})}
+						{groups.map((group, groupIndex) => (
+							<div key={group.key}>
+								{groupIndex > 0 && <Separator className="my-2" />}
+								<span className="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
+									{group.label}
+								</span>
+								{group.features.map((feature) => {
+									const isActive = feature.id === activeFeatureId;
+									return (
+										<button
+											key={feature.id}
+											type="button"
+											onClick={() => {
+												onFeatureSelect(feature.id);
+												onClose();
+											}}
+											className={cn(
+												"flex items-center gap-2 rounded-none border p-2 text-left text-xs transition-colors",
+												isActive
+													? "border-primary/40 bg-muted"
+													: "border-transparent hover:bg-muted/50",
+											)}
+										>
+											<span className="truncate">{feature.title}</span>
+										</button>
+									);
+								})}
+							</div>
+						))}
 					</div>
 				</nav>
 

--- a/apps/website/src/data/features.ts
+++ b/apps/website/src/data/features.ts
@@ -14,28 +14,53 @@ export interface DemoFeature {
 	messages: DemoMessage[];
 }
 
-const featureIds = [
-	"multi-machine",
-	"streaming",
-	"sessions",
-	"file-explorer",
-	"e2ee",
-	"cross-platform",
-	"acp",
+export interface FeatureGroup {
+	key: string;
+	label: string;
+	features: DemoFeature[];
+}
+
+const featureGroupDefs = [
+	{
+		key: "intro",
+		featureIds: ["what-is-mobvibe", "acp"],
+	},
+	{
+		key: "getting-started",
+		featureIds: ["install-login", "e2ee", "sessions", "cross-platform"],
+	},
+	{
+		key: "features",
+		featureIds: [
+			"multi-machine",
+			"streaming",
+			"file-explorer",
+			"git-integration",
+		],
+	},
 ] as const;
 
-export function useFeatures(): DemoFeature[] {
+export function useFeatureGroups(): FeatureGroup[] {
 	const { t } = useTranslation();
 
 	return useMemo(
 		() =>
-			featureIds.map((id) => ({
-				id,
-				title: t(`features.${id}.title`),
-				messages: t(`features.${id}.messages`, {
-					returnObjects: true,
-				}) as DemoMessage[],
+			featureGroupDefs.map((group) => ({
+				key: group.key,
+				label: t(`sidebar.groups.${group.key}`),
+				features: group.featureIds.map((id) => ({
+					id,
+					title: t(`features.${id}.title`),
+					messages: t(`features.${id}.messages`, {
+						returnObjects: true,
+					}) as DemoMessage[],
+				})),
 			})),
 		[t],
 	);
+}
+
+export function useFeatures(): DemoFeature[] {
+	const groups = useFeatureGroups();
+	return useMemo(() => groups.flatMap((g) => g.features), [groups]);
 }

--- a/apps/website/src/i18n/locales/en/translation.json
+++ b/apps/website/src/i18n/locales/en/translation.json
@@ -12,7 +12,12 @@
 		"getStarted": "Get Started"
 	},
 	"sidebar": {
-		"closeSidebar": "Close sidebar"
+		"closeSidebar": "Close sidebar",
+		"groups": {
+			"intro": "About Mobvibe",
+			"getting-started": "Getting Started",
+			"features": "Core Features"
+		}
 	},
 	"theme": {
 		"light": "Light",
@@ -39,6 +44,132 @@
 		"viewOnGitHub": "View on GitHub"
 	},
 	"features": {
+		"what-is-mobvibe": {
+			"title": "What is Mobvibe?",
+			"messages": [
+				{
+					"role": "user",
+					"content": "What is Mobvibe?"
+				},
+				{
+					"role": "assistant",
+					"content": "Mobvibe is a **remote AI coding agent management platform**. It lets you monitor and control AI agents (like Claude Code, Codex, Gemini CLI) running on any of your machines — from a single web or native interface.\n\nThe architecture is simple:\n- **CLI daemon** runs alongside your agent on each machine\n- **Gateway** relays messages between CLI and frontends\n- **WebUI / Desktop / Mobile** provides the unified interface\n\nEverything is open source, and you can self-host the entire stack."
+				},
+				{
+					"role": "user",
+					"content": "How is it different from just using the terminal?"
+				},
+				{
+					"role": "assistant",
+					"content": "Using agents directly in the terminal works, but Mobvibe adds several layers on top:\n\n- **Unified interface** — manage sessions across all machines from one place\n- **Session persistence** — reconnect anytime without losing context\n- **End-to-end encryption** — your code stays private, even from the gateway\n- **Real-time streaming** — see agent output token by token with rich rendering\n- **File explorer** — browse remote files, use @mentions to reference them\n- **Git integration** — view diffs, blame, branches without leaving the UI\n- **Permission approval** — review and approve tool calls before they execute"
+				}
+			]
+		},
+		"acp": {
+			"title": "Agent Support",
+			"messages": [
+				{
+					"role": "user",
+					"content": "Which AI agents does Mobvibe support?"
+				},
+				{
+					"role": "assistant",
+					"content": "Mobvibe supports multiple AI coding agents through the **ACP (Agent Communication Protocol)**:\n\n- **Claude Code** — Anthropic's coding agent\n- **Codex** — OpenAI's coding agent\n- **Gemini CLI** — Google's coding agent\n- **OpenCode** — Open-source coding agent\n\nACP is a transport-agnostic, streaming-first open protocol. Any agent that speaks ACP can plug into Mobvibe — new agents can be added without modifying the platform."
+				},
+				{
+					"role": "user",
+					"content": "Can I use different agents at the same time?"
+				},
+				{
+					"role": "assistant",
+					"content": "Absolutely. Each machine runs its own agent independently, so you can have:\n\n- Claude Code on your main workstation\n- Codex on a cloud VM\n- Gemini CLI on another server\n\nAll sessions appear in the same sidebar, grouped by machine. You can switch between agents instantly and even compare their approaches to the same task."
+				}
+			]
+		},
+		"install-login": {
+			"title": "Install & Login",
+			"messages": [
+				{
+					"role": "user",
+					"content": "How do I get started with Mobvibe?"
+				},
+				{
+					"role": "assistant",
+					"content": "Getting started takes just one command:\n\n```bash\nnpx @mobvibe/cli login\n```\n\nThis will:\n1. Install the Mobvibe CLI globally\n2. Open your browser for authentication\n3. Generate an **Ed25519 keypair** for secure signing\n4. Register your machine with the gateway\n\nOnce logged in, the CLI daemon starts automatically and your machine appears in the web UI at **app.mobvibe.net**."
+				},
+				{
+					"role": "user",
+					"content": "Do I need to deploy my own gateway?"
+				},
+				{
+					"role": "assistant",
+					"content": "No — by default, the CLI connects to the **public Mobvibe gateway** at `api.mobvibe.net`. This is the fastest way to get started.\n\nIf you want full control, you can self-host:\n- The gateway is a Node.js + Express + Socket.io server\n- PostgreSQL for persistence\n- Deploy anywhere — Docker, Render, or bare metal\n\nJust set `MOBVIBE_GATEWAY_URL` in your CLI config to point to your own instance."
+				}
+			]
+		},
+		"e2ee": {
+			"title": "End-to-End Encryption",
+			"messages": [
+				{
+					"role": "user",
+					"content": "How does Mobvibe protect my code?"
+				},
+				{
+					"role": "assistant",
+					"content": "Mobvibe supports **end-to-end encryption (E2EE)** using proven cryptographic primitives. When enabled, all messages are encrypted on the CLI daemon before transmission and decrypted only in your browser.\n\nThe encryption stack:\n- **X25519** for key exchange (Diffie-Hellman over Curve25519)\n- **XChaCha20-Poly1305** for authenticated encryption\n- **Ed25519** for message signing\n\nThe gateway **never sees plaintext** — it only relays encrypted payloads. Even if the gateway is compromised, your code and conversations remain private."
+				},
+				{
+					"role": "user",
+					"content": "How is the key exchange handled?"
+				},
+				{
+					"role": "assistant",
+					"content": "During the E2EE handshake, the CLI daemon and web client each generate **ephemeral X25519 keypairs**. After the Diffie-Hellman exchange, a shared secret is derived and used for symmetric encryption.\n\nKey properties:\n- **No keys stored on gateway** — it only relays the handshake\n- **Forward secrecy** — each session uses fresh keypairs\n- **Automatic setup** — E2EE is negotiated transparently when both sides support it\n\nYou can verify the encryption status in the session header — a lock icon confirms E2EE is active."
+				}
+			]
+		},
+		"sessions": {
+			"title": "Create & Manage Sessions",
+			"messages": [
+				{
+					"role": "user",
+					"content": "How do I create and manage sessions?"
+				},
+				{
+					"role": "assistant",
+					"content": "Sessions are the core of Mobvibe — each one represents a conversation with an AI agent. Here's the workflow:\n\n1. **Create** — click \"New Session\" and select a machine + working directory\n2. **Chat** — interact with the agent, send code references with @mentions\n3. **Rename** — give sessions meaningful names for easy reference\n4. **Archive** — hide completed sessions without deleting them\n\nSessions persist across reconnections. If your browser disconnects, you pick up right where you left off — full message history, agent context, everything."
+				},
+				{
+					"role": "user",
+					"content": "Can I resume a session later?"
+				},
+				{
+					"role": "assistant",
+					"content": "Absolutely. Sessions maintain their full message history including code blocks, tool outputs, and file changes. When you reconnect:\n\n- All previous messages are restored instantly\n- The agent retains its context\n- File references and @mentions remain valid\n- You can continue the conversation seamlessly\n\nThis makes Mobvibe ideal for long-running tasks — start a refactoring session in the morning, review progress in the evening, all from any device."
+				}
+			]
+		},
+		"cross-platform": {
+			"title": "Access Anywhere",
+			"messages": [
+				{
+					"role": "user",
+					"content": "What platforms does Mobvibe support?"
+				},
+				{
+					"role": "assistant",
+					"content": "Mobvibe is truly cross-platform:\n\n- **Web** — works in any modern browser\n- **Desktop** — native apps via Tauri for macOS, Windows, and Linux\n- **Mobile** — iOS and Android apps (also via Tauri)\n\nAll platforms share the same React codebase and connect to the same gateway, so your sessions sync everywhere."
+				},
+				{
+					"role": "user",
+					"content": "Are there differences between platforms?"
+				},
+				{
+					"role": "assistant",
+					"content": "The core experience is identical. Desktop and mobile apps get a few extras:\n\n- **Native notifications** when the agent completes a task\n- **Deep linking** to open sessions directly\n- **Persistent storage** for offline access to session history\n- **System theme** integration that follows your OS appearance\n\nThe web version works great too — it's the easiest way to get started."
+				}
+			]
+		},
 		"multi-machine": {
 			"title": "Multi-Machine Management",
 			"messages": [
@@ -81,29 +212,8 @@
 				}
 			]
 		},
-		"sessions": {
-			"title": "Session Management",
-			"messages": [
-				{
-					"role": "user",
-					"content": "How do sessions work in Mobvibe?"
-				},
-				{
-					"role": "assistant",
-					"content": "Each conversation with an AI agent is a **session**. Sessions persist across reconnections — if your browser disconnects, you pick up right where you left off.\n\nYou can:\n- Create new sessions on any connected machine\n- **Rename** sessions for easy reference\n- **Archive** sessions you're done with\n- Switch between active sessions instantly"
-				},
-				{
-					"role": "user",
-					"content": "Can I resume a session later?"
-				},
-				{
-					"role": "assistant",
-					"content": "Absolutely. Sessions maintain their full message history. When you reconnect, all previous messages — including code blocks, tool outputs, and file changes — are restored. The agent retains its context too, so you can continue the conversation seamlessly."
-				}
-			]
-		},
 		"file-explorer": {
-			"title": "File Explorer",
+			"title": "File Explorer & @Mentions",
 			"messages": [
 				{
 					"role": "user",
@@ -111,78 +221,36 @@
 				},
 				{
 					"role": "assistant",
-					"content": "The built-in **file explorer** lets you browse the remote file system of any connected machine directly from the web UI. You can:\n\n- Navigate directories with a familiar tree view\n- **Preview files** with syntax highlighting\n- Reference files in your messages using `@filename` mentions\n- See which files the agent has modified during a session"
+					"content": "The built-in **file explorer** lets you browse the remote file system of any connected machine directly from the web UI. You can:\n\n- Navigate directories with a familiar tree view\n- **Preview files** with syntax highlighting\n- Reference files in your messages using `@filename` mentions\n- See which files the agent has modified during a session\n- Use the **command palette** (`Ctrl+K`) to quickly jump to any file"
 				},
 				{
 					"role": "user",
-					"content": "How do @file mentions work?"
+					"content": "How does the file search work?"
 				},
 				{
 					"role": "assistant",
-					"content": "Type `@` in the message input to trigger the file picker. As you type, it filters matching files from the session's working directory. Select a file, and it gets attached as context — the agent sees the file's contents along with your message.\n\nThis is perfect for saying things like \"refactor `@utils.ts` to use async/await\"."
+					"content": "Mobvibe uses **uFuzzy** for blazing-fast fuzzy file search. Type `@` in the message input to trigger the file picker, then start typing — it matches filenames, paths, and even partial fragments.\n\nThe command palette (`Ctrl+K`) provides the same search across all files in the working directory. Results are ranked by relevance, and you can navigate with keyboard shortcuts.\n\nSelected files get attached as context — the agent sees their contents along with your message. Perfect for requests like \"refactor `@utils.ts` to use async/await\"."
 				}
 			]
 		},
-		"e2ee": {
-			"title": "End-to-End Encryption",
+		"git-integration": {
+			"title": "Git Integration",
 			"messages": [
 				{
 					"role": "user",
-					"content": "How does end-to-end encryption work?"
+					"content": "What Git features does Mobvibe offer?"
 				},
 				{
 					"role": "assistant",
-					"content": "Mobvibe supports **end-to-end encryption (E2EE)** using proven cryptographic primitives (XSalsa20-Poly1305, X25519, Ed25519). When enabled, messages are encrypted on the CLI daemon before transmission and decrypted only in your browser.\n\nThe gateway **never sees plaintext** — it only relays encrypted payloads. This means even if the gateway is compromised, your code and conversations remain private."
+					"content": "Mobvibe includes a comprehensive **Git integration** with 13 built-in functions accessible from the web UI:\n\n- **Diff viewer** — side-by-side or unified diff for any file or commit\n- **Blame** — see who changed each line and when\n- **Branch management** — create, switch, and delete branches\n- **Commit history** — browse the full log with filtering\n- **Status** — see staged, unstaged, and untracked changes\n- **Stash** — save and restore work in progress\n\nAll operations run on the remote machine and results stream back in real time."
 				},
 				{
 					"role": "user",
-					"content": "How is the key exchange handled?"
+					"content": "Are Git operations executed remotely?"
 				},
 				{
 					"role": "assistant",
-					"content": "Key exchange uses **X25519** (Diffie-Hellman over Curve25519). The CLI daemon and web client each generate ephemeral keypairs. After the handshake, a shared secret is derived and used for **XChaCha20-Poly1305** authenticated encryption.\n\nNo keys are ever stored on the gateway. Each session establishes a fresh keypair, providing forward secrecy."
-				}
-			]
-		},
-		"cross-platform": {
-			"title": "Desktop & Mobile",
-			"messages": [
-				{
-					"role": "user",
-					"content": "What platforms does Mobvibe support?"
-				},
-				{
-					"role": "assistant",
-					"content": "Mobvibe is truly cross-platform:\n\n- **Web** — works in any modern browser\n- **Desktop** — native apps via Tauri for macOS, Windows, and Linux\n- **Mobile** — iOS and Android apps (also via Tauri)\n\nAll platforms share the same React codebase and connect to the same gateway, so your sessions sync everywhere."
-				},
-				{
-					"role": "user",
-					"content": "Are there differences between platforms?"
-				},
-				{
-					"role": "assistant",
-					"content": "The core experience is identical. Desktop and mobile apps get a few extras:\n\n- **Native notifications** when the agent completes a task\n- **Deep linking** to open sessions directly\n- **Persistent storage** for offline access to session history\n- **System theme** integration that follows your OS appearance\n\nThe web version works great too — it's the easiest way to get started."
-				}
-			]
-		},
-		"acp": {
-			"title": "Use whatever agent you want claude code or codex.",
-			"messages": [
-				{
-					"role": "user",
-					"content": "What is ACP?"
-				},
-				{
-					"role": "assistant",
-					"content": "**ACP (Agent Communication Protocol)** is the open protocol Mobvibe uses for communication between the gateway, CLI daemons, and frontends. It's designed to be:\n\n- **Transport-agnostic** — works over WebSocket, HTTP, or stdio\n- **Extensible** — new message types can be added without breaking existing clients\n- **Streaming-first** — all responses support incremental delivery\n- **Secure** — optional E2EE layer built into the protocol"
-				},
-				{
-					"role": "user",
-					"content": "Can I build my own client?"
-				},
-				{
-					"role": "assistant",
-					"content": "Yes! ACP is fully documented and designed for third-party integration. You can:\n\n- Build custom frontends that connect to any Mobvibe gateway\n- Create CLI tools that interact with agents programmatically\n- Integrate agent capabilities into your existing tools and workflows\n\nThe `@mobvibe/shared` package provides TypeScript types for all protocol messages."
+					"content": "Yes — all Git operations execute on the remote machine through the CLI daemon's **RPC pipeline**. Results are streamed back to your browser in real time.\n\nWhen E2EE is enabled, file contents in diffs and blame output are encrypted end-to-end — the gateway never sees your source code.\n\nThis means you can review diffs, browse commit history, and manage branches on a remote server, all from your phone or tablet — no SSH required."
 				}
 			]
 		}

--- a/apps/website/src/i18n/locales/zh/translation.json
+++ b/apps/website/src/i18n/locales/zh/translation.json
@@ -12,7 +12,12 @@
 		"getStarted": "开始使用"
 	},
 	"sidebar": {
-		"closeSidebar": "关闭侧边栏"
+		"closeSidebar": "关闭侧边栏",
+		"groups": {
+			"intro": "了解 Mobvibe",
+			"getting-started": "快速上手",
+			"features": "核心功能"
+		}
 	},
 	"theme": {
 		"light": "浅色",
@@ -40,6 +45,132 @@
 		"viewOnGitHub": "在 GitHub 上查看"
 	},
 	"features": {
+		"what-is-mobvibe": {
+			"title": "Mobvibe 是什么？",
+			"messages": [
+				{
+					"role": "user",
+					"content": "Mobvibe 是什么？"
+				},
+				{
+					"role": "assistant",
+					"content": "Mobvibe 是一个**远程 AI 编程代理管理平台**。它让你能够从统一的 Web 或原生界面，监控和管理运行在任意机器上的 AI 代理（如 Claude Code、Codex、Gemini CLI）。\n\n架构很简单：\n- **CLI 守护进程** 在每台机器上与代理一起运行\n- **Gateway 网关** 在 CLI 和前端之间中转消息\n- **WebUI / 桌面端 / 移动端** 提供统一界面\n\n整个项目完全开源，你可以自托管全套服务。"
+				},
+				{
+					"role": "user",
+					"content": "和直接在终端使用有什么区别？"
+				},
+				{
+					"role": "assistant",
+					"content": "直接在终端使用代理当然可以，但 Mobvibe 在此基础上增加了多层能力：\n\n- **统一界面** — 从一个地方管理所有机器的会话\n- **会话持久化** — 随时重连，不丢失上下文\n- **端到端加密** — 代码保持私密，网关也看不到\n- **实时流式传输** — 逐 token 查看代理输出，富文本渲染\n- **文件浏览器** — 浏览远程文件，用 @提及引用它们\n- **Git 集成** — 查看 diff、blame、分支，无需离开界面\n- **权限审批** — 在工具调用执行前审查和批准"
+				}
+			]
+		},
+		"acp": {
+			"title": "代理支持",
+			"messages": [
+				{
+					"role": "user",
+					"content": "Mobvibe 支持哪些 AI 代理？"
+				},
+				{
+					"role": "assistant",
+					"content": "Mobvibe 通过 **ACP（代理通信协议）** 支持多种 AI 编程代理：\n\n- **Claude Code** — Anthropic 的编程代理\n- **Codex** — OpenAI 的编程代理\n- **Gemini CLI** — Google 的编程代理\n- **OpenCode** — 开源编程代理\n\nACP 是传输无关、流式优先的开放协议。任何支持 ACP 的代理都可以接入 Mobvibe——添加新代理无需修改平台。"
+				},
+				{
+					"role": "user",
+					"content": "可以同时使用不同的代理吗？"
+				},
+				{
+					"role": "assistant",
+					"content": "当然可以。每台机器独立运行自己的代理，所以你可以：\n\n- 主工作站上运行 Claude Code\n- 云端虚拟机上运行 Codex\n- 另一台服务器上运行 Gemini CLI\n\n所有会话都显示在同一个侧边栏中，按机器分组。你可以即时切换代理，甚至比较它们对同一任务的不同方案。"
+				}
+			]
+		},
+		"install-login": {
+			"title": "安装与登录",
+			"messages": [
+				{
+					"role": "user",
+					"content": "怎么开始使用 Mobvibe？"
+				},
+				{
+					"role": "assistant",
+					"content": "只需一条命令即可开始：\n\n```bash\nnpx @mobvibe/cli login\n```\n\n这会：\n1. 全局安装 Mobvibe CLI\n2. 打开浏览器进行身份验证\n3. 生成 **Ed25519 密钥对** 用于安全签名\n4. 将你的机器注册到网关\n\n登录完成后，CLI 守护进程自动启动，你的机器会出现在 **app.mobvibe.net** 的 Web 界面中。"
+				},
+				{
+					"role": "user",
+					"content": "需要自己部署 Gateway 吗？"
+				},
+				{
+					"role": "assistant",
+					"content": "不需要——默认情况下，CLI 连接到 `api.mobvibe.net` 的**公共 Mobvibe 网关**。这是最快的上手方式。\n\n如果你想完全掌控，可以自托管：\n- 网关是 Node.js + Express + Socket.io 服务\n- PostgreSQL 用于数据持久化\n- 随处部署——Docker、Render 或裸机\n\n只需在 CLI 配置中设置 `MOBVIBE_GATEWAY_URL` 指向你自己的实例即可。"
+				}
+			]
+		},
+		"e2ee": {
+			"title": "端到端加密",
+			"messages": [
+				{
+					"role": "user",
+					"content": "Mobvibe 如何保护我的代码？"
+				},
+				{
+					"role": "assistant",
+					"content": "Mobvibe 使用成熟的加密原语支持 **端到端加密 (E2EE)**。启用后，所有消息在 CLI 守护进程上加密后传输，仅在浏览器中解密。\n\n加密技术栈：\n- **X25519** 密钥交换（基于 Curve25519 的 Diffie-Hellman）\n- **XChaCha20-Poly1305** 认证加密\n- **Ed25519** 消息签名\n\n网关 **永远看不到明文**——它只转发加密的数据包。即使网关被入侵，你的代码和对话仍然是私密的。"
+				},
+				{
+					"role": "user",
+					"content": "密钥交换是如何处理的？"
+				},
+				{
+					"role": "assistant",
+					"content": "在 E2EE 握手过程中，CLI 守护进程和 Web 客户端各自生成 **临时 X25519 密钥对**。Diffie-Hellman 交换后，派生共享密钥用于对称加密。\n\n关键特性：\n- **网关不存储密钥** — 它只中转握手过程\n- **前向保密** — 每个会话使用全新密钥对\n- **自动建立** — 当双方都支持时，E2EE 透明协商\n\n你可以在会话头部验证加密状态——锁图标确认 E2EE 已激活。"
+				}
+			]
+		},
+		"sessions": {
+			"title": "创建与管理会话",
+			"messages": [
+				{
+					"role": "user",
+					"content": "如何创建和管理会话？"
+				},
+				{
+					"role": "assistant",
+					"content": "会话是 Mobvibe 的核心——每个会话代表与 AI 代理的一次对话。工作流程如下：\n\n1. **创建** — 点击「新建会话」，选择机器和工作目录\n2. **对话** — 与代理交互，使用 @提及发送代码引用\n3. **重命名** — 给会话起有意义的名称，方便查找\n4. **归档** — 隐藏已完成的会话，但不删除\n\n会话在重连时保持不变。如果浏览器断开连接，你可以从上次中断的地方继续——完整的消息历史、代理上下文，一切都在。"
+				},
+				{
+					"role": "user",
+					"content": "可以稍后恢复会话吗？"
+				},
+				{
+					"role": "assistant",
+					"content": "当然可以。会话保留完整的消息历史，包括代码块、工具输出和文件更改。重新连接时：\n\n- 所有之前的消息即时恢复\n- 代理保留其上下文\n- 文件引用和 @提及仍然有效\n- 可以无缝继续对话\n\n这使 Mobvibe 非常适合长时间运行的任务——早上开始重构会话，晚上查看进度，随时随地，任何设备。"
+				}
+			]
+		},
+		"cross-platform": {
+			"title": "随时随地访问",
+			"messages": [
+				{
+					"role": "user",
+					"content": "Mobvibe 支持哪些平台？"
+				},
+				{
+					"role": "assistant",
+					"content": "Mobvibe 真正做到了跨平台：\n\n- **Web** ——适用于任何现代浏览器\n- **桌面端** ——通过 Tauri 提供 macOS、Windows 和 Linux 原生应用\n- **移动端** ——iOS 和 Android 应用（同样基于 Tauri）\n\n所有平台共享相同的 React 代码库并连接到同一个网关，因此你的会话在所有设备间同步。"
+				},
+				{
+					"role": "user",
+					"content": "不同平台之间有区别吗？"
+				},
+				{
+					"role": "assistant",
+					"content": "核心体验完全一致。桌面端和移动端应用有一些额外功能：\n\n- 代理完成任务时的 **原生通知**\n- **深度链接** 可直接打开会话\n- **持久存储** 可离线访问会话历史\n- **系统主题** 集成，跟随操作系统外观\n\nWeb 版本同样出色——它是最简单的入门方式。"
+				}
+			]
+		},
 		"multi-machine": {
 			"title": "多机器管理",
 			"messages": [
@@ -82,29 +213,8 @@
 				}
 			]
 		},
-		"sessions": {
-			"title": "会话管理",
-			"messages": [
-				{
-					"role": "user",
-					"content": "Mobvibe 中的会话是如何工作的？"
-				},
-				{
-					"role": "assistant",
-					"content": "与 AI 代理的每次对话都是一个 **会话**。会话在重新连接时保持不变——如果浏览器断开连接，你可以从上次中断的地方继续。\n\n你可以：\n- 在任何已连接的机器上创建新会话\n- **重命名** 会话以便于查找\n- **归档** 已完成的会话\n- 即时切换活跃会话"
-				},
-				{
-					"role": "user",
-					"content": "我可以稍后恢复会话吗？"
-				},
-				{
-					"role": "assistant",
-					"content": "当然可以。会话保留完整的消息历史。重新连接时，所有之前的消息——包括代码块、工具输出和文件更改——都会恢复。代理也保留其上下文，因此你可以无缝地继续对话。"
-				}
-			]
-		},
 		"file-explorer": {
-			"title": "文件浏览器",
+			"title": "文件浏览器与 @提及",
 			"messages": [
 				{
 					"role": "user",
@@ -112,78 +222,36 @@
 				},
 				{
 					"role": "assistant",
-					"content": "内置的 **文件浏览器** 让你可以直接在 Web 界面中浏览任何已连接机器的远程文件系统。你可以：\n\n- 使用熟悉的树形视图浏览目录\n- **预览文件** 并带有语法高亮\n- 使用 `@文件名` 提及在消息中引用文件\n- 查看代理在会话期间修改了哪些文件"
+					"content": "内置的 **文件浏览器** 让你可以直接在 Web 界面中浏览任何已连接机器的远程文件系统。你可以：\n\n- 使用熟悉的树形视图浏览目录\n- **预览文件** 并带有语法高亮\n- 使用 `@文件名` 提及在消息中引用文件\n- 查看代理在会话期间修改了哪些文件\n- 使用 **命令面板**（`Ctrl+K`）快速跳转到任意文件"
 				},
 				{
 					"role": "user",
-					"content": "@文件提及是怎么工作的？"
+					"content": "文件搜索是怎么工作的？"
 				},
 				{
 					"role": "assistant",
-					"content": "在消息输入框中输入 `@` 即可触发文件选择器。输入时会从会话工作目录中过滤匹配的文件。选择文件后，它会作为上下文附加——代理会在你的消息中看到文件内容。\n\n这非常适合说「重构 `@utils.ts` 使用 async/await」之类的请求。"
+					"content": "Mobvibe 使用 **uFuzzy** 实现超快的模糊文件搜索。在消息输入框中输入 `@` 触发文件选择器，然后开始输入——它会匹配文件名、路径，甚至部分片段。\n\n命令面板（`Ctrl+K`）在工作目录中的所有文件上提供相同的搜索。结果按相关性排序，你可以使用键盘快捷键导航。\n\n选中的文件会作为上下文附加——代理会在你的消息中看到文件内容。非常适合「重构 `@utils.ts` 使用 async/await」这样的请求。"
 				}
 			]
 		},
-		"e2ee": {
-			"title": "端到端加密",
+		"git-integration": {
+			"title": "Git 集成",
 			"messages": [
 				{
 					"role": "user",
-					"content": "端到端加密是如何工作的？"
+					"content": "Mobvibe 有哪些 Git 功能？"
 				},
 				{
 					"role": "assistant",
-					"content": "Mobvibe 使用成熟的加密原语（XSalsa20-Poly1305、X25519、Ed25519）支持 **端到端加密 (E2EE)**。启用后，消息在 CLI 守护进程上加密后传输，仅在浏览器中解密。\n\n网关 **永远看不到明文**——它只转发加密的数据包。这意味着即使网关被入侵，你的代码和对话仍然是私密的。"
+					"content": "Mobvibe 包含全面的 **Git 集成**，在 Web 界面中提供 13 个内置函数：\n\n- **Diff 查看器** — 任意文件或提交的并排或统一 diff\n- **Blame** — 查看每行的修改者和时间\n- **分支管理** — 创建、切换和删除分支\n- **提交历史** — 浏览带过滤的完整日志\n- **状态** — 查看已暂存、未暂存和未跟踪的更改\n- **Stash** — 保存和恢复进行中的工作\n\n所有操作在远程机器上执行，结果实时流回。"
 				},
 				{
 					"role": "user",
-					"content": "密钥交换是如何处理的？"
+					"content": "Git 操作是在远程执行的吗？"
 				},
 				{
 					"role": "assistant",
-					"content": "密钥交换使用 **X25519**（基于 Curve25519 的 Diffie-Hellman）。CLI 守护进程和 Web 客户端各自生成临时密钥对。握手后，派生共享密钥并用于 **XChaCha20-Poly1305** 认证加密。\n\n密钥永远不会存储在网关上。每个会话都建立新的密钥对，提供前向保密性。"
-				}
-			]
-		},
-		"cross-platform": {
-			"title": "桌面端与移动端",
-			"messages": [
-				{
-					"role": "user",
-					"content": "Mobvibe 支持哪些平台？"
-				},
-				{
-					"role": "assistant",
-					"content": "Mobvibe 真正做到了跨平台：\n\n- **Web** ——适用于任何现代浏览器\n- **桌面端** ——通过 Tauri 提供 macOS、Windows 和 Linux 原生应用\n- **移动端** ——iOS 和 Android 应用（同样基于 Tauri）\n\n所有平台共享相同的 React 代码库并连接到同一个网关，因此你的会话在所有设备间同步。"
-				},
-				{
-					"role": "user",
-					"content": "不同平台之间有区别吗？"
-				},
-				{
-					"role": "assistant",
-					"content": "核心体验完全一致。桌面端和移动端应用有一些额外功能：\n\n- 代理完成任务时的 **原生通知**\n- **深度链接** 可直接打开会话\n- **持久存储** 可离线访问会话历史\n- **系统主题** 集成，跟随操作系统外观\n\nWeb 版本同样出色——它是最简单的入门方式。"
-				}
-			]
-		},
-		"acp": {
-			"title": "使用你想要的任何代理，Claude Code 或 Codex。",
-			"messages": [
-				{
-					"role": "user",
-					"content": "什么是 ACP？"
-				},
-				{
-					"role": "assistant",
-					"content": "**ACP（代理通信协议）** 是 Mobvibe 用于网关、CLI 守护进程和前端之间通信的开放协议。它的设计目标是：\n\n- **传输无关** ——支持 WebSocket、HTTP 或 stdio\n- **可扩展** ——可以添加新的消息类型而不破坏现有客户端\n- **流式优先** ——所有响应支持增量传输\n- **安全** ——协议内置可选的端到端加密层"
-				},
-				{
-					"role": "user",
-					"content": "我可以构建自己的客户端吗？"
-				},
-				{
-					"role": "assistant",
-					"content": "可以！ACP 有完整的文档，专为第三方集成而设计。你可以：\n\n- 构建连接到任何 Mobvibe 网关的自定义前端\n- 创建以编程方式与代理交互的 CLI 工具\n- 将代理能力集成到你现有的工具和工作流中\n\n`@mobvibe/shared` 包提供了所有协议消息的 TypeScript 类型。"
+					"content": "是的——所有 Git 操作通过 CLI 守护进程的 **RPC 管道** 在远程机器上执行。结果实时流回到你的浏览器。\n\n当 E2EE 启用时，diff 和 blame 输出中的文件内容都是端到端加密的——网关永远看不到你的源代码。\n\n这意味着你可以在远程服务器上查看 diff、浏览提交历史、管理分支，全部在手机或平板上操作——无需 SSH。"
 				}
 			]
 		}


### PR DESCRIPTION
## Summary

- Restructure the flat 7-item sidebar into 3 grouped sections: **About Mobvibe** → **Getting Started** → **Core Features**
- Add `FeatureGroup` interface and `useFeatureGroups()` hook for grouped data model
- Add 3 new feature conversations: What is Mobvibe, Install & Login, Git Integration
- Update existing feature content (ACP → Agent Support, enhanced E2EE/Sessions/File Explorer descriptions)
- Full EN/ZH translations for all new and modified content

## Test plan

- [ ] Open http://localhost:3010 and verify 3 sidebar sections with labels and separators
- [ ] Click each feature item — verify streaming demo plays correctly
- [ ] Switch between EN/ZH — verify all group labels and feature content translate
- [ ] Test mobile responsive: sidebar overlay, feature selection, close behavior
- [ ] `pnpm -C apps/website build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)