### PR TITLE
refactor(cli): show all registry agents in first-run selection UI

### DIFF
--- a/apps/mobvibe-cli/src/acp/__tests__/session-manager.test.ts
+++ b/apps/mobvibe-cli/src/acp/__tests__/session-manager.test.ts
@@ -108,6 +108,7 @@ const createMockConfig = (): CliConfig => ({
 			args: [],
 		},
 	],
+	registryAgents: [],
 	homePath: "/tmp/mobvibe-test",
 	logPath: "/tmp/mobvibe-test/logs",
 	pidFile: "/tmp/mobvibe-test/daemon.pid",

--- a/apps/mobvibe-cli/src/config.ts
+++ b/apps/mobvibe-cli/src/config.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import type { AcpBackendId } from "@mobvibe/shared";
+import type { AcpBackendId, RegistryAgent } from "@mobvibe/shared";
 import { getGatewayUrl } from "./auth/credentials.js";
 import { loadUserConfig } from "./config-loader.js";
 import { logger } from "./lib/logger.js";
@@ -71,6 +71,8 @@ export type CliConfig = {
 	consolidation: ConsolidationConfig;
 	/** Base directory for git worktrees (default: ~/.mobvibe/worktrees) */
 	worktreeBaseDir: string;
+	/** Full registry agent list (for first-run selection UI) */
+	registryAgents: RegistryAgent[];
 	/** undefined = not yet configured (first run); string[] = user's selection */
 	enabledAgents?: string[];
 };
