### PR TITLE
feat(cli): TUI agent selection with enabledAgents config persistence

### DIFF
--- a/apps/mobvibe-cli/package.json
+++ b/apps/mobvibe-cli/package.json
@@ -50,6 +50,7 @@
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^0.14.1",
+		"@clack/prompts": "^1.0.1",
 		"commander": "^13.1.0",
 		"ignore": "^7.0.4",
 		"open": "^10.1.0",

--- a/apps/mobvibe-cli/src/__tests__/config-loader.test.ts
+++ b/apps/mobvibe-cli/src/__tests__/config-loader.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { loadUserConfig, saveUserConfig } from "../config-loader.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mobvibe-cfg-test-"));
+});
+
+afterEach(async () => {
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("loadUserConfig — enabledAgents validation", () => {
+	it("accepts valid enabledAgents string array", async () => {
+		const configPath = path.join(tmpDir, ".config.json");
+		await fs.writeFile(
+			configPath,
+			JSON.stringify({ enabledAgents: ["claude-code", "aider"] }),
+		);
+
+		const result = await loadUserConfig(tmpDir);
+		expect(result.errors).toHaveLength(0);
+		expect(result.config?.enabledAgents).toEqual(["claude-code", "aider"]);
+	});
+
+	it("accepts empty enabledAgents array", async () => {
+		const configPath = path.join(tmpDir, ".config.json");
+		await fs.writeFile(configPath, JSON.stringify({ enabledAgents: [] }));
+
+		const result = await loadUserConfig(tmpDir);
+		expect(result.errors).toHaveLength(0);
+		expect(result.config?.enabledAgents).toEqual([]);
+	});
+
+	it("rejects enabledAgents that is not an array", async () => {
+		const configPath = path.join(tmpDir, ".config.json");
+		await fs.writeFile(
+			configPath,
+			JSON.stringify({ enabledAgents: "claude-code" }),
+		);
+
+		const result = await loadUserConfig(tmpDir);
+		expect(result.errors).toContain(
+			"enabledAgents: must be an array of strings",
+		);
+		expect(result.config).toBeNull();
+	});
+
+	it("rejects enabledAgents with non-string elements", async () => {
+		const configPath = path.join(tmpDir, ".config.json");
+		await fs.writeFile(
+			configPath,
+			JSON.stringify({ enabledAgents: ["claude-code", 42] }),
+		);
+
+		const result = await loadUserConfig(tmpDir);
+		expect(result.errors).toContain(
+			"enabledAgents: every element must be a string",
+		);
+		expect(result.config).toBeNull();
+	});
+
+	it("returns undefined enabledAgents when field is absent", async () => {
+		const configPath = path.join(tmpDir, ".config.json");
+		await fs.writeFile(configPath, JSON.stringify({ worktreeBaseDir: "/tmp" }));
+
+		const result = await loadUserConfig(tmpDir);
+		expect(result.errors).toHaveLength(0);
+		expect(result.config?.enabledAgents).toBeUndefined();
+	});
+
+	it("returns null config when no file exists", async () => {
+		const result = await loadUserConfig(tmpDir);
+		expect(result.errors).toHaveLength(0);
+		expect(result.config).toBeNull();
+	});
+});
+
+describe("saveUserConfig", () => {
+	it("creates config file with patch when none exists", async () => {
+		await saveUserConfig(tmpDir, { enabledAgents: ["claude-code"] });
+
+		const configPath = path.join(tmpDir, ".config.json");
+		const content = JSON.parse(await fs.readFile(configPath, "utf-8"));
+		expect(content.enabledAgents).toEqual(["claude-code"]);
+	});
+
+	it("merges patch into existing config preserving other fields", async () => {
+		const configPath = path.join(tmpDir, ".config.json");
+		await fs.writeFile(
+			configPath,
+			JSON.stringify({ worktreeBaseDir: "/custom/path" }),
+		);
+
+		await saveUserConfig(tmpDir, { enabledAgents: ["aider"] });
+
+		const content = JSON.parse(await fs.readFile(configPath, "utf-8"));
+		expect(content.worktreeBaseDir).toBe("/custom/path");
+		expect(content.enabledAgents).toEqual(["aider"]);
+	});
+
+	it("overwrites existing enabledAgents on re-save", async () => {
+		await saveUserConfig(tmpDir, { enabledAgents: ["a", "b"] });
+		await saveUserConfig(tmpDir, { enabledAgents: ["c"] });
+
+		const configPath = path.join(tmpDir, ".config.json");
+		const content = JSON.parse(await fs.readFile(configPath, "utf-8"));
+		expect(content.enabledAgents).toEqual(["c"]);
+	});
+
+	it("creates parent directory if it does not exist", async () => {
+		const nestedDir = path.join(tmpDir, "nested", "dir");
+
+		await saveUserConfig(nestedDir, { enabledAgents: [] });
+
+		const configPath = path.join(nestedDir, ".config.json");
+		const content = JSON.parse(await fs.readFile(configPath, "utf-8"));
+		expect(content.enabledAgents).toEqual([]);
+	});
+
+	it("handles corrupted existing config by starting fresh", async () => {
+		const configPath = path.join(tmpDir, ".config.json");
+		await fs.writeFile(configPath, "not valid json{{{");
+
+		await saveUserConfig(tmpDir, { enabledAgents: ["x"] });
+
+		const content = JSON.parse(await fs.readFile(configPath, "utf-8"));
+		expect(content.enabledAgents).toEqual(["x"]);
+	});
+});

--- a/packages/shared/src/types/agent-config.ts
+++ b/packages/shared/src/types/agent-config.ts
@@ -21,4 +21,6 @@ export type UserAgentConfig = {
 export type MobvibeUserConfig = {
 	/** Base directory for git worktrees (default: ~/.mobvibe/worktrees) */
 	worktreeBaseDir?: string;
+	/** Agent IDs the user has chosen to enable (e.g., ["claude-code", "aider"]) */
+	enabledAgents?: string[];
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: ^0.14.1
         version: 0.14.1(zod@4.3.5)
+      '@clack/prompts':
+        specifier: ^1.0.1
+        version: 1.0.1
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -681,6 +684,12 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@clack/core@1.0.1':
+    resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
+
+  '@clack/prompts@1.0.1':
+    resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -6098,6 +6107,17 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.3.11':
     optional: true
+
+  '@clack/core@1.0.1':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.0.1':
+    dependencies:
+      '@clack/core': 1.0.1
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@csstools/color-helpers@5.1.0': {}
 


### PR DESCRIPTION
## Summary

- **TUI multiselect on first run**: When `enabledAgents` is not yet configured and the terminal is interactive, `mobvibe start` prompts the user to select which agents to enable via `@clack/prompts` multiselect
- **Single filtering point in `getCliConfig()`**: All downstream consumers (gateway registration, session discovery, session creation) automatically receive only the enabled backends — no per-consumer changes needed
- **Config persistence**: Selections saved to `~/.mobvibe/.config.json` via new `saveUserConfig()` merge-write function; supports `MOBVIBE_ENABLED_AGENTS` env var override
- **Backend stderr cleanup**: Redirected `child.stderr.pipe(process.stderr)` to pino debug logs, preventing agent stderr from leaking into the user's terminal

## Changed files

| File | Change |
|---|---|
| `packages/shared/src/types/agent-config.ts` | Added `enabledAgents?: string[]` to `MobvibeUserConfig` |
| `apps/mobvibe-cli/src/config-loader.ts` | Added `enabledAgents` validation + `saveUserConfig()` |
| `apps/mobvibe-cli/src/config.ts` | Added `enabledAgents` to `CliConfig`; filtering logic in `getCliConfig()` |
| `apps/mobvibe-cli/src/index.ts` | TUI multiselect prompt in `start` command |
| `apps/mobvibe-cli/src/acp/acp-connection.ts` | stderr → pino debug log |
| `apps/mobvibe-cli/package.json` | Added `@clack/prompts` dependency |
| `apps/mobvibe-cli/src/__tests__/config-loader.test.ts` | 11 unit tests for validation + saveUserConfig |

## Test plan

- [x] `pnpm -C packages/shared build` — shared types build
- [x] `pnpm -C apps/mobvibe-cli build` — CLI build
- [x] `pnpm -C apps/mobvibe-cli test` — 182 tests pass, 0 fail
- [x] `pnpm -C apps/mobvibe-cli build:bin` — binary compilation (5 platforms)
- [ ] Delete `~/.mobvibe/.config.json` → `mobvibe start --foreground` → verify TUI appears, selection saved, unselected agents not spawned
- [ ] Re-run `mobvibe start --foreground` → verify no TUI, only selected agents active
- [ ] Set `MOBVIBE_ENABLED_AGENTS=claude-code` env var → verify override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)