### PR TITLE
feat(webui): show target machine and improve default cwd in create dialog

### DIFF
--- a/apps/webui/src/components/app/CreateSessionDialog.tsx
+++ b/apps/webui/src/components/app/CreateSessionDialog.tsx
@@ -1,3 +1,5 @@
+import { ComputerIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -73,7 +75,11 @@ export function CreateSessionDialog({
 		setDraftWorktreeBranch,
 		setDraftWorktreeBaseBranch,
 	} = useUiStore();
-	const { selectedMachineId } = useMachinesStore();
+	const { selectedMachineId, machines } = useMachinesStore();
+	const machineDisplayName = selectedMachineId
+		? (machines[selectedMachineId]?.hostname ?? selectedMachineId.slice(0, 8))
+		: undefined;
+
 	const rootsQuery = useQuery({
 		queryKey: ["fs-roots", selectedMachineId],
 		queryFn: () => fetchFsRoots({ machineId: selectedMachineId ?? undefined }),
@@ -157,6 +163,18 @@ export function CreateSessionDialog({
 						{t("session.createDescription")}
 					</AlertDialogDescription>
 				</AlertDialogHeader>
+				{machineDisplayName ? (
+					<div className="text-muted-foreground flex items-center gap-1.5 text-sm">
+						<HugeiconsIcon
+							icon={ComputerIcon}
+							strokeWidth={2}
+							className="size-4"
+						/>
+						<span>
+							{t("session.targetMachine", { name: machineDisplayName })}
+						</span>
+					</div>
+				) : null}
 				<div className="flex min-w-0 flex-col gap-3">
 					<div className="flex flex-col gap-2">
 						<Label htmlFor="session-title">{t("session.titleLabel")}</Label>

--- a/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
@@ -1,0 +1,236 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatSession } from "@/lib/chat-store";
+import type { Machine } from "@/lib/machines-store";
+import {
+	type UseSessionHandlersParams,
+	useSessionHandlers,
+} from "../useSessionHandlers";
+
+vi.mock("@/lib/chat-store", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/chat-store")>();
+	return {
+		...actual,
+		useChatStore: {
+			getState: () => ({ sessions: {} }),
+		},
+	};
+});
+
+vi.mock("@/lib/ui-store", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/ui-store")>();
+	return {
+		...actual,
+		useUiStore: {
+			getState: () => ({
+				draftTitle: "",
+				draftBackendId: undefined,
+				draftCwd: undefined,
+				draftWorktreeEnabled: false,
+				draftWorktreeBranch: "",
+				draftWorktreeBaseBranch: undefined,
+				editingSessionId: undefined,
+				editingTitle: "",
+			}),
+		},
+	};
+});
+
+const createMockUiActions = (): UseSessionHandlersParams["uiActions"] => ({
+	setMobileMenuOpen: vi.fn(),
+	setCreateDialogOpen: vi.fn(),
+	setDraftTitle: vi.fn(),
+	setDraftBackendId: vi.fn(),
+	setDraftCwd: vi.fn(),
+	resetDraftWorktree: vi.fn(),
+	clearEditingSession: vi.fn(),
+});
+
+const createMockChatActions = (): UseSessionHandlersParams["chatActions"] => ({
+	setAppError: vi.fn(),
+	renameSession: vi.fn(),
+	setError: vi.fn(),
+	setSending: vi.fn(),
+	setCanceling: vi.fn(),
+	setInput: vi.fn(),
+	setInputContents: vi.fn(),
+	addUserMessage: vi.fn(),
+});
+
+const createMockMutations = (): UseSessionHandlersParams["mutations"] => ({
+	createSessionMutation: {
+		mutateAsync: vi.fn(),
+		isPending: false,
+	},
+	renameSessionMutation: { mutate: vi.fn() },
+	archiveSessionMutation: { mutateAsync: vi.fn() },
+	bulkArchiveSessionsMutation: { mutateAsync: vi.fn(), isPending: false },
+	cancelSessionMutation: { mutate: vi.fn(), mutateAsync: vi.fn() },
+	setSessionModeMutation: { mutate: vi.fn(), isPending: false },
+	setSessionModelMutation: { mutate: vi.fn(), isPending: false },
+	sendMessageMutation: { mutate: vi.fn() },
+	permissionDecisionMutation: { mutate: vi.fn() },
+});
+
+const createBaseSession = (overrides: Partial<ChatSession> = {}): ChatSession =>
+	({
+		sessionId: "session-1",
+		machineId: "machine-1",
+		backendId: "backend-1",
+		cwd: "/projects/bar",
+		title: "Session 1",
+		isAttached: true,
+		sending: false,
+		canceling: false,
+		isLoading: false,
+		input: "",
+		inputContents: [],
+		messages: [],
+		error: undefined,
+		worktreeSourceCwd: undefined,
+		...overrides,
+	}) as unknown as ChatSession;
+
+describe("useSessionHandlers — handleOpenCreateDialog", () => {
+	let queryClient: QueryClient;
+	let uiActions: ReturnType<typeof createMockUiActions>;
+	let chatActions: ReturnType<typeof createMockChatActions>;
+	let mutations: ReturnType<typeof createMockMutations>;
+
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+
+	const renderHandlers = (
+		overrides: Partial<UseSessionHandlersParams> = {},
+	) => {
+		const defaults: UseSessionHandlersParams = {
+			sessions: {},
+			activeSessionId: undefined,
+			activeSession: undefined,
+			sessionList: [],
+			selectedMachineId: "machine-1",
+			lastCreatedCwd: {},
+			machines: {
+				"machine-1": {
+					machineId: "machine-1",
+					hostname: "dev-box",
+					connected: true,
+				} as Machine,
+			},
+			defaultBackendId: "backend-1",
+			chatActions,
+			uiActions,
+			mutations,
+			activateSession: vi.fn(),
+			isActivating: false,
+			syncSessionHistory: vi.fn(),
+		};
+
+		return renderHook(() => useSessionHandlers({ ...defaults, ...overrides }), {
+			wrapper,
+		});
+	};
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false } },
+		});
+		uiActions = createMockUiActions();
+		chatActions = createMockChatActions();
+		mutations = createMockMutations();
+		vi.clearAllMocks();
+	});
+
+	it("uses lastCreatedCwd when available (highest priority)", () => {
+		const activeSession = createBaseSession({ cwd: "/projects/bar" });
+
+		const { result } = renderHandlers({
+			activeSessionId: "session-1",
+			activeSession,
+			lastCreatedCwd: { "machine-1": "/projects/foo" },
+		});
+
+		result.current.handleOpenCreateDialog();
+
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith("/projects/foo");
+	});
+
+	it("falls back to active session cwd when on same machine", () => {
+		const activeSession = createBaseSession({
+			machineId: "machine-1",
+			cwd: "/projects/bar",
+		});
+
+		const { result } = renderHandlers({
+			activeSessionId: "session-1",
+			activeSession,
+			lastCreatedCwd: {},
+		});
+
+		result.current.handleOpenCreateDialog();
+
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith("/projects/bar");
+	});
+
+	it("uses worktreeSourceCwd for worktree sessions", () => {
+		const activeSession = createBaseSession({
+			machineId: "machine-1",
+			cwd: "~/.mobvibe/worktrees/repo/feat",
+			worktreeSourceCwd: "/projects/repo",
+		});
+
+		const { result } = renderHandlers({
+			activeSessionId: "session-1",
+			activeSession,
+			lastCreatedCwd: {},
+		});
+
+		result.current.handleOpenCreateDialog();
+
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith("/projects/repo");
+	});
+
+	it("does not use active session cwd when on different machine", () => {
+		const activeSession = createBaseSession({
+			machineId: "machine-2",
+			cwd: "/projects/other",
+		});
+
+		const { result } = renderHandlers({
+			activeSessionId: "session-1",
+			activeSession,
+			selectedMachineId: "machine-1",
+			lastCreatedCwd: {},
+		});
+
+		result.current.handleOpenCreateDialog();
+
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith(undefined);
+	});
+
+	it("sets undefined when no active session", () => {
+		const { result } = renderHandlers({
+			activeSessionId: undefined,
+			activeSession: undefined,
+			lastCreatedCwd: {},
+		});
+
+		result.current.handleOpenCreateDialog();
+
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith(undefined);
+	});
+
+	it("sets undefined when no machine is selected", () => {
+		const { result } = renderHandlers({
+			selectedMachineId: null,
+			lastCreatedCwd: {},
+		});
+
+		result.current.handleOpenCreateDialog();
+
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith(undefined);
+	});
+});

