### PR TITLE
fix(cli): prevent daemon restart from using bunfs virtual path

### DIFF
--- a/apps/mobvibe-cli/src/daemon/__tests__/spawn-utils.test.ts
+++ b/apps/mobvibe-cli/src/daemon/__tests__/spawn-utils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { buildForegroundSpawnArgs } from "../spawn-utils.js";
+
+describe("buildForegroundSpawnArgs", () => {
+	test("keeps script path for interpreted runtime", () => {
+		expect(
+			buildForegroundSpawnArgs([
+				"/usr/local/bin/bun",
+				"dist/index.js",
+				"start",
+				"--gateway",
+				"https://api.mobvibe.net",
+			]),
+		).toEqual([
+			"dist/index.js",
+			"start",
+			"--gateway",
+			"https://api.mobvibe.net",
+			"--foreground",
+		]);
+	});
+
+	test("drops Bun virtual entrypoint from compiled binary argv", () => {
+		expect(
+			buildForegroundSpawnArgs([
+				"/private/tmp/mobvibe",
+				"/$bunfs/root/mobvibe",
+				"start",
+			]),
+		).toEqual(["start", "--foreground"]);
+	});
+
+	test("removes existing foreground flags before re-adding", () => {
+		expect(
+			buildForegroundSpawnArgs([
+				"/private/tmp/mobvibe",
+				"start",
+				"--foreground",
+				"--gateway",
+				"https://api.mobvibe.net",
+				"-f",
+			]),
+		).toEqual([
+			"start",
+			"--gateway",
+			"https://api.mobvibe.net",
+			"--foreground",
+		]);
+	});
+});

--- a/apps/mobvibe-cli/src/daemon/daemon.ts
+++ b/apps/mobvibe-cli/src/daemon/daemon.ts
@@ -10,6 +10,7 @@ import { CliCryptoService } from "../e2ee/crypto-service.js";
 import { logger } from "../lib/logger.js";
 import { WalCompactor, WalStore } from "../wal/index.js";
 import { SocketClient } from "./socket-client.js";
+import { buildForegroundSpawnArgs } from "./spawn-utils.js";
 
 type DaemonStatus = {
 	running: boolean;
@@ -144,13 +145,9 @@ export class DaemonManager {
 			`${new Date().toISOString().replace(/[:.]/g, "-")}-daemon.log`,
 		);
 
-		// Filter out --foreground if already present, then add it
-		const args = process.argv
-			.slice(1)
-			.filter((arg) => arg !== "--foreground" && arg !== "-f");
-		args.push("--foreground");
+		const args = buildForegroundSpawnArgs(process.argv);
 
-		const child = spawn(process.argv[0], args, {
+		const child = spawn(process.execPath, args, {
 			detached: true,
 			stdio: ["ignore", "pipe", "pipe"],
 			env: {

--- a/apps/mobvibe-cli/src/daemon/spawn-utils.ts
+++ b/apps/mobvibe-cli/src/daemon/spawn-utils.ts
@@ -1,0 +1,26 @@
+const FOREGROUND_FLAGS = new Set(["--foreground", "-f"]);
+
+const isBunVirtualEntrypoint = (arg: string): boolean =>
+	arg.startsWith("/$bunfs/");
+
+export const buildForegroundSpawnArgs = (execArgv: string[]): string[] => {
+	const scriptOrCommandArg = execArgv[1];
+	const passthroughArgs = execArgv
+		.slice(2)
+		.filter((arg) => !FOREGROUND_FLAGS.has(arg));
+
+	const args: string[] = [];
+
+	if (
+		typeof scriptOrCommandArg === "string" &&
+		!isBunVirtualEntrypoint(scriptOrCommandArg) &&
+		!FOREGROUND_FLAGS.has(scriptOrCommandArg)
+	) {
+		args.push(scriptOrCommandArg);
+	}
+
+	args.push(...passthroughArgs);
+	args.push("--foreground");
+
+	return args;
+};


### PR DESCRIPTION
## Summary
- fix daemon background spawn to rebuild argv instead of reusing Bun-compiled `process.argv` values that may contain `/$bunfs/...`
- switch child process startup to `process.execPath` and append `--foreground` deterministically
- add focused tests for argument construction in interpreted and Bun-compiled runtime shapes
- closes #49

## Verification
- pnpm -C apps/mobvibe-cli format
- pnpm -C apps/mobvibe-cli lint
- pnpm -C apps/mobvibe-cli test -- src/daemon/__tests__/spawn-utils.test.ts