### PR TITLE
feat(webui): add ACP agent plan indicator in header

### DIFF
--- a/apps/webui/src/App.tsx
+++ b/apps/webui/src/App.tsx
@@ -603,6 +603,7 @@ function MainApp() {
 						statusMessage={statusMessage}
 						streamError={streamError}
 						loadingMessage={loadingMessage}
+						plan={activeSession?.plan}
 						onOpenMobileMenu={() => uiActions.setMobileMenuOpen(true)}
 						onOpenFileExplorer={() => uiActions.setFileExplorerOpen(true)}
 						onOpenCommandPalette={() => uiActions.setCommandPaletteOpen(true)}

--- a/apps/webui/src/components/app/AppHeader.tsx
+++ b/apps/webui/src/components/app/AppHeader.tsx
@@ -7,6 +7,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useTranslation } from "react-i18next";
 import { UserMenu } from "@/components/auth/UserMenu";
+import PlanIndicator from "@/components/plan/plan-indicator";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -20,6 +21,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import type { PlanEntry } from "@/lib/acp";
 import type { ChatSession } from "@/lib/chat-store";
 
 export type AppHeaderProps = {
@@ -27,6 +29,7 @@ export type AppHeaderProps = {
 	statusMessage?: string;
 	streamError?: ChatSession["streamError"];
 	loadingMessage?: string;
+	plan?: PlanEntry[];
 	onOpenMobileMenu: () => void;
 	onOpenFileExplorer?: () => void;
 	onOpenCommandPalette?: () => void;
@@ -45,6 +48,7 @@ export function AppHeader({
 	statusMessage,
 	streamError,
 	loadingMessage,
+	plan,
 	onOpenMobileMenu,
 	onOpenFileExplorer,
 	onOpenCommandPalette,
@@ -90,6 +94,7 @@ export function AppHeader({
 							{backendLabel}
 						</Badge>
 					) : null}
+					{plan && plan.length > 0 ? <PlanIndicator plan={plan} /> : null}
 				</div>
 				{showSyncHistory ? (
 					<Button

--- a/apps/webui/src/components/plan/plan-indicator.tsx
+++ b/apps/webui/src/components/plan/plan-indicator.tsx
@@ -1,0 +1,321 @@
+import { ArrowDown01Icon, ArrowUp01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { LazyStreamdown } from "@/components/chat/LazyStreamdown";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+} from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-mobile";
+import type { PlanEntry, PlanEntryPriority, PlanEntryStatus } from "@/lib/acp";
+import { cn } from "@/lib/utils";
+
+// --- Helpers ---
+
+type PlanStatusCounts = {
+	completed: number;
+	inProgress: number;
+	pending: number;
+	total: number;
+};
+
+function countPlanStatuses(entries: PlanEntry[]): PlanStatusCounts {
+	let completed = 0;
+	let inProgress = 0;
+	let pending = 0;
+	for (const entry of entries) {
+		switch (entry.status) {
+			case "completed":
+				completed++;
+				break;
+			case "in_progress":
+				inProgress++;
+				break;
+			case "pending":
+				pending++;
+				break;
+		}
+	}
+	return { completed, inProgress, pending, total: entries.length };
+}
+
+function getPlanStatusDotClass(status: PlanEntryStatus): string {
+	switch (status) {
+		case "completed":
+			return "bg-green-600";
+		case "in_progress":
+			return "bg-amber-500 animate-pulse";
+		case "pending":
+			return "border border-muted-foreground bg-transparent";
+	}
+}
+
+function getPriorityBadgeVariant(
+	priority: PlanEntryPriority,
+): "destructive" | "secondary" | "outline" {
+	switch (priority) {
+		case "high":
+			return "destructive";
+		case "medium":
+			return "secondary";
+		case "low":
+			return "outline";
+	}
+}
+
+// --- Sub-components ---
+
+function PlanProgressBar({
+	counts,
+	size,
+}: {
+	counts: PlanStatusCounts;
+	size: "mini" | "full";
+}) {
+	const { total, completed, inProgress } = counts;
+	if (total === 0) return null;
+
+	const completedPct = (completed / total) * 100;
+	const inProgressPct = (inProgress / total) * 100;
+
+	return (
+		<div
+			className={cn(
+				"bg-muted overflow-hidden rounded-full",
+				size === "mini" ? "h-1 w-20" : "h-1.5 w-full",
+			)}
+		>
+			<div className="flex h-full">
+				<div
+					className="bg-green-600 transition-[width] duration-500"
+					style={{ width: `${completedPct}%` }}
+				/>
+				<div
+					className="bg-amber-500 transition-[width] duration-500"
+					style={{ width: `${inProgressPct}%` }}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function PlanEntryItem({ entry }: { entry: PlanEntry }) {
+	const { t } = useTranslation();
+	const isLong =
+		entry.content.length > 200 || (entry.content.match(/\n/g)?.length ?? 0) > 3;
+	const [expanded, setExpanded] = useState(false);
+
+	return (
+		<div className="flex gap-2 py-1.5">
+			<div className="mt-1 shrink-0">
+				<div
+					className={cn(
+						"size-2 rounded-full",
+						getPlanStatusDotClass(entry.status),
+					)}
+				/>
+			</div>
+			<div className="min-w-0 flex-1">
+				<div className="flex items-start gap-1.5">
+					<div
+						className={cn(
+							"min-w-0 flex-1 text-xs",
+							entry.status === "in_progress" && "font-medium",
+							entry.status === "completed" &&
+								"text-muted-foreground line-through",
+							entry.status === "pending" && "text-muted-foreground",
+						)}
+					>
+						{isLong && !expanded ? (
+							<div className="relative max-h-[4.5rem] overflow-hidden">
+								<span className="whitespace-pre-wrap">{entry.content}</span>
+								<div className="from-popover pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t" />
+							</div>
+						) : isLong && expanded ? (
+							<div className="max-h-60 overflow-y-auto">
+								<LazyStreamdown>{entry.content}</LazyStreamdown>
+							</div>
+						) : (
+							<span className="whitespace-pre-wrap">{entry.content}</span>
+						)}
+					</div>
+					{entry.status !== "completed" && (
+						<Badge
+							variant={getPriorityBadgeVariant(entry.priority)}
+							className="shrink-0 text-[10px] leading-none"
+						>
+							{t(`plan.priority.${entry.priority}`)}
+						</Badge>
+					)}
+				</div>
+				{isLong && (
+					<Button
+						variant="link"
+						size="sm"
+						className="h-auto p-0 text-[10px]"
+						onClick={() => setExpanded(!expanded)}
+					>
+						{expanded ? t("plan.showLess") : t("plan.showMore")}
+					</Button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function PlanDetailContent({ entries }: { entries: PlanEntry[] }) {
+	const { t } = useTranslation();
+	const counts = countPlanStatuses(entries);
+
+	const inProgressEntries = entries.filter((e) => e.status === "in_progress");
+	const pendingEntries = entries.filter((e) => e.status === "pending");
+	const completedEntries = entries.filter((e) => e.status === "completed");
+
+	return (
+		<div className="max-h-[60vh] space-y-3 overflow-y-auto">
+			{/* Header */}
+			<div className="space-y-2">
+				<div className="flex items-center justify-between">
+					<span className="text-sm font-medium">{t("plan.title")}</span>
+					<span className="text-muted-foreground text-xs">
+						{t("plan.completedCount", {
+							completed: counts.completed,
+							total: counts.total,
+						})}
+					</span>
+				</div>
+				<PlanProgressBar counts={counts} size="full" />
+				<div className="text-muted-foreground flex flex-wrap gap-2 text-[10px]">
+					{counts.completed > 0 && (
+						<span>
+							{t("plan.summaryCompleted", { count: counts.completed })}
+						</span>
+					)}
+					{counts.inProgress > 0 && (
+						<span>
+							· {t("plan.summaryInProgress", { count: counts.inProgress })}
+						</span>
+					)}
+					{counts.pending > 0 && (
+						<span>· {t("plan.summaryPending", { count: counts.pending })}</span>
+					)}
+				</div>
+			</div>
+
+			{/* In Progress */}
+			{inProgressEntries.length > 0 && (
+				<div className="space-y-0.5">
+					{inProgressEntries.map((entry, i) => (
+						<PlanEntryItem key={`ip-${i}`} entry={entry} />
+					))}
+				</div>
+			)}
+
+			{/* Pending */}
+			{pendingEntries.length > 0 && (
+				<div className="space-y-0.5">
+					{pendingEntries.map((entry, i) => (
+						<PlanEntryItem key={`pd-${i}`} entry={entry} />
+					))}
+				</div>
+			)}
+
+			{/* Completed (collapsible) */}
+			{completedEntries.length > 0 && (
+				<Collapsible>
+					<CollapsibleTrigger className="text-muted-foreground flex w-full items-center gap-1 text-[10px] hover:underline">
+						<HugeiconsIcon
+							icon={ArrowDown01Icon}
+							strokeWidth={2}
+							className="size-3 group-data-[state=open]:hidden"
+						/>
+						<HugeiconsIcon
+							icon={ArrowUp01Icon}
+							strokeWidth={2}
+							className="size-3 group-data-[state=closed]:hidden"
+						/>
+						{t("plan.completedSection", { count: completedEntries.length })}
+					</CollapsibleTrigger>
+					<CollapsibleContent>
+						<div className="mt-1 space-y-0.5">
+							{completedEntries.map((entry, i) => (
+								<PlanEntryItem key={`cp-${i}`} entry={entry} />
+							))}
+						</div>
+					</CollapsibleContent>
+				</Collapsible>
+			)}
+		</div>
+	);
+}
+
+// --- Main component ---
+
+export default function PlanIndicator({ plan }: { plan: PlanEntry[] }) {
+	const isMobile = useIsMobile();
+	const [sheetOpen, setSheetOpen] = useState(false);
+	const counts = countPlanStatuses(plan);
+
+	if (plan.length === 0) return null;
+
+	const miniIndicator = (
+		<div className="flex items-center gap-2">
+			<PlanProgressBar counts={counts} size="mini" />
+			<span className="text-muted-foreground text-xs tabular-nums">
+				{counts.completed}/{counts.total}
+			</span>
+		</div>
+	);
+
+	if (isMobile) {
+		return (
+			<>
+				<button
+					type="button"
+					onClick={() => setSheetOpen(true)}
+					className="flex items-center"
+				>
+					{miniIndicator}
+				</button>
+				<Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+					<SheetContent side="bottom" className="max-h-[50vh]">
+						<SheetHeader>
+							<SheetTitle className="sr-only">Plan</SheetTitle>
+						</SheetHeader>
+						<div className="px-4 pb-4">
+							<PlanDetailContent entries={plan} />
+						</div>
+					</SheetContent>
+				</Sheet>
+			</>
+		);
+	}
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button type="button" className="flex items-center">
+					{miniIndicator}
+				</button>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-80">
+				<PlanDetailContent entries={plan} />
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/webui/src/components/ui/popover.tsx
+++ b/apps/webui/src/components/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Popover as PopoverPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Popover({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverAnchor({
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverContent({
+	className,
+	align = "center",
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+	return (
+		<PopoverPrimitive.Portal>
+			<PopoverPrimitive.Content
+				data-slot="popover-content"
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-hidden origin-(--radix-popover-content-transform-origin)",
+					className,
+				)}
+				{...props}
+			/>
+		</PopoverPrimitive.Portal>
+	);
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/apps/webui/src/hooks/useSessionMutations.ts
+++ b/apps/webui/src/hooks/useSessionMutations.ts
@@ -113,6 +113,8 @@ export interface ChatStoreActions {
 				| "availableModels"
 				| "availableCommands"
 				| "usage"
+				| "_meta"
+				| "plan"
 			>
 		>,
 	) => void;

--- a/apps/webui/src/hooks/useSocket.ts
+++ b/apps/webui/src/hooks/useSocket.ts
@@ -5,6 +5,7 @@ import type { ChatStoreActions } from "@/hooks/useSessionMutations";
 import {
 	type CliStatusPayload,
 	extractAvailableCommandsUpdate,
+	extractPlanUpdate,
 	extractSessionInfoUpdate,
 	extractSessionModeUpdate,
 	extractTextChunk,
@@ -215,6 +216,10 @@ export function useSocket({
 				const availableCommands = extractAvailableCommandsUpdate(notification);
 				if (availableCommands !== null) {
 					updateSessionMeta(event.sessionId, { availableCommands });
+				}
+				const planUpdate = extractPlanUpdate(notification);
+				if (planUpdate) {
+					updateSessionMeta(event.sessionId, { plan: planUpdate.entries });
 				}
 				break;
 			}

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -368,5 +368,20 @@
 	},
 	"cli": {
 		"discoveringCapabilities": "Discovering agent capabilities..."
+	},
+	"plan": {
+		"title": "Plan",
+		"completedCount": "{{completed}} of {{total}} completed",
+		"summaryCompleted": "{{count}} completed",
+		"summaryInProgress": "{{count}} in progress",
+		"summaryPending": "{{count}} pending",
+		"completedSection": "{{count}} completed",
+		"showMore": "Show more",
+		"showLess": "Show less",
+		"priority": {
+			"high": "HIGH",
+			"medium": "MED",
+			"low": "LOW"
+		}
 	}
 }

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -368,5 +368,20 @@
 	},
 	"cli": {
 		"discoveringCapabilities": "正在获取 Agent 能力..."
+	},
+	"plan": {
+		"title": "计划",
+		"completedCount": "已完成 {{completed}}/{{total}}",
+		"summaryCompleted": "{{count}} 已完成",
+		"summaryInProgress": "{{count}} 进行中",
+		"summaryPending": "{{count}} 待处理",
+		"completedSection": "{{count}} 已完成",
+		"showMore": "展开",
+		"showLess": "收起",
+		"priority": {
+			"high": "高",
+			"medium": "中",
+			"low": "低"
+		}
 	}
 }

--- a/apps/webui/src/lib/acp-types.ts
+++ b/apps/webui/src/lib/acp-types.ts
@@ -1,5 +1,6 @@
 import type {
 	AvailableCommand,
+	PlanEntry,
 	SessionNotification,
 	ToolCallUpdate,
 } from "@mobvibe/shared";
@@ -81,6 +82,21 @@ export const extractToolCallUpdate = (
 		return null;
 	}
 	return update as ToolCallUpdate;
+};
+
+export type PlanUpdatePayload = {
+	entries: PlanEntry[];
+};
+
+export const extractPlanUpdate = (
+	notification: SessionNotification,
+): PlanUpdatePayload | null => {
+	const { update } = notification;
+	if (update.sessionUpdate !== "plan") {
+		return null;
+	}
+	const planUpdate = update as unknown as { entries?: PlanEntry[] };
+	return { entries: planUpdate.entries ?? [] };
 };
 
 export const extractAvailableCommandsUpdate = (

--- a/apps/webui/src/lib/acp.ts
+++ b/apps/webui/src/lib/acp.ts
@@ -16,6 +16,10 @@ export type {
 	PermissionRequestPayload,
 	PermissionResultNotification,
 	PermissionToolCall,
+	// Plan types
+	PlanEntry,
+	PlanEntryPriority,
+	PlanEntryStatus,
 	ResourceLink,
 	SessionAttachedPayload,
 	SessionDetachedPayload,
@@ -36,6 +40,7 @@ export type {
 
 export {
 	extractAvailableCommandsUpdate,
+	extractPlanUpdate,
 	extractSessionInfoUpdate,
 	extractSessionModeUpdate,
 	extractTextChunk,

--- a/apps/webui/src/lib/chat-store.ts
+++ b/apps/webui/src/lib/chat-store.ts
@@ -5,6 +5,7 @@ import type {
 	PermissionOption,
 	PermissionOutcome,
 	PermissionToolCall,
+	PlanEntry,
 	SessionModelOption,
 	SessionModeOption,
 	SessionSummary,
@@ -162,6 +163,8 @@ export type ChatSession = {
 	worktreeSourceCwd?: string;
 	/** Branch name of the worktree (only for worktree sessions) */
 	worktreeBranch?: string;
+	/** Agent execution plan entries (replaced in full on each update) */
+	plan?: PlanEntry[];
 };
 
 type ChatState = {
@@ -238,6 +241,7 @@ type ChatState = {
 				| "availableCommands"
 				| "usage"
 				| "_meta"
+				| "plan"
 			>
 		>,
 	) => void;
@@ -602,6 +606,7 @@ const sanitizeSessionForPersist = (session: ChatSession): ChatSession => ({
 	detachedAt: undefined,
 	detachedReason: undefined,
 	e2eeStatus: undefined,
+	plan: undefined,
 	// Preserve messages even when cursor is set so detached sessions keep history.
 	// Backfill applies only new events based on the cursor.
 	messages: session.messages.map(sanitizeMessageForPersist),
@@ -1018,6 +1023,9 @@ export const useChatStore = create<ChatState>()(
 					if (payload._meta !== undefined) {
 						nextSession._meta = payload._meta;
 					}
+					if (payload.plan !== undefined) {
+						nextSession.plan = payload.plan;
+					}
 					return {
 						sessions: {
 							...state.sessions,
@@ -1425,6 +1433,7 @@ export const useChatStore = create<ChatState>()(
 								streamingMessageId: undefined,
 								streamingMessageRole: undefined,
 								streamingThoughtId: undefined,
+								plan: undefined,
 								revision: newRevision,
 								lastAppliedSeq: 0,
 							},

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -38,6 +38,11 @@ export type {
 	PermissionOutcome,
 	PermissionResultNotification,
 	PermissionToolCall,
+	// Plan types (local definitions matching SDK schema)
+	Plan,
+	PlanEntry,
+	PlanEntryPriority,
+	PlanEntryStatus,
 	RequestPermissionOutcome,
 	RequestPermissionRequest,
 	RequestPermissionResponse,

--- a/packages/shared/src/types/acp.ts
+++ b/packages/shared/src/types/acp.ts
@@ -39,6 +39,35 @@ export type {
 	UsageUpdate,
 } from "@agentclientprotocol/sdk";
 
+// Plan types — SDK defines these in schema but doesn't export TS types yet
+// Matches schema.json: Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus
+
+/** Priority levels for plan entries */
+export type PlanEntryPriority = "high" | "medium" | "low";
+
+/** Status of a plan entry in the execution flow */
+export type PlanEntryStatus = "pending" | "in_progress" | "completed";
+
+/** A single entry in the execution plan */
+export type PlanEntry = {
+	/** Human-readable description of what this task aims to accomplish */
+	content: string;
+	/** The relative importance of this task */
+	priority: PlanEntryPriority;
+	/** Current execution status of this task */
+	status: PlanEntryStatus;
+	/** Extensibility metadata */
+	_meta?: Record<string, unknown> | null;
+};
+
+/** An execution plan for accomplishing complex tasks */
+export type Plan = {
+	/** The list of tasks to be accomplished (full replacement on each update) */
+	entries: PlanEntry[];
+	/** Extensibility metadata */
+	_meta?: Record<string, unknown> | null;
+};
+
 // Backwards-compatible aliases still in use
 import type { EmbeddedResource, ResourceLink } from "@agentclientprotocol/sdk";
 


### PR DESCRIPTION
## Summary

- Add Plan types (`Plan`, `PlanEntry`, `PlanEntryPriority`, `PlanEntryStatus`) to shared package, matching ACP SDK schema
- Wire plan data extraction from `session_info_update` WAL events through socket → store pipeline
- Create `PlanIndicator` component: compact progress bar + count in AppHeader, expanding to Popover (desktop) / bottom Sheet (mobile) with grouped entries, priority badges, and markdown rendering
- Add `Popover` UI primitive (Radix wrapper following existing tooltip pattern)
- Add en/zh i18n translations for plan UI

## Test plan

- [x] `pnpm build` — all 5 packages pass
- [x] `pnpm format && pnpm lint` — no new errors
- [x] `pnpm test:run` — 617 tests pass, no regressions
- [ ] Manual: connect ACP agent with plan support, verify indicator appears with correct progress
- [ ] Manual: click indicator → Popover (desktop) / Sheet (mobile) shows grouped entries
- [ ] Manual: long markdown content truncates with "Show more" toggle
- [ ] Manual: plan updates refresh UI in real-time (full replacement semantics)
- [ ] Manual: no indicator shown when session has no plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)