--- a/apps/webui/src/hooks/useSessionHandlers.ts
+++ b/apps/webui/src/hooks/useSessionHandlers.ts
@@ -140,9 +140,17 @@ export function useSessionHandlers({
 	const handleOpenCreateDialog = () => {
 		uiActions.setDraftTitle(buildSessionTitle(sessionList, t));
 		uiActions.setDraftBackendId(defaultBackendId);
-		uiActions.setDraftCwd(
-			selectedMachineId ? lastCreatedCwd[selectedMachineId] : undefined,
-		);
+
+		// CWD priority: lastCreatedCwd > activeSession cwd (same machine) > undefined (fallback to homePath in dialog)
+		let initialCwd: string | undefined;
+		if (selectedMachineId) {
+			initialCwd = lastCreatedCwd[selectedMachineId];
+			if (!initialCwd && activeSession?.machineId === selectedMachineId) {
+				initialCwd = activeSession.worktreeSourceCwd || activeSession.cwd;
+			}
+		}
+		uiActions.setDraftCwd(initialCwd);
+
 		uiActions.resetDraftWorktree();
 		uiActions.setCreateDialogOpen(true);
 	};

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -79,6 +79,7 @@
 		"cwdLabel": "Working directory",
 		"cwdPlaceholder": "Enter or paste a Home path",
 		"browse": "Browse",
+		"targetMachine": "Target: {{name}}",
 		"archiveAll": "Archive All",
 		"archiveAllTitle": "Archive all sessions?",
 		"archiveAllDescription": "This will archive {{count}} session(s), ending their backend processes and hiding them from the list.",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -79,6 +79,7 @@
 		"cwdLabel": "工作目录",
 		"cwdPlaceholder": "输入或粘贴 Home 内路径",
 		"browse": "浏览",
+		"targetMachine": "目标机器：{{name}}",
 		"archiveAll": "全部归档",
 		"archiveAllTitle": "归档所有对话？",
 		"archiveAllDescription": "将归档 {{count}} 个对话，结束后端进程并从列表中隐藏。",


### PR DESCRIPTION
## Summary
- Display the target machine hostname in the create session dialog, so users know which machine the new session will be created on
- Optimize default CWD priority: `lastCreatedCwd` > active session cwd (same machine, with worktree support) > `homePath` fallback
- Add i18n translations for the target machine label (en/zh)
- Add 6 unit tests covering `handleOpenCreateDialog` CWD logic

## Test plan
- [x] `pnpm -C apps/webui test:run` — all 341 tests pass (6 new)
- [x] `pnpm -C apps/webui build` — builds successfully
- [x] `pnpm format && pnpm lint` — no new warnings
- [ ] Manual: verify target machine label shows correct hostname in multi-machine setup
- [ ] Manual: verify active session cwd is used as default when creating new session on same machine
- [ ] Manual: verify worktree session uses `worktreeSourceCwd` as default cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)