### PR TITLE
refactor: redesign sidebar with workspace/sessions tab layout

### DIFF
--- a/apps/webui/src/components/app/AppSidebar.tsx
+++ b/apps/webui/src/components/app/AppSidebar.tsx
@@ -3,7 +3,6 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { MachineWorkspaces } from "@/components/machines/MachineWorkspaces";
 import { RegisterMachineDialog } from "@/components/machines/RegisterMachineDialog";
 import { SessionSidebar } from "@/components/session/SessionSidebar";
 import { Button } from "@/components/ui/button";
@@ -125,11 +124,7 @@ function MobileMachineColumn() {
 	const queryClient = useQueryClient();
 	const discoverSessionsMutation = useDiscoverSessionsMutation();
 	const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
-	const {
-		selectedWorkspaceByMachine,
-		expandedMachines,
-		toggleMachineExpanded,
-	} = useUiStore();
+	const { selectedWorkspaceByMachine } = useUiStore();
 
 	const machineList = Object.values(machines).sort((a, b) => {
 		if (a.connected !== b.connected) {
@@ -198,29 +193,14 @@ function MobileMachineColumn() {
 						</div>
 					) : null}
 
-					{machineList.map((machine) => {
-						const isExpanded = Boolean(expandedMachines[machine.machineId]);
-						return (
-							<div
-								key={machine.machineId}
-								className="flex flex-col items-center gap-1"
-							>
-								<MachineIcon
-									machine={machine}
-									isSelected={machine.machineId === selectedMachineId}
-									isExpanded={isExpanded}
-									onSelect={() => {
-										setSelectedMachineId(machine.machineId);
-										toggleMachineExpanded(machine.machineId);
-									}}
-								/>
-								<MachineWorkspaces
-									machineId={machine.machineId}
-									isExpanded={isExpanded}
-								/>
-							</div>
-						);
-					})}
+					{machineList.map((machine) => (
+						<MachineIcon
+							key={machine.machineId}
+							machine={machine}
+							isSelected={machine.machineId === selectedMachineId}
+							onSelect={() => setSelectedMachineId(machine.machineId)}
+						/>
+					))}
 				</div>
 
 				<Tooltip>
@@ -249,16 +229,10 @@ function MobileMachineColumn() {
 type MachineIconProps = {
 	machine: Machine;
 	isSelected: boolean;
-	isExpanded?: boolean;
 	onSelect: () => void;
 };
 
-function MachineIcon({
-	machine,
-	isSelected,
-	isExpanded,
-	onSelect,
-}: MachineIconProps) {
+function MachineIcon({ machine, isSelected, onSelect }: MachineIconProps) {
 	const { t } = useTranslation();
 	const displayName = machine.hostname ?? machine.machineId.slice(0, 8);
 	const initials = displayName.slice(0, 2).toUpperCase();
@@ -269,13 +243,11 @@ function MachineIcon({
 				<button
 					type="button"
 					onClick={onSelect}
-					aria-expanded={isExpanded}
 					className={cn(
 						"relative flex h-10 w-10 items-center justify-center rounded-sm border transition-colors",
 						isSelected
 							? "border-primary bg-primary/10 text-primary"
 							: "border-border bg-background hover:bg-muted text-foreground",
-						isExpanded && !isSelected && "border-primary/40",
 						!machine.connected && "opacity-50",
 					)}
 				>

--- a/apps/webui/src/components/machines/MachinesSidebar.tsx
+++ b/apps/webui/src/components/machines/MachinesSidebar.tsx
@@ -3,7 +3,6 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { MachineWorkspaces } from "@/components/machines/MachineWorkspaces";
 import { RegisterMachineDialog } from "@/components/machines/RegisterMachineDialog";
 import { Button } from "@/components/ui/button";
 import { ResizeHandle } from "@/components/ui/ResizeHandle";
@@ -38,8 +37,6 @@ export function MachinesSidebar({ onAddMachine }: MachinesSidebarProps) {
 	} = useMachinesStore();
 	const {
 		selectedWorkspaceByMachine,
-		expandedMachines,
-		toggleMachineExpanded,
 		machineSidebarWidth,
 		setMachineSidebarWidth,
 	} = useUiStore();
@@ -128,29 +125,14 @@ export function MachinesSidebar({ onAddMachine }: MachinesSidebarProps) {
 						</div>
 					) : null}
 
-					{machineList.map((machine) => {
-						const isExpanded = Boolean(expandedMachines[machine.machineId]);
-						return (
-							<div
-								key={machine.machineId}
-								className="flex flex-col items-center gap-1"
-							>
-								<MachineIcon
-									machine={machine}
-									isSelected={machine.machineId === selectedMachineId}
-									isExpanded={isExpanded}
-									onSelect={() => {
-										setSelectedMachineId(machine.machineId);
-										toggleMachineExpanded(machine.machineId);
-									}}
-								/>
-								<MachineWorkspaces
-									machineId={machine.machineId}
-									isExpanded={isExpanded}
-								/>
-							</div>
-						);
-					})}
+					{machineList.map((machine) => (
+						<MachineIcon
+							key={machine.machineId}
+							machine={machine}
+							isSelected={machine.machineId === selectedMachineId}
+							onSelect={() => setSelectedMachineId(machine.machineId)}
+						/>
+					))}
 				</div>
 
 				<Tooltip>
@@ -185,16 +167,10 @@ export function MachinesSidebar({ onAddMachine }: MachinesSidebarProps) {
 type MachineIconProps = {
 	machine: Machine;
 	isSelected: boolean;
-	isExpanded?: boolean;
 	onSelect: () => void;
 };
 
-function MachineIcon({
-	machine,
-	isSelected,
-	isExpanded,
-	onSelect,
-}: MachineIconProps) {
+function MachineIcon({ machine, isSelected, onSelect }: MachineIconProps) {
 	const { t } = useTranslation();
 	const displayName = machine.hostname ?? machine.machineId.slice(0, 8);
 	const initials = displayName.slice(0, 2).toUpperCase();
@@ -206,13 +182,11 @@ function MachineIcon({
 					<button
 						type="button"
 						onClick={onSelect}
-						aria-expanded={isExpanded}
 						className={cn(
 							"relative flex h-10 w-10 items-center justify-center rounded-sm border transition-colors",
 							isSelected
 								? "border-primary bg-primary/10 text-primary"
 								: "border-border bg-background hover:bg-muted text-foreground",
-							isExpanded && !isSelected && "border-primary/40",
 							!machine.connected && "opacity-50",
 						)}
 					>

--- a/apps/webui/src/components/session/SessionSidebar.tsx
+++ b/apps/webui/src/components/session/SessionSidebar.tsx
@@ -1,8 +1,12 @@
-import { Loading01Icon, Settings02Icon } from "@hugeicons/core-free-icons";
+import {
+	Add01Icon,
+	ArrowDown01Icon,
+	ArrowRight01Icon,
+	MoreHorizontalIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -12,23 +16,59 @@ import {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-	AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { WorkspaceList } from "@/components/workspace/WorkspaceList";
 import { type ChatSession } from "@/lib/chat-store";
+import { useMachinesStore } from "@/lib/machines-store";
 import {
 	getSessionDisplayStatus,
 	type SessionDisplayPhase,
 	type SessionMutationsSnapshot,
 } from "@/lib/session-utils";
 import { useUiStore } from "@/lib/ui-store";
-import { getPathBasename } from "@/lib/ui-utils";
+import { formatRelativeTime, getPathBasename } from "@/lib/ui-utils";
 import { cn } from "@/lib/utils";
 
 const getSessionStamp = (session: ChatSession) =>
 	session.updatedAt ?? session.createdAt ?? "";
+
+/** Map display status to a colored dot style */
+const statusDotClass: Record<SessionDisplayPhase, string> = {
+	active: "bg-green-500",
+	loading: "bg-blue-500 animate-pulse",
+	error: "bg-red-500",
+	detached: "bg-yellow-500",
+	history: "bg-muted-foreground/40",
+};
+
+/** Return a human-readable tooltip for statuses that carry extra info */
+function getStatusTooltip(
+	session: ChatSession,
+	status: SessionDisplayPhase,
+	t: (key: string) => string,
+): string | null {
+	if (status === "error" && session.error?.message) {
+		return `${t("session.status.error")}: ${session.error.message}`;
+	}
+	if (status === "detached" && session.detachedReason) {
+		return `${t("session.status.detached")}: ${session.detachedReason}`;
+	}
+	return t(`session.status.${status}`);
+}
 
 type SessionSidebarProps = {
 	sessions: ChatSession[];
@@ -65,7 +105,42 @@ export const SessionSidebar = ({
 		startEditingSession,
 		setEditingTitle,
 		clearEditingSession,
+		sidebarTab,
+		setSidebarTab,
+		selectedWorkspaceByMachine,
 	} = useUiStore();
+	const { selectedMachineId } = useMachinesStore();
+
+	// Shared archive confirmation dialog state
+	const [archiveTarget, setArchiveTarget] = useState<
+		| {
+				type: "single";
+				sessionId: string;
+		  }
+		| {
+				type: "bulk";
+				sessionIds: string[];
+		  }
+		| null
+	>(null);
+
+	const handleArchiveConfirm = useCallback(() => {
+		if (!archiveTarget) return;
+		if (archiveTarget.type === "single") {
+			onArchiveSession(archiveTarget.sessionId);
+		} else {
+			onArchiveAllSessions(archiveTarget.sessionIds);
+		}
+		setArchiveTarget(null);
+	}, [archiveTarget, onArchiveSession, onArchiveAllSessions]);
+
+	// Current workspace label for header display
+	const currentWorkspace = useMemo(() => {
+		if (!selectedMachineId) return null;
+		const cwd = selectedWorkspaceByMachine[selectedMachineId];
+		if (!cwd) return null;
+		return { label: getPathBasename(cwd) ?? cwd };
+	}, [selectedMachineId, selectedWorkspaceByMachine]);
 
 	const groupedSessions = useMemo(() => {
 		const groups = new Map<
@@ -117,109 +192,199 @@ export const SessionSidebar = ({
 	}, [sessions, t]);
 
 	return (
-		<div className="flex h-full min-h-0 flex-col gap-4 overflow-hidden">
-			<div className="flex items-center justify-between">
-				<div className="text-sm font-semibold">{t("session.title")}</div>
-
-				<div className="flex items-center gap-2">
-					{sessions.length > 0 ? (
-						<AlertDialog>
-							<AlertDialogTrigger asChild>
-								<Button size="sm" variant="outline" disabled={isBulkArchiving}>
-									{t("session.archiveAll")}
-								</Button>
-							</AlertDialogTrigger>
-							<AlertDialogContent size="sm">
-								<AlertDialogHeader>
-									<AlertDialogTitle>
-										{t("session.archiveAllTitle")}
-									</AlertDialogTitle>
-									<AlertDialogDescription>
-										{t("session.archiveAllDescription", {
-											count: sessions.length,
-										})}
-									</AlertDialogDescription>
-								</AlertDialogHeader>
-								<AlertDialogFooter>
-									<AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-									<AlertDialogAction
-										onClick={() =>
-											onArchiveAllSessions(sessions.map((s) => s.sessionId))
-										}
-									>
-										{t("session.archiveAllConfirm")}
-									</AlertDialogAction>
-								</AlertDialogFooter>
-							</AlertDialogContent>
-						</AlertDialog>
-					) : null}
-					<Button variant="outline" size="icon-sm" asChild>
-						<Link to="/settings" aria-label={t("settings.title")}>
-							<HugeiconsIcon icon={Settings02Icon} strokeWidth={2} />
-						</Link>
-					</Button>
-
-					<Button onClick={onCreateSession} size="sm" disabled={isCreating}>
-						{t("common.new")}
+		<TooltipProvider delayDuration={300}>
+			<div className="flex h-full min-h-0 flex-col gap-3 overflow-hidden">
+				{/* Header: Tab switcher + New button */}
+				<div className="flex items-center gap-1">
+					<button
+						type="button"
+						className={cn(
+							"rounded-md px-2 py-1 text-sm",
+							sidebarTab === "workspaces"
+								? "bg-accent font-semibold"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+						onClick={() => setSidebarTab("workspaces")}
+					>
+						{t("workspace.title")}
+					</button>
+					<button
+						type="button"
+						className={cn(
+							"rounded-md px-2 py-1 text-sm",
+							sidebarTab === "sessions"
+								? "bg-accent font-semibold"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+						onClick={() => setSidebarTab("sessions")}
+					>
+						{t("session.title")}
+					</button>
+					<Button
+						onClick={onCreateSession}
+						size="icon-sm"
+						disabled={isCreating}
+						aria-label={t("common.new")}
+						className="ml-auto"
+					>
+						<HugeiconsIcon icon={Add01Icon} strokeWidth={2} />
 					</Button>
 				</div>
-			</div>
-			<div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain">
-				{sessions.length === 0 ? (
-					<div className="text-muted-foreground text-xs">
-						{t("session.empty")}
+
+				{/* Workspaces tab */}
+				{sidebarTab === "workspaces" ? (
+					<div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain">
+						{selectedMachineId ? (
+							<WorkspaceList machineId={selectedMachineId} />
+						) : (
+							<div className="text-muted-foreground text-xs">
+								{t("workspace.empty")}
+							</div>
+						)}
 					</div>
 				) : null}
-				{groupedSessions.map((group) => {
-					const isExpanded = expandedGroups[group.id] ?? true;
-					return (
-						<div key={group.id} className="flex flex-col gap-2">
-							<button
-								type="button"
-								className="text-muted-foreground hover:text-foreground flex items-center gap-2 text-xs font-semibold"
-								aria-expanded={isExpanded}
-								onClick={() =>
-									setExpandedGroups((prev) => ({
-										...prev,
-										[group.id]: !(prev[group.id] ?? true),
-									}))
-								}
-							>
-								<span className="w-3 text-center">
-									{isExpanded ? "v" : ">"}
+
+				{/* Sessions tab */}
+				{sidebarTab === "sessions" ? (
+					<>
+						{/* Current workspace indicator */}
+						{currentWorkspace ? (
+							<div className="rounded-md bg-muted/50 px-2.5 py-1.5">
+								<span className="text-sm font-semibold">
+									{currentWorkspace.label}
 								</span>
-								<span className="truncate">{group.label}</span>
-							</button>
-							{isExpanded ? (
-								<div className="flex flex-col gap-2 pl-4">
-									{group.sessions.map((session) => (
-										<SessionListItem
-											key={session.sessionId}
-											session={session}
-											isActive={session.sessionId === activeSessionId}
-											isEditing={session.sessionId === editingSessionId}
-											editingTitle={editingTitle}
-											displayStatus={getSessionDisplayStatus(
-												session,
-												mutations,
-											)}
-											onSelect={onSelectSession}
-											onEdit={() =>
-												startEditingSession(session.sessionId, session.title)
-											}
-											onEditCancel={clearEditingSession}
-											onEditSubmit={onEditSubmit}
-											onEditingTitleChange={setEditingTitle}
-											onArchive={onArchiveSession}
-										/>
-									))}
+							</div>
+						) : null}
+
+						{/* Session list */}
+						<div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain">
+							{sessions.length === 0 ? (
+								<div className="text-muted-foreground text-xs">
+									{t("session.empty")}
 								</div>
 							) : null}
+							{groupedSessions.map((group) => {
+								const isExpanded = expandedGroups[group.id] ?? true;
+								return (
+									<div key={group.id} className="flex flex-col gap-1">
+										<div className="flex items-center justify-between">
+											<button
+												type="button"
+												className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-xs font-semibold"
+												aria-expanded={isExpanded}
+												onClick={() =>
+													setExpandedGroups((prev) => ({
+														...prev,
+														[group.id]: !(prev[group.id] ?? true),
+													}))
+												}
+											>
+												<HugeiconsIcon
+													icon={isExpanded ? ArrowDown01Icon : ArrowRight01Icon}
+													strokeWidth={2}
+													className="h-3.5 w-3.5 shrink-0"
+													aria-hidden="true"
+												/>
+												<span className="truncate">
+													{group.label}
+													<span className="ml-1 opacity-50">
+														({group.sessions.length})
+													</span>
+												</span>
+											</button>
+											{isExpanded && group.sessions.length > 1 ? (
+												<Button
+													size="xs"
+													variant="ghost"
+													className="text-muted-foreground h-5 px-1.5 text-[10px]"
+													disabled={isBulkArchiving}
+													onClick={() =>
+														setArchiveTarget({
+															type: "bulk",
+															sessionIds: group.sessions.map(
+																(s) => s.sessionId,
+															),
+														})
+													}
+												>
+													{t("session.archiveAll")}
+												</Button>
+											) : null}
+										</div>
+										{isExpanded ? (
+											<div className="flex flex-col gap-0.5 pl-2">
+												{group.sessions.map((session) => (
+													<SessionListItem
+														key={session.sessionId}
+														session={session}
+														isActive={session.sessionId === activeSessionId}
+														isEditing={session.sessionId === editingSessionId}
+														editingTitle={editingTitle}
+														displayStatus={getSessionDisplayStatus(
+															session,
+															mutations,
+														)}
+														onSelect={onSelectSession}
+														onEdit={() =>
+															startEditingSession(
+																session.sessionId,
+																session.title,
+															)
+														}
+														onEditCancel={clearEditingSession}
+														onEditSubmit={onEditSubmit}
+														onEditingTitleChange={setEditingTitle}
+														onArchive={() =>
+															setArchiveTarget({
+																type: "single",
+																sessionId: session.sessionId,
+															})
+														}
+													/>
+												))}
+											</div>
+										) : null}
+									</div>
+								);
+							})}
 						</div>
-					);
-				})}
+					</>
+				) : null}
+
+				{/* Shared archive confirmation dialog */}
+				<AlertDialog
+					open={archiveTarget !== null}
+					onOpenChange={(open) => {
+						if (!open) setArchiveTarget(null);
+					}}
+				>
+					<AlertDialogContent size="sm">
+						<AlertDialogHeader>
+							<AlertDialogTitle>
+								{archiveTarget?.type === "bulk"
+									? t("session.archiveAllTitle")
+									: t("session.archiveTitle")}
+							</AlertDialogTitle>
+							<AlertDialogDescription>
+								{archiveTarget?.type === "bulk"
+									? t("session.archiveAllDescription", {
+											count: archiveTarget.sessionIds.length,
+										})
+									: t("session.archiveDescription")}
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+							<AlertDialogAction onClick={handleArchiveConfirm}>
+								{archiveTarget?.type === "bulk"
+									? t("session.archiveAllConfirm")
+									: t("session.archiveConfirm")}
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
 			</div>
-		</div>
+		</TooltipProvider>
 	);
 };
 
@@ -234,7 +399,7 @@ type SessionListItemProps = {
 	onEditCancel: () => void;
 	onEditSubmit: () => void;
 	onEditingTitleChange: (value: string) => void;
-	onArchive: (sessionId: string) => void;
+	onArchive: () => void;
 };
 
 const SessionListItem = ({
@@ -251,145 +416,122 @@ const SessionListItem = ({
 	onArchive,
 }: SessionListItemProps) => {
 	const { t } = useTranslation();
-	const cwdLabel =
-		getPathBasename(session.worktreeSourceCwd || session.cwd) ??
-		t("common.unknown");
+	const inputRef = useRef<HTMLInputElement>(null);
 	const handleSelect = () => onSelect(session.sessionId);
 
-	const renderStatusBadge = () => {
-		switch (displayStatus) {
-			case "loading":
-				return (
-					<Badge variant="secondary" className="gap-1">
-						<HugeiconsIcon
-							icon={Loading01Icon}
-							strokeWidth={2}
-							className="h-3 w-3 animate-spin"
-						/>
-						{t("session.status.loading")}
-					</Badge>
-				);
-			case "active":
-				return (
-					<Badge className="bg-green-600 hover:bg-green-700">
-						{t("session.status.active")}
-					</Badge>
-				);
-			case "error":
-				return <Badge variant="destructive">{t("session.status.error")}</Badge>;
-			case "detached":
-				return (
-					<Badge variant="outline" className="text-warning border-warning">
-						{t("session.status.detached")}
-					</Badge>
-				);
-			case "history":
-				return (
-					<Badge
-						variant="outline"
-						className="text-muted-foreground border-muted-foreground/30"
-					>
-						{t("session.status.history")}
-					</Badge>
-				);
-			default:
-				return null;
+	const statusTooltip = getStatusTooltip(session, displayStatus, t);
+
+	// Relative time from session timestamp
+	const stamp = getSessionStamp(session);
+	const relativeTime = stamp ? formatRelativeTime(stamp) : null;
+
+	const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+		event.stopPropagation();
+		if (event.key === "Enter") {
+			onEditSubmit();
+		} else if (event.key === "Escape") {
+			onEditCancel();
 		}
 	};
 
 	return (
 		<div
 			className={cn(
-				"border-border bg-background hover:bg-muted flex flex-col gap-2 rounded-none border p-2 text-left",
-				isActive ? "border-primary/40" : "",
+				"group/session relative flex items-start gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+				isActive
+					? "bg-accent border-l-primary border-l-2"
+					: "hover:bg-muted/50",
 			)}
 		>
+			{/* Status dot */}
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span
+						className={cn(
+							"mt-1.5 h-2 w-2 shrink-0 rounded-full",
+							statusDotClass[displayStatus],
+						)}
+						aria-label={statusTooltip ?? undefined}
+					/>
+				</TooltipTrigger>
+				{statusTooltip ? (
+					<TooltipContent side="right">
+						<span className="text-xs">{statusTooltip}</span>
+					</TooltipContent>
+				) : null}
+			</Tooltip>
+
+			{/* Content area */}
 			<button
 				type="button"
 				onClick={handleSelect}
-				className="flex flex-1 flex-col gap-1 text-left outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+				className="flex min-w-0 flex-1 flex-col gap-0.5 text-left outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
 			>
-				<div className="flex items-center justify-between gap-2">
-					{isEditing ? (
-						<Input
-							aria-label="Session title"
-							name="session-title"
-							autoComplete="off"
-							value={editingTitle}
-							onChange={(event) => onEditingTitleChange(event.target.value)}
-							onClick={(event) => event.stopPropagation()}
-							onKeyDown={(event) => event.stopPropagation()}
-							className="h-7 text-xs"
-						/>
-					) : (
-						<span className="text-sm font-medium">{session.title}</span>
-					)}
-					<div className="flex items-center gap-2 shrink-0">
-						{renderStatusBadge()}
-						{session.e2eeStatus === "missing_key" ? (
-							<Badge variant="outline" className="text-warning border-warning">
-								{t("e2ee.missingKeyBadge")}
-							</Badge>
-						) : null}
-					</div>
-				</div>
-				<span className="text-muted-foreground text-xs">
-					{cwdLabel}
+				{/* Title row */}
+				{isEditing ? (
+					<Input
+						ref={inputRef}
+						aria-label="Session title"
+						name="session-title"
+						autoComplete="off"
+						autoFocus
+						value={editingTitle}
+						onChange={(event) => onEditingTitleChange(event.target.value)}
+						onClick={(event) => event.stopPropagation()}
+						onKeyDown={handleKeyDown}
+						className="h-6 text-xs"
+					/>
+				) : (
+					<span className="truncate text-sm font-medium leading-tight">
+						{session.title}
+					</span>
+				)}
+
+				{/* Metadata row: relative time · branch · e2ee badge */}
+				<span className="text-muted-foreground truncate text-xs leading-tight">
+					{relativeTime}
 					{session.worktreeBranch ? (
 						<span className="ml-1 inline-flex items-center gap-0.5">
 							<span className="opacity-50">&middot;</span>
 							<span>{session.worktreeBranch}</span>
 						</span>
 					) : null}
+					{session.e2eeStatus === "missing_key" ? (
+						<span className="ml-1 inline-flex items-center gap-0.5">
+							<span className="opacity-50">&middot;</span>
+							<span className="text-warning">{t("e2ee.missingKeyBadge")}</span>
+						</span>
+					) : null}
 				</span>
-				{session.detachedReason ? (
-					<span className="text-muted-foreground text-xs">
-						{t("status.error")}: {session.detachedReason}
-					</span>
-				) : null}
-				{session.error ? (
-					<span className="text-destructive text-xs">
-						{session.error.message}
-					</span>
-				) : null}
 			</button>
-			<div className="flex items-center gap-2">
-				{isEditing ? (
-					<>
-						<Button size="xs" onClick={onEditSubmit}>
-							{t("common.save")}
+
+			{/* Three-dot menu — visible on mobile, hover on desktop */}
+			{!isEditing ? (
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							size="icon-sm"
+							variant="ghost"
+							className="h-6 w-6 shrink-0 opacity-100 md:opacity-0 transition-opacity md:group-hover/session:opacity-100 data-[state=open]:opacity-100"
+							onClick={(event) => event.stopPropagation()}
+						>
+							<HugeiconsIcon
+								icon={MoreHorizontalIcon}
+								strokeWidth={2}
+								className="h-3.5 w-3.5"
+							/>
 						</Button>
-						<Button size="xs" variant="outline" onClick={onEditCancel}>
-							{t("common.cancel")}
-						</Button>
-					</>
-				) : (
-					<Button size="xs" variant="ghost" onClick={onEdit}>
-						{t("common.rename")}
-					</Button>
-				)}
-				<AlertDialog>
-					<AlertDialogTrigger asChild>
-						<Button size="xs" variant="outline">
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="w-36">
+						<DropdownMenuItem onClick={onEdit}>
+							{t("common.rename")}
+						</DropdownMenuItem>
+						<DropdownMenuItem variant="destructive" onClick={onArchive}>
 							{t("common.archive")}
-						</Button>
-					</AlertDialogTrigger>
-					<AlertDialogContent size="sm">
-						<AlertDialogHeader>
-							<AlertDialogTitle>{t("session.archiveTitle")}</AlertDialogTitle>
-							<AlertDialogDescription>
-								{t("session.archiveDescription")}
-							</AlertDialogDescription>
-						</AlertDialogHeader>
-						<AlertDialogFooter>
-							<AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-							<AlertDialogAction onClick={() => onArchive(session.sessionId)}>
-								{t("session.archiveConfirm")}
-							</AlertDialogAction>
-						</AlertDialogFooter>
-					</AlertDialogContent>
-				</AlertDialog>
-			</div>
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			) : null}
 		</div>
 	);
 };

--- a/apps/webui/src/components/workspace/WorkspaceList.tsx
+++ b/apps/webui/src/components/workspace/WorkspaceList.tsx
@@ -9,25 +9,11 @@ import { useUiStore } from "@/lib/ui-store";
 import { cn } from "@/lib/utils";
 import { collectWorkspaces } from "@/lib/workspace-utils";
 
-const getWorkspaceInitials = (label: string) => {
-	const trimmed = label.trim();
-	if (trimmed.length === 0) {
-		return "--";
-	}
-	return trimmed.slice(0, 2).toUpperCase();
-};
-
-type MachineWorkspacesProps = {
+type WorkspaceListProps = {
 	machineId: string;
-	isExpanded: boolean;
-	className?: string;
 };
 
-export function MachineWorkspaces({
-	machineId,
-	isExpanded,
-	className,
-}: MachineWorkspacesProps) {
+export function WorkspaceList({ machineId }: WorkspaceListProps) {
 	const { t } = useTranslation();
 	const { sessions } = useChatStore();
 	const { machines, setSelectedMachineId, updateBackendCapabilities } =
@@ -36,6 +22,7 @@ export function MachineWorkspaces({
 		selectedWorkspaceByMachine,
 		setSelectedWorkspace,
 		setCreateDialogOpen,
+		setSidebarTab,
 	} = useUiStore();
 	const discoverSessionsMutation = useDiscoverSessionsMutation();
 
@@ -43,10 +30,12 @@ export function MachineWorkspaces({
 		() => collectWorkspaces(sessions, machineId),
 		[sessions, machineId],
 	);
+
 	const machine = machines[machineId];
-	const canValidateWorkspaces = Boolean(isExpanded && machine?.connected);
+	const canValidate = Boolean(machine?.connected);
+
 	const workspaceValidityQueries = useQueries({
-		queries: canValidateWorkspaces
+		queries: canValidate
 			? workspaceList.map((workspace) => ({
 					queryKey: ["fs-entries", machineId, workspace.cwd],
 					queryFn: () => fetchFsEntries({ path: workspace.cwd, machineId }),
@@ -55,22 +44,22 @@ export function MachineWorkspaces({
 				}))
 			: [],
 	});
+
 	const validWorkspaces = useMemo(() => {
-		if (!canValidateWorkspaces) {
-			return [];
-		}
+		if (!canValidate) return [];
 		return workspaceList.filter(
 			(_, index) => workspaceValidityQueries[index]?.isSuccess,
 		);
-	}, [canValidateWorkspaces, workspaceList, workspaceValidityQueries]);
-	const isValidating =
-		canValidateWorkspaces &&
-		workspaceValidityQueries.some((query) => query.isFetching);
-	const selectedWorkspaceCwd = selectedWorkspaceByMachine[machineId];
-	const effectiveWorkspaceCwd = selectedWorkspaceCwd;
+	}, [canValidate, workspaceList, workspaceValidityQueries]);
 
+	const isValidating =
+		canValidate && workspaceValidityQueries.some((query) => query.isFetching);
+
+	const selectedWorkspaceCwd = selectedWorkspaceByMachine[machineId];
+
+	// Fallback when selected workspace becomes invalid
 	const selectedWorkspaceQueryState = useMemo(() => {
-		if (!canValidateWorkspaces || !selectedWorkspaceCwd) return undefined;
+		if (!canValidate || !selectedWorkspaceCwd) return undefined;
 		const index = workspaceList.findIndex(
 			(w) => w.cwd === selectedWorkspaceCwd,
 		);
@@ -80,14 +69,14 @@ export function MachineWorkspaces({
 		if (q.isError) return "error" as const;
 		return "success" as const;
 	}, [
-		canValidateWorkspaces,
+		canValidate,
 		selectedWorkspaceCwd,
 		workspaceList,
 		workspaceValidityQueries,
 	]);
 
 	useEffect(() => {
-		if (!canValidateWorkspaces || !selectedWorkspaceCwd) return;
+		if (!canValidate || !selectedWorkspaceCwd) return;
 		if (
 			selectedWorkspaceQueryState === "not-found" ||
 			selectedWorkspaceQueryState === "error"
@@ -100,7 +89,7 @@ export function MachineWorkspaces({
 			}
 		}
 	}, [
-		canValidateWorkspaces,
+		canValidate,
 		machineId,
 		selectedWorkspaceCwd,
 		selectedWorkspaceQueryState,
@@ -108,13 +97,10 @@ export function MachineWorkspaces({
 		validWorkspaces,
 	]);
 
-	if (!isExpanded) {
-		return null;
-	}
-
 	const handleSelectWorkspace = (cwd: string) => {
 		setSelectedMachineId(machineId);
 		setSelectedWorkspace(machineId, cwd);
+		setSidebarTab("sessions");
 		discoverSessionsMutation.mutate(
 			{ machineId, cwd },
 			{
@@ -123,7 +109,6 @@ export function MachineWorkspaces({
 				},
 			},
 		);
-		// 不自动选中 session，由 App.tsx 验证 effect 处理无效状态
 	};
 
 	const handleEmptyClick = () => {
@@ -131,52 +116,49 @@ export function MachineWorkspaces({
 		setCreateDialogOpen(true);
 	};
 
+	if (isValidating && validWorkspaces.length === 0) {
+		return (
+			<div className="text-muted-foreground text-xs p-2">
+				{t("common.loading")}
+			</div>
+		);
+	}
+
+	if (validWorkspaces.length === 0) {
+		return (
+			<button
+				type="button"
+				onClick={handleEmptyClick}
+				className="text-xs text-muted-foreground hover:text-foreground p-2"
+			>
+				{t("workspace.empty")}
+			</button>
+		);
+	}
+
 	return (
-		<div className={cn("flex flex-col items-center gap-1", className)}>
-			{isValidating && validWorkspaces.length === 0 ? (
-				<div className="text-muted-foreground text-[10px] text-center px-1">
-					{t("common.loading")}
-				</div>
-			) : validWorkspaces.length === 0 ? (
-				<button
-					type="button"
-					onClick={handleEmptyClick}
-					className="text-[10px] text-muted-foreground hover:text-foreground"
-				>
-					{t("workspace.empty")}
-				</button>
-			) : (
-				validWorkspaces.map((workspace) => {
-					const isActive = workspace.cwd === effectiveWorkspaceCwd;
-					const initials = getWorkspaceInitials(workspace.label);
-					return (
-						<button
-							key={`${workspace.machineId}:${workspace.cwd}`}
-							type="button"
-							onClick={() => handleSelectWorkspace(workspace.cwd)}
-							className={cn(
-								"flex flex-col items-center gap-0.5 text-[9px]",
-								isActive
-									? "text-primary"
-									: "text-muted-foreground hover:text-foreground",
-							)}
-							title={`${workspace.label} - ${workspace.cwd}`}
-						>
-							<span
-								className={cn(
-									"flex h-7 w-7 items-center justify-center rounded-sm border transition-colors",
-									isActive
-										? "border-primary bg-primary/10"
-										: "border-border bg-background hover:bg-muted",
-								)}
-							>
-								<span className="text-[10px] font-semibold">{initials}</span>
-							</span>
-							<span className="w-10 truncate">{workspace.label}</span>
-						</button>
-					);
-				})
-			)}
+		<div className="flex flex-col gap-0.5">
+			{validWorkspaces.map((workspace) => {
+				const isActive = workspace.cwd === selectedWorkspaceCwd;
+				return (
+					<button
+						key={`${workspace.machineId}:${workspace.cwd}`}
+						type="button"
+						onClick={() => handleSelectWorkspace(workspace.cwd)}
+						className={cn(
+							"flex flex-col gap-0.5 rounded-md px-2 py-1.5 text-left transition-colors",
+							isActive
+								? "bg-accent border-l-primary border-l-2 font-semibold"
+								: "hover:bg-muted/50",
+						)}
+					>
+						<span className="truncate text-sm">{workspace.label}</span>
+						<span className="text-muted-foreground truncate text-xs">
+							{workspace.cwd}
+						</span>
+					</button>
+				);
+			})}
 		</div>
 	);
 }

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -340,6 +340,10 @@
 		"refreshAriaLabel": "Refresh",
 		"addMachineAriaLabel": "Add machine"
 	},
+	"workspace": {
+		"title": "Workspaces",
+		"empty": "No workspaces"
+	},
 	"commandPalette": {
 		"openCommandPalette": "Command Palette",
 		"searchPlaceholder": "Type a command or search...",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -340,6 +340,10 @@
 		"refreshAriaLabel": "刷新",
 		"addMachineAriaLabel": "添加设备"
 	},
+	"workspace": {
+		"title": "工作区",
+		"empty": "暂无工作区"
+	},
 	"commandPalette": {
 		"openCommandPalette": "命令面板",
 		"searchPlaceholder": "输入命令或搜索...",

--- a/apps/webui/src/lib/ui-store.ts
+++ b/apps/webui/src/lib/ui-store.ts
@@ -49,7 +49,7 @@ type UiState = {
 	draftWorktreeBranch: string;
 	draftWorktreeBaseBranch?: string;
 	selectedWorkspaceByMachine: Record<string, string>;
-	expandedMachines: Record<string, boolean>;
+	sidebarTab: "workspaces" | "sessions";
 	machineSidebarWidth: number;
 	sessionSidebarWidth: number;
 	setMobileMenuOpen: (open: boolean) => void;
@@ -69,7 +69,7 @@ type UiState = {
 	setDraftWorktreeBaseBranch: (value?: string) => void;
 	resetDraftWorktree: () => void;
 	setSelectedWorkspace: (machineId: string, cwd?: string) => void;
-	toggleMachineExpanded: (machineId: string) => void;
+	setSidebarTab: (tab: "workspaces" | "sessions") => void;
 	setMachineSidebarWidth: (width: number) => void;
 	setSessionSidebarWidth: (width: number) => void;
 };
@@ -90,7 +90,7 @@ export const useUiStore = create<UiState>((set) => ({
 	draftWorktreeBranch: "",
 	draftWorktreeBaseBranch: undefined,
 	selectedWorkspaceByMachine: {},
-	expandedMachines: {},
+	sidebarTab: "sessions",
 	machineSidebarWidth: loadStoredWidth(
 		MACHINE_SIDEBAR_WIDTH_KEY,
 		MACHINE_WIDTH_DEFAULT,
@@ -136,13 +136,7 @@ export const useUiStore = create<UiState>((set) => ({
 			}
 			return { selectedWorkspaceByMachine: next };
 		}),
-	toggleMachineExpanded: (machineId) =>
-		set((state) => ({
-			expandedMachines: {
-				...state.expandedMachines,
-				[machineId]: !state.expandedMachines[machineId],
-			},
-		})),
+	setSidebarTab: (tab) => set({ sidebarTab: tab }),
 	setMachineSidebarWidth: (width) =>
 		set(() => {
 			const next = clamp(width, MACHINE_WIDTH_MIN, MACHINE_WIDTH_MAX);

--- a/apps/webui/src/lib/ui-utils.ts
+++ b/apps/webui/src/lib/ui-utils.ts
@@ -12,6 +12,19 @@ export const buildSessionTitle = (
 		count: sessions.length + 1,
 	});
 
+/** Format an ISO date string as a relative time (e.g. "2h ago"). */
+export const formatRelativeTime = (isoString: string): string => {
+	const diff = Date.now() - new Date(isoString).getTime();
+	const minutes = Math.floor(diff / 60000);
+	if (minutes < 1) return "just now";
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	if (days < 30) return `${days}d ago`;
+	return `${Math.floor(days / 30)}mo ago`;
+};
+
 /** Extract the last segment from a file path (cross-platform). */
 export const getPathBasename = (path?: string): string | undefined => {
 	if (!path) return undefined;

--- a/apps/webui/tests/machine-workspaces.test.tsx
+++ b/apps/webui/tests/machine-workspaces.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/lib/chat-store";
-import { MachineWorkspaces } from "../src/components/machines/MachineWorkspaces";
+import { WorkspaceList } from "../src/components/workspace/WorkspaceList";
 import { useMachinesStore } from "../src/lib/machines-store";
 import { useUiStore } from "../src/lib/ui-store";
 
@@ -61,7 +61,7 @@ beforeEach(() => {
 		},
 	});
 
-	// Set up machine as connected and expanded
+	// Set up machine as connected
 	useMachinesStore.setState({
 		machines: {
 			[MACHINE_ID]: {
@@ -76,7 +76,7 @@ beforeEach(() => {
 	// Clear UI store
 	useUiStore.setState({
 		selectedWorkspaceByMachine: {},
-		expandedMachines: { [MACHINE_ID]: true },
+		sidebarTab: "workspaces",
 	});
 });
 
@@ -93,11 +93,11 @@ afterEach(() => {
 	});
 	useUiStore.setState({
 		selectedWorkspaceByMachine: {},
-		expandedMachines: {},
+		sidebarTab: "sessions",
 	});
 });
 
-describe("MachineWorkspaces validation effect", () => {
+describe("WorkspaceList validation effect", () => {
 	it("selects valid fallback when selected workspace CWD becomes invalid", async () => {
 		const validCwd = "/home/user/valid-project";
 		const invalidCwd = "/home/user/deleted-project";
@@ -125,7 +125,7 @@ describe("MachineWorkspaces validation effect", () => {
 
 		render(
 			<Wrapper>
-				<MachineWorkspaces machineId={MACHINE_ID} isExpanded />
+				<WorkspaceList machineId={MACHINE_ID} />
 			</Wrapper>,
 		);
 
@@ -157,7 +157,7 @@ describe("MachineWorkspaces validation effect", () => {
 
 		render(
 			<Wrapper>
-				<MachineWorkspaces machineId={MACHINE_ID} isExpanded />
+				<WorkspaceList machineId={MACHINE_ID} />
 			</Wrapper>,
 		);
 
@@ -189,7 +189,7 @@ describe("MachineWorkspaces validation effect", () => {
 
 		render(
 			<Wrapper>
-				<MachineWorkspaces machineId={MACHINE_ID} isExpanded />
+				<WorkspaceList machineId={MACHINE_ID} />
 			</Wrapper>,
 		);
 
@@ -204,20 +204,17 @@ describe("MachineWorkspaces validation effect", () => {
 		expect(state.selectedWorkspaceByMachine[MACHINE_ID]).toBe(validCwd);
 	});
 
-	it("renders nothing when not expanded", () => {
-		useChatStore.setState({
-			sessions: {
-				"s-1": buildSession("s-1", "/home/user/project"),
-			},
-		});
+	it("shows empty state when no sessions for machine", () => {
+		useChatStore.setState({ sessions: {} });
 
 		const { container } = render(
 			<Wrapper>
-				<MachineWorkspaces machineId={MACHINE_ID} isExpanded={false} />
+				<WorkspaceList machineId={MACHINE_ID} />
 			</Wrapper>,
 		);
 
-		expect(container.innerHTML).toBe("");
+		// Should show the empty button
+		expect(container.querySelector("button")).toBeTruthy();
 	});
 
 	it("selects fallback when workspace is removed from session list", async () => {
@@ -240,7 +237,7 @@ describe("MachineWorkspaces validation effect", () => {
 
 		render(
 			<Wrapper>
-				<MachineWorkspaces machineId={MACHINE_ID} isExpanded />
+				<WorkspaceList machineId={MACHINE_ID} />
 			</Wrapper>,
 		);
 

--- a/apps/webui/tests/session-sidebar.test.tsx
+++ b/apps/webui/tests/session-sidebar.test.tsx
@@ -16,13 +16,17 @@ const defaultMutations: SessionMutationsSnapshot = {
 	reloadSessionVariables: undefined,
 };
 
+// --- mocks ---
+
 vi.mock("../src/components/ui/alert-dialog", () => ({
-	AlertDialog: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogTrigger: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
+	AlertDialog: ({
+		children,
+		open,
+	}: {
+		children: React.ReactNode;
+		open?: boolean;
+		onOpenChange?: (v: boolean) => void;
+	}) => (open ? <div>{children}</div> : null),
 	AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
 	),
@@ -54,26 +58,6 @@ vi.mock("../src/components/ui/alert-dialog", () => ({
 	}) => <button {...props}>{children}</button>,
 }));
 
-vi.mock("../src/components/ui/select", () => ({
-	Select: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-	SelectTrigger: ({ children, ...props }: { children: React.ReactNode }) => (
-		<button type="button" {...props}>
-			{children}
-		</button>
-	),
-	SelectValue: ({ placeholder }: { placeholder?: string }) => (
-		<span>{placeholder}</span>
-	),
-	SelectContent: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-	SelectItem: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-}));
-
 vi.mock("../src/components/ui/dropdown-menu", () => ({
 	DropdownMenu: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
@@ -84,16 +68,49 @@ vi.mock("../src/components/ui/dropdown-menu", () => ({
 	DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
 	),
-	DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => (
+	DropdownMenuItem: ({
+		children,
+		onClick,
+	}: {
+		children: React.ReactNode;
+		onClick?: () => void;
+		variant?: string;
+	}) => (
+		<button type="button" onClick={onClick}>
+			{children}
+		</button>
+	),
+}));
+
+vi.mock("../src/components/ui/tooltip", () => ({
+	Tooltip: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
 	),
-	DropdownMenuRadioGroup: ({ children }: { children: React.ReactNode }) => (
+	TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
 	),
-	DropdownMenuRadioItem: ({ children }: { children: React.ReactNode }) => (
+	TooltipContent: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	TooltipProvider: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
 	),
 }));
+
+vi.mock("../src/lib/machines-store", () => ({
+	useMachinesStore: vi.fn(() => ({
+		selectedMachineId: "machine-1",
+		machines: {},
+		setSelectedMachineId: vi.fn(),
+		updateBackendCapabilities: vi.fn(),
+	})),
+}));
+
+vi.mock("../src/components/workspace/WorkspaceList", () => ({
+	WorkspaceList: () => <div data-testid="workspace-list">WorkspaceList</div>,
+}));
+
+// --- helpers ---
 
 const buildSession = (overrides?: Partial<ChatSession>): ChatSession => ({
 	sessionId: "session-1",
@@ -130,6 +147,8 @@ const renderSidebar = (
 		</MemoryRouter>,
 	);
 
+// --- tests ---
+
 describe("SessionSidebar", () => {
 	beforeEach(() => {
 		useUiStore.setState({
@@ -143,7 +162,7 @@ describe("SessionSidebar", () => {
 			draftBackendId: undefined,
 			draftCwd: undefined,
 			selectedWorkspaceByMachine: {},
-			expandedMachines: {},
+			sidebarTab: "sessions",
 			machineSidebarWidth: 56,
 			sessionSidebarWidth: 256,
 		});
@@ -171,7 +190,7 @@ describe("SessionSidebar", () => {
 			editingSessionId: "session-1",
 			editingTitle: "Updated title",
 			selectedWorkspaceByMachine: {},
-			expandedMachines: {},
+			sidebarTab: "sessions",
 			machineSidebarWidth: 56,
 			sessionSidebarWidth: 256,
 		});
@@ -179,7 +198,46 @@ describe("SessionSidebar", () => {
 
 		const input = screen.getByDisplayValue("Updated title");
 		expect(input).toBeInTheDocument();
-		expect(screen.getByText(i18n.t("common.save"))).toBeInTheDocument();
+	});
+
+	it("submits rename on Enter key", async () => {
+		const onEditSubmit = vi.fn();
+		const user = userEvent.setup();
+		useUiStore.setState({
+			editingSessionId: "session-1",
+			editingTitle: "New name",
+			selectedWorkspaceByMachine: {},
+			sidebarTab: "sessions",
+			machineSidebarWidth: 56,
+			sessionSidebarWidth: 256,
+		});
+		renderSidebar([buildSession()], { onEditSubmit });
+
+		const input = screen.getByDisplayValue("New name");
+		await user.click(input);
+		await user.keyboard("{Enter}");
+
+		expect(onEditSubmit).toHaveBeenCalled();
+	});
+
+	it("cancels rename on Escape key", async () => {
+		const user = userEvent.setup();
+		useUiStore.setState({
+			editingSessionId: "session-1",
+			editingTitle: "New name",
+			selectedWorkspaceByMachine: {},
+			sidebarTab: "sessions",
+			machineSidebarWidth: 56,
+			sessionSidebarWidth: 256,
+		});
+		renderSidebar([buildSession()]);
+
+		const input = screen.getByDisplayValue("New name");
+		await user.click(input);
+		await user.keyboard("{Escape}");
+
+		// After escape, editing should be cleared — title text should show again
+		expect(screen.queryByDisplayValue("New name")).not.toBeInTheDocument();
 	});
 
 	it("groups sessions by backend and sorts by recent use", () => {
@@ -222,19 +280,20 @@ describe("SessionSidebar", () => {
 		expect(alphaSessions[1]).toHaveTextContent("Alpha 1");
 	});
 
-	it("shows the last directory name for cwd", () => {
+	it("shows relative time in metadata row", () => {
+		const oneHourAgo = new Date(Date.now() - 3600_000).toISOString();
 		renderSidebar([
 			buildSession({
-				sessionId: "session-cwd",
-				title: "Session With Path",
-				cwd: "/home/user/projects/mobvibe/",
+				sessionId: "session-time",
+				title: "Session With Time",
+				updatedAt: oneHourAgo,
 			}),
 		]);
 
-		expect(screen.getByText("mobvibe")).toBeInTheDocument();
+		expect(screen.getByText(/1h ago/)).toBeInTheDocument();
 	});
 
-	it("shows loading badge when session is loading", () => {
+	it("shows status tooltip for loading session", () => {
 		renderSidebar([
 			buildSession({
 				sessionId: "session-loading",
@@ -248,7 +307,7 @@ describe("SessionSidebar", () => {
 		).toBeInTheDocument();
 	});
 
-	it("shows detached reason when present", () => {
+	it("shows detached reason in tooltip", () => {
 		renderSidebar([
 			buildSession({
 				sessionId: "session-detached",
@@ -258,7 +317,23 @@ describe("SessionSidebar", () => {
 		]);
 
 		expect(
-			screen.getByText(`${i18n.t("status.error")}: gateway_disconnect`),
+			screen.getByText(
+				`${i18n.t("session.status.detached")}: gateway_disconnect`,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("shows error message in tooltip", () => {
+		renderSidebar([
+			buildSession({
+				sessionId: "session-err",
+				title: "Error Session",
+				error: { message: "connection lost", code: "ERR" },
+			}),
+		]);
+
+		expect(
+			screen.getByText(`${i18n.t("session.status.error")}: connection lost`),
 		).toBeInTheDocument();
 	});
 
@@ -273,46 +348,169 @@ describe("SessionSidebar", () => {
 			}),
 		]);
 
-		await user.click(screen.getByText("Backend Toggle"));
+		// Group header includes label + count
+		await user.click(screen.getByText(/Backend Toggle/));
 		expect(screen.queryByText("Toggle Session")).not.toBeInTheDocument();
-		await user.click(screen.getByText("Backend Toggle"));
+		await user.click(screen.getByText(/Backend Toggle/));
 		expect(screen.getByText("Toggle Session")).toBeInTheDocument();
 	});
 
+	it("shows rename and archive in dropdown menu", () => {
+		renderSidebar([buildSession({ title: "My Session" })]);
+
+		expect(screen.getByText(i18n.t("common.rename"))).toBeInTheDocument();
+		expect(screen.getByText(i18n.t("common.archive"))).toBeInTheDocument();
+	});
+
+	it("triggers edit mode from dropdown rename", async () => {
+		const user = userEvent.setup();
+		renderSidebar([buildSession({ title: "My Session" })]);
+
+		await user.click(screen.getByText(i18n.t("common.rename")));
+
+		// Should now be in editing mode with an input
+		const input = screen.getByRole("textbox", { name: "Session title" });
+		expect(input).toBeInTheDocument();
+	});
+
+	it("applies active indicator to the current session", () => {
+		renderSidebar(
+			[buildSession({ sessionId: "active-1", title: "Active Session" })],
+			{ activeSessionId: "active-1" },
+		);
+
+		// The outer card div has the border-l-primary class
+		const card = screen
+			.getByText("Active Session")
+			.closest(".border-l-primary");
+		expect(card).toBeInTheDocument();
+	});
+
+	describe("Tab switching", () => {
+		it("shows sessions tab by default", () => {
+			renderSidebar([buildSession({ title: "My Session" })]);
+			expect(screen.getByText("My Session")).toBeInTheDocument();
+		});
+
+		it("switches to workspaces tab when clicked", async () => {
+			const user = userEvent.setup();
+			renderSidebar([buildSession({ title: "My Session" })]);
+
+			await user.click(screen.getByText(i18n.t("workspace.title")));
+
+			// WorkspaceList mock should be rendered
+			expect(screen.getByTestId("workspace-list")).toBeInTheDocument();
+			// Session items should not be visible
+			expect(screen.queryByText("My Session")).not.toBeInTheDocument();
+		});
+
+		it("switches back to sessions tab", async () => {
+			const user = userEvent.setup();
+			useUiStore.setState({ sidebarTab: "workspaces" });
+			renderSidebar([buildSession({ title: "My Session" })]);
+
+			await user.click(screen.getByText(i18n.t("session.title")));
+
+			expect(screen.getByText("My Session")).toBeInTheDocument();
+		});
+	});
+
 	describe("Archive All", () => {
-		it("is hidden when sessions list is empty", () => {
-			renderSidebar([]);
+		it("is hidden when group has only one session", () => {
+			renderSidebar([buildSession()]);
 			expect(
 				screen.queryByText(i18n.t("session.archiveAll")),
 			).not.toBeInTheDocument();
 		});
 
-		it("is visible when sessions exist", () => {
-			renderSidebar([buildSession()]);
+		it("is visible when group has multiple sessions", () => {
+			renderSidebar([
+				buildSession({
+					sessionId: "s1",
+					title: "Session 1",
+					backendId: "b1",
+					backendLabel: "Backend",
+				}),
+				buildSession({
+					sessionId: "s2",
+					title: "Session 2",
+					backendId: "b1",
+					backendLabel: "Backend",
+				}),
+			]);
 			expect(
 				screen.getByText(i18n.t("session.archiveAll")),
 			).toBeInTheDocument();
 		});
 
-		it("calls onArchiveAllSessions with all session IDs on confirm", async () => {
+		it("opens confirm dialog and calls onArchiveAllSessions on confirm", async () => {
 			const onArchiveAllSessions = vi.fn();
 			const user = userEvent.setup();
 			renderSidebar(
 				[
-					buildSession({ sessionId: "s1", title: "Session 1" }),
-					buildSession({ sessionId: "s2", title: "Session 2" }),
+					buildSession({
+						sessionId: "s1",
+						title: "Session 1",
+						backendId: "b1",
+						backendLabel: "Backend",
+					}),
+					buildSession({
+						sessionId: "s2",
+						title: "Session 2",
+						backendId: "b1",
+						backendLabel: "Backend",
+					}),
 				],
 				{ onArchiveAllSessions },
 			);
 
+			// Click Archive All to open dialog
+			await user.click(screen.getByText(i18n.t("session.archiveAll")));
+			// Dialog should now be open — click confirm
 			await user.click(screen.getByText(i18n.t("session.archiveAllConfirm")));
+
 			expect(onArchiveAllSessions).toHaveBeenCalledWith(["s1", "s2"]);
 		});
 
 		it("is disabled when isBulkArchiving is true", () => {
-			renderSidebar([buildSession()], { isBulkArchiving: true });
-			const button = screen.getByText(i18n.t("session.archiveAll"));
-			expect(button.closest("button")).toBeDisabled();
+			renderSidebar(
+				[
+					buildSession({
+						sessionId: "s1",
+						title: "Session 1",
+						backendId: "b1",
+						backendLabel: "Backend",
+					}),
+					buildSession({
+						sessionId: "s2",
+						title: "Session 2",
+						backendId: "b1",
+						backendLabel: "Backend",
+					}),
+				],
+				{ isBulkArchiving: true },
+			);
+			const button = screen
+				.getByText(i18n.t("session.archiveAll"))
+				.closest("button");
+			expect(button).toBeDisabled();
+		});
+	});
+
+	describe("Archive single session", () => {
+		it("opens confirm dialog via dropdown and calls onArchiveSession", async () => {
+			const onArchiveSession = vi.fn();
+			const user = userEvent.setup();
+			renderSidebar([buildSession({ sessionId: "s1", title: "My Session" })], {
+				onArchiveSession,
+			});
+
+			// Click archive in dropdown
+			await user.click(screen.getByText(i18n.t("common.archive")));
+			// Dialog should be open — click confirm
+			await user.click(screen.getByText(i18n.t("session.archiveConfirm")));
+
+			expect(onArchiveSession).toHaveBeenCalledWith("s1");
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Move workspace selection from MachinesSidebar into SessionSidebar as a dual-tab layout (Workspaces / Sessions)
- Workspaces tab renders a vertical list with labels and full paths, replacing the cramped icon grid
- Sessions tab shows a workspace name header and relative timestamps (e.g. "2h ago") instead of redundant cwd basenames
- Three-dot menu is always visible on mobile (no hover required)
- MachinesSidebar simplified to only show machine icons without expandable workspace lists
- Remove `expandedMachines` from ui-store, add `sidebarTab` state

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm format && pnpm lint` clean
- [x] `pnpm -C apps/webui test:run` — 29 files, 351 tests pass
- [ ] Browser: Workspaces tab shows full workspace names and paths
- [ ] Browser: Clicking workspace auto-switches to Sessions tab
- [ ] Browser: Sessions tab shows workspace label header + relative time metadata
- [ ] Browser: Mobile three-dot menu visible without hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)