@@ -99,10 +101,12 @@ export const getCliConfig = async (): Promise<CliConfig> => {
 
 	const userConfig = userConfigResult.config;
 
-	// Detect backends from registry
+	// Load registry and detect backends
 	let backends: AcpBackendConfig[] = [];
+	let registryAgents: RegistryAgent[] = [];
 	const registry = await getRegistry({ homePath });
 	if (registry) {
+		registryAgents = registry.agents;
 		backends = await detectAgents(registry);
 	}
 
@@ -122,6 +126,7 @@ export const getCliConfig = async (): Promise<CliConfig> => {
 	return {
 		gatewayUrl,
 		acpBackends: backends,
+		registryAgents,
 		enabledAgents,
 		clientName: env.MOBVIBE_ACP_CLIENT_NAME ?? "mobvibe-cli",
 		clientVersion: env.MOBVIBE_ACP_CLIENT_VERSION ?? "0.0.0",

--- a/apps/mobvibe-cli/src/index.ts
+++ b/apps/mobvibe-cli/src/index.ts
@@ -1,5 +1,12 @@
 import { Database } from "bun:sqlite";
-import { cancel, intro, isCancel, multiselect, outro } from "@clack/prompts";
+import {
+	cancel,
+	intro,
+	isCancel,
+	log,
+	multiselect,
+	outro,
+} from "@clack/prompts";
 import { Command } from "commander";
 import { loadCredentials } from "./auth/credentials.js";
 import { login, loginStatus, logout } from "./auth/login.js";
@@ -7,6 +14,7 @@ import { getCliConfig } from "./config.js";
 import { saveUserConfig } from "./config-loader.js";
 import { DaemonManager } from "./daemon/daemon.js";
 import { logger } from "./lib/logger.js";
+import { resolveSelectedAgents } from "./registry/agent-detector.js";
 import { WalCompactor, WalStore } from "./wal/index.js";
 
 const program = new Command();
@@ -29,14 +37,14 @@ program
 
 		// First run with interactive terminal → prompt user to select agents
 		if (config.enabledAgents === undefined && process.stdout.isTTY) {
-			if (config.acpBackends.length > 0) {
+			if (config.registryAgents.length > 0) {
 				intro("Welcome to Mobvibe!");
 				const selected = await multiselect({
 					message: "Which agents do you want to enable?",
-					options: config.acpBackends.map((b) => ({
-						value: b.id,
-						label: b.label,
-						hint: b.description,
+					options: config.registryAgents.map((a) => ({
+						value: a.id,
+						label: a.name,
+						hint: a.description,
 					})),
 					required: false,
 				});
@@ -44,17 +52,30 @@ program
 					cancel("Setup cancelled.");
 					process.exit(0);
 				}
-				await saveUserConfig(config.homePath, {
-					enabledAgents: selected as string[],
-				});
-				// Apply filtering in-place without reloading config
-				const enabled = new Set(selected as string[]);
-				config.acpBackends = config.acpBackends.filter((b) =>
-					enabled.has(b.id),
+
+				// Resolve selected agents — check PATH/npx/uvx availability
+				const { resolved, failed } = resolveSelectedAgents(
+					config.registryAgents,
+					selected as string[],
 				);
-				config.enabledAgents = selected as string[];
+
+				if (failed.length > 0) {
+					for (const agent of failed) {
+						log.warn(
+							`Agent "${agent.name}" cannot be resolved — binary not in PATH, or npx/uvx unavailable. Skipping.`,
+						);
+					}
+				}
+
+				// Only save successfully resolved agent IDs
+				const enabledIds = resolved.map((b) => b.id);
+				await saveUserConfig(config.homePath, {
+					enabledAgents: enabledIds,
+				});
+				config.acpBackends = resolved;
+				config.enabledAgents = enabledIds;
 				outro(
-					`Enabled ${(selected as string[]).length} agent(s). Config saved to ${config.homePath}/.config.json`,
+					`Enabled ${resolved.length} agent(s). Config saved to ${config.homePath}/.config.json`,
 				);
 			}
 		}

--- a/apps/mobvibe-cli/src/registry/agent-detector.ts
+++ b/apps/mobvibe-cli/src/registry/agent-detector.ts
@@ -9,7 +9,7 @@ import { getRegistryPlatformKey } from "./platform.js";
  * Priority: binary (fastest startup) > npx > uvx
  * Returns null if no usable distribution found for this platform/toolchain.
  */
-const resolveAgentCommand = (
+export const resolveAgentCommand = (
 	agent: RegistryAgent,
 	platformKey: string | null,
 	hasNpx: boolean,
@@ -23,10 +23,15 @@ const resolveAgentCommand = (
 		if (entry) {
 			// Registry cmd may use "./" prefix (archive-relative); strip it for PATH lookup
 			const cmdName = entry.cmd.replace(/^\.\//, "");
-			const binPath = Bun.which(cmdName);
+			// Bun.which() cannot resolve names with path separators; fall back to basename
+			const baseName =
+				cmdName.includes("/") || cmdName.includes("\\")
+					? cmdName.split(/[/\\]/).pop()!
+					: cmdName;
+			const binPath = Bun.which(baseName);
 			if (binPath) {
 				return {
-					command: cmdName,
+					command: baseName,
 					args: entry.args ?? [],
 					envOverrides:
 						entry.env && Object.keys(entry.env).length > 0
@@ -98,4 +103,45 @@ export const detectAgents = async (
 	);
 
 	return results;
+};
+
+export type ResolveResult = {
+	resolved: AcpBackendConfig[];
+	failed: RegistryAgent[];
+};
+
+/**
+ * Resolve launch commands for a subset of registry agents (selected by user).
+ *
+ * Returns both successfully resolved backends and agents that could not be resolved,
+ * so the caller can warn the user about missing toolchains (binary not in PATH, etc.).
+ */
+export const resolveSelectedAgents = (
+	agents: RegistryAgent[],
+	selectedIds: string[],
+): ResolveResult => {
+	const platformKey = getRegistryPlatformKey();
+	const hasNpx = Bun.which("npx") !== null;
+	const hasUvx = Bun.which("uvx") !== null;
+
+	const selected = agents.filter((a) => selectedIds.includes(a.id));
+	const resolved: AcpBackendConfig[] = [];
+	const failed: RegistryAgent[] = [];
+
+	for (const agent of selected) {
+		const cmd = resolveAgentCommand(agent, platformKey, hasNpx, hasUvx);
+		if (cmd) {
+			resolved.push({
+				id: agent.id,
+				label: agent.name,
+				icon: agent.icon,
+				description: agent.description,
+				...cmd,
+			});
+		} else {
+			failed.push(agent);
+		}
+	}
+
+	return { resolved, failed };
 };


### PR DESCRIPTION
## Summary
- Show all registry agents in the first-run multiselect UI, instead of only agents whose binaries are already resolvable
- Resolve PATH/npx/uvx availability **after** user selection, with warnings for unresolvable agents
- Export `resolveAgentCommand` and add `resolveSelectedAgents` helper for post-selection resolution

Closes #42

## Test plan
- [x] `pnpm -C apps/mobvibe-cli build` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] Delete `~/.mobvibe/.config.json`, run `pnpm -C apps/mobvibe-cli dev` — verify all registry agents (including Cursor) appear in selection list
- [x] Select Cursor — verify it resolves and starts correctly if installed, or shows a warning if not

🤖 Generated with [Claude Code](https://claude.com/claude-code)