### PR TITLE
refactor(webui): switch sidebar + button behavior based on active tab

### DIFF
--- a/apps/webui/src/App.tsx
+++ b/apps/webui/src/App.tsx
@@ -206,13 +206,18 @@ function MainApp() {
 
 	// --- Extracted hooks ---
 
-	const { workspaceList, activeSession, selectedWorkspaceCwd, sessionList } =
-		useSessionList({
-			sessions,
-			activeSessionId,
-			selectedMachineId,
-			selectedWorkspaceByMachine,
-		});
+	const {
+		workspaceList,
+		activeSession,
+		selectedWorkspaceCwd,
+		effectiveWorkspaceCwd,
+		sessionList,
+	} = useSessionList({
+		sessions,
+		activeSessionId,
+		selectedMachineId,
+		selectedWorkspaceByMachine,
+	});
 
 	useMachineDiscovery({
 		machines,
@@ -245,6 +250,7 @@ function MainApp() {
 		lastCreatedCwd,
 		machines,
 		defaultBackendId,
+		effectiveWorkspaceCwd,
 		chatActions,
 		uiActions,
 		mutations,

--- a/apps/webui/src/components/app/AppSidebar.tsx
+++ b/apps/webui/src/components/app/AppSidebar.tsx
@@ -24,7 +24,7 @@ import { cn } from "@/lib/utils";
 export type AppSidebarProps = {
 	sessions: ChatSession[];
 	activeSessionId: string | undefined;
-	onCreateSession: () => void;
+	onCreateSession: (mode: "workspace" | "session") => void;
 	onSelectSession: (sessionId: string) => void;
 	onEditSubmit: () => void;
 	onArchiveSession: (sessionId: string) => void;

--- a/apps/webui/src/components/session/SessionSidebar.tsx
+++ b/apps/webui/src/components/session/SessionSidebar.tsx
@@ -73,7 +73,7 @@ function getStatusTooltip(
 type SessionSidebarProps = {
 	sessions: ChatSession[];
 	activeSessionId?: string;
-	onCreateSession: () => void;
+	onCreateSession: (mode: "workspace" | "session") => void;
 	onSelectSession: (sessionId: string) => void;
 	onEditSubmit: () => void;
 	onArchiveSession: (sessionId: string) => void;
@@ -221,10 +221,18 @@ export const SessionSidebar = ({
 						{t("session.title")}
 					</button>
 					<Button
-						onClick={onCreateSession}
+						onClick={() =>
+							onCreateSession(
+								sidebarTab === "workspaces" ? "workspace" : "session",
+							)
+						}
 						size="icon-sm"
 						disabled={isCreating}
-						aria-label={t("common.new")}
+						aria-label={
+							sidebarTab === "workspaces"
+								? t("workspace.new")
+								: t("session.new")
+						}
 						className="ml-auto"
 					>
 						<HugeiconsIcon icon={Add01Icon} strokeWidth={2} />

--- a/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
@@ -121,6 +121,7 @@ describe("useSessionHandlers — handleOpenCreateDialog", () => {
 				} as Machine,
 			},
 			defaultBackendId: "backend-1",
+			effectiveWorkspaceCwd: undefined,
 			chatActions,
 			uiActions,
 			mutations,
@@ -232,5 +233,52 @@ describe("useSessionHandlers — handleOpenCreateDialog", () => {
 		result.current.handleOpenCreateDialog();
 
 		expect(uiActions.setDraftCwd).toHaveBeenCalledWith(undefined);
+	});
+
+	it('mode "workspace" uses fallback logic (same as no mode)', () => {
+		const activeSession = createBaseSession({ cwd: "/projects/bar" });
+
+		const { result } = renderHandlers({
+			activeSessionId: "session-1",
+			activeSession,
+			lastCreatedCwd: { "machine-1": "/projects/foo" },
+			effectiveWorkspaceCwd: "/projects/workspace-a",
+		});
+
+		result.current.handleOpenCreateDialog("workspace");
+
+		// workspace mode ignores effectiveWorkspaceCwd, uses lastCreatedCwd
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith("/projects/foo");
+	});
+
+	it('mode "session" uses effectiveWorkspaceCwd when available', () => {
+		const { result } = renderHandlers({
+			lastCreatedCwd: { "machine-1": "/projects/foo" },
+			effectiveWorkspaceCwd: "/projects/workspace-a",
+		});
+
+		result.current.handleOpenCreateDialog("session");
+
+		// session mode prefers effectiveWorkspaceCwd over lastCreatedCwd
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith("/projects/workspace-a");
+	});
+
+	it('mode "session" falls back when no effectiveWorkspaceCwd', () => {
+		const activeSession = createBaseSession({
+			machineId: "machine-1",
+			cwd: "/projects/bar",
+		});
+
+		const { result } = renderHandlers({
+			activeSessionId: "session-1",
+			activeSession,
+			lastCreatedCwd: {},
+			effectiveWorkspaceCwd: undefined,
+		});
+
+		result.current.handleOpenCreateDialog("session");
+
+		// No workspace → falls back to activeSession cwd
+		expect(uiActions.setDraftCwd).toHaveBeenCalledWith("/projects/bar");
 	});
 });

--- a/apps/webui/src/hooks/useSessionHandlers.ts
+++ b/apps/webui/src/hooks/useSessionHandlers.ts
@@ -106,6 +106,8 @@ export type UseSessionHandlersParams = {
 	lastCreatedCwd: Record<string, string>;
 	machines: Record<string, Machine>;
 	defaultBackendId: string | undefined;
+	/** CWD of the effective workspace (selected or auto-fallback first workspace) */
+	effectiveWorkspaceCwd: string | undefined;
 	chatActions: ChatActions;
 	uiActions: UiActions;
 	mutations: Mutations;
@@ -125,6 +127,7 @@ export function useSessionHandlers({
 	lastCreatedCwd,
 	machines,
 	defaultBackendId,
+	effectiveWorkspaceCwd,
 	chatActions,
 	uiActions,
 	mutations,
@@ -137,20 +140,28 @@ export function useSessionHandlers({
 	const activeSessionRef = useRef(activeSession);
 	activeSessionRef.current = activeSession;
 
-	const handleOpenCreateDialog = () => {
+	const handleOpenCreateDialog = (mode?: "workspace" | "session") => {
 		uiActions.setDraftTitle(buildSessionTitle(sessionList, t));
 		uiActions.setDraftBackendId(defaultBackendId);
 
-		// CWD priority: lastCreatedCwd > activeSession cwd (same machine) > undefined (fallback to homePath in dialog)
 		let initialCwd: string | undefined;
-		if (selectedMachineId) {
+
+		// "session" mode: prefer the effective workspace CWD so the new session
+		// is pre-filled with the currently visible workspace path.
+		if (mode === "session" && effectiveWorkspaceCwd) {
+			initialCwd = effectiveWorkspaceCwd;
+		}
+
+		// Fallback (workspace mode, no mode, or session mode without workspace):
+		// lastCreatedCwd > activeSession cwd (same machine) > undefined (homePath in dialog)
+		if (!initialCwd && selectedMachineId) {
 			initialCwd = lastCreatedCwd[selectedMachineId];
 			if (!initialCwd && activeSession?.machineId === selectedMachineId) {
 				initialCwd = activeSession.worktreeSourceCwd || activeSession.cwd;
 			}
 		}
-		uiActions.setDraftCwd(initialCwd);
 
+		uiActions.setDraftCwd(initialCwd);
 		uiActions.resetDraftWorktree();
 		uiActions.setCreateDialogOpen(true);
 	};

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -54,6 +54,7 @@
 	},
 	"session": {
 		"title": "Sessions",
+		"new": "New session",
 		"newTitle": "Session {{count}}",
 		"defaultTitle": "New session",
 		"empty": "No sessions",
@@ -342,7 +343,8 @@
 	},
 	"workspace": {
 		"title": "Workspaces",
-		"empty": "No workspaces"
+		"empty": "No workspaces",
+		"new": "New workspace"
 	},
 	"commandPalette": {
 		"openCommandPalette": "Command Palette",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -54,6 +54,7 @@
 	},
 	"session": {
 		"title": "对话",
+		"new": "新建对话",
 		"newTitle": "对话 {{count}}",
 		"defaultTitle": "新对话",
 		"empty": "暂无对话",
@@ -342,7 +343,8 @@
 	},
 	"workspace": {
 		"title": "工作区",
-		"empty": "暂无工作区"
+		"empty": "暂无工作区",
+		"new": "新建工作区"
 	},
 	"commandPalette": {
 		"openCommandPalette": "命令面板",


### PR DESCRIPTION
## Summary

- Sidebar "+" button now passes a `mode` parameter (`"workspace"` or `"session"`) based on the active tab
- **Workspaces tab**: uses existing fallback CWD logic (lastCreatedCwd > activeSession.cwd > homePath)
- **Sessions tab**: pre-fills CWD with the currently selected workspace path for faster session creation
- Keyboard shortcut (Cmd+N) and CommandPalette retain the original fallback behavior (backward compatible)
- Added `workspace.new` / `session.new` i18n keys for dynamic aria-labels

## Test plan

- [x] `pnpm -C apps/webui build` passes
- [x] `pnpm format && pnpm lint` clean
- [x] `pnpm -C apps/webui test:run` — 354 tests pass (9 in useSessionHandlers, including 3 new mode tests)
- [ ] Manual: Workspaces tab → "+" → CWD defaults to fallback logic
- [ ] Manual: Sessions tab → "+" → CWD pre-filled with current workspace path
- [ ] Manual: Cmd+N → CWD uses fallback logic (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)