### PR TITLE
refactor(cli): remove agents and registry from .config.json

### DIFF
--- a/apps/mobvibe-cli/src/config.ts
+++ b/apps/mobvibe-cli/src/config.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import type { AcpBackendId, UserAgentConfig } from "@mobvibe/shared";
+import type { AcpBackendId } from "@mobvibe/shared";
 import { getGatewayUrl } from "./auth/credentials.js";
 import { loadUserConfig } from "./config-loader.js";
 import { logger } from "./lib/logger.js";
@@ -71,49 +71,6 @@ const generateMachineId = (): string => {
 	return `${hostname}-${platform}-${arch}-${username}`;
 };
 
-const userAgentToBackendConfig = (
-	agent: UserAgentConfig,
-): AcpBackendConfig => ({
-	id: agent.id,
-	label: agent.label ?? agent.id,
-	command: agent.command,
-	args: agent.args ?? [],
-	envOverrides: agent.env,
-});
-
-/**
- * Merge registry-detected backends with user-configured agents.
- *
- * 1. Registry agents form the base list
- * 2. User agents with a matching ID override the registry entry
- * 3. User agents with a new ID are appended (custom/private agents)
- */
-export const mergeBackends = (
-	registryBackends: AcpBackendConfig[],
-	userAgents: UserAgentConfig[] | undefined,
-): AcpBackendConfig[] => {
-	if (!userAgents || userAgents.length === 0) {
-		return registryBackends;
-	}
-
-	const userMap = new Map(
-		userAgents.map((a) => [a.id, userAgentToBackendConfig(a)]),
-	);
-
-	// Replace registry entries that the user overrides
-	const merged = registryBackends.map((rb) => userMap.get(rb.id) ?? rb);
-
-	// Append user-only agents not found in registry
-	const registryIds = new Set(registryBackends.map((b) => b.id));
-	for (const [id, backend] of userMap) {
-		if (!registryIds.has(id)) {
-			merged.push(backend);
-		}
-	}
-
-	return merged;
-};
-
 export const getCliConfig = async (): Promise<CliConfig> => {
 	const env = process.env;
 	const homePath = env.MOBVIBE_HOME ?? path.join(os.homedir(), ".mobvibe");
@@ -128,27 +85,12 @@ export const getCliConfig = async (): Promise<CliConfig> => {
 		}
 	}
 
-	const registryConfig = userConfigResult.config?.registry;
-
-	// Detect backends from registry (unless disabled)
-	let registryBackends: AcpBackendConfig[] = [];
-	if (!registryConfig?.disabled) {
-		const registry = await getRegistry({
-			homePath,
-			url: registryConfig?.url,
-			cacheTtlMs: registryConfig?.cacheTtlMs,
-		});
-
-		if (registry) {
-			registryBackends = await detectAgents(registry);
-		}
+	// Detect backends from registry
+	let backends: AcpBackendConfig[] = [];
+	const registry = await getRegistry({ homePath });
+	if (registry) {
+		backends = await detectAgents(registry);
 	}
-
-	// Merge registry + user backends
-	const backends = mergeBackends(
-		registryBackends,
-		userConfigResult.config?.agents,
-	);
 
 	// Get gateway URL (env var > credentials file > default production URL)
 	const gatewayUrl = await getGatewayUrl();

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -71,7 +71,6 @@ export type {
 // Agent configuration types
 export type {
 	MobvibeUserConfig,
-	RegistryConfig,
 	UserAgentConfig,
 } from "./types/agent-config.js";
 // Error types

--- a/packages/shared/src/types/agent-config.ts
+++ b/packages/shared/src/types/agent-config.ts
@@ -1,5 +1,6 @@
 /**
  * User-defined agent configuration for custom ACP backends.
+ * Used internally by registry agent-detector; no longer part of user config.
  */
 export type UserAgentConfig = {
 	/** Unique identifier for this agent (e.g., "opencode", "my-agent") */
@@ -14,24 +15,10 @@ export type UserAgentConfig = {
 	env?: Record<string, string>;
 };
 
-/** Registry auto-detection settings */
-export type RegistryConfig = {
-	/** Disable registry auto-detection entirely */
-	disabled?: boolean;
-	/** Cache TTL in milliseconds (default: 3600000 = 1 hour) */
-	cacheTtlMs?: number;
-	/** Custom registry URL (overrides the default CDN) */
-	url?: string;
-};
-
 /**
  * User configuration file format for $HOME/.mobvibe/.config.json
  */
 export type MobvibeUserConfig = {
-	/** List of agent configurations */
-	agents?: UserAgentConfig[];
 	/** Base directory for git worktrees (default: ~/.mobvibe/worktrees) */
 	worktreeBaseDir?: string;
-	/** Registry auto-detection settings */
-	registry?: RegistryConfig;
 };


### PR DESCRIPTION
## Summary
- Remove `agents` and `registry` fields from `MobvibeUserConfig`, keeping only `worktreeBaseDir`
- Delete `RegistryConfig` type and its export from shared package
- Remove `validateAgentConfig()`, `userAgentToBackendConfig()`, `mergeBackends()` (~130 lines)
- Simplify `getCliConfig()` to always use default registry parameters
- Replace `console.log` with pino `logger` in config-loader

## Test plan
- [x] `pnpm -C packages/shared build` — shared types build
- [x] `pnpm -C apps/mobvibe-cli build` — CLI build
- [x] `pnpm -C apps/mobvibe-cli test` — 171 tests pass
- [x] `pnpm -C apps/mobvibe-cli build:bin` — binary compilation (5 platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)