### PR TITLE
fix(cli): daemon start now properly detaches from parent terminal

### DIFF
--- a/apps/mobvibe-cli/src/daemon/daemon.ts
+++ b/apps/mobvibe-cli/src/daemon/daemon.ts
@@ -147,9 +147,12 @@ export class DaemonManager {
 
 		const args = buildForegroundSpawnArgs(process.argv);
 
+		// Open log file for direct stdio redirection (no pipe, parent can exit immediately)
+		const logFd = await fs.open(logFile, "a");
+
 		const child = spawn(process.execPath, args, {
 			detached: true,
-			stdio: ["ignore", "pipe", "pipe"],
+			stdio: ["ignore", logFd.fd, logFd.fd],
 			env: {
 				...process.env,
 				MOBVIBE_GATEWAY_URL: this.config.gatewayUrl,
@@ -161,27 +164,10 @@ export class DaemonManager {
 			throw new Error("Failed to spawn daemon process");
 		}
 
-		// Create log file stream before writing PID
-		const logStream = await fs.open(logFile, "a");
-		const fileHandle = logStream;
+		// Close parent's fd reference (child has duplicated it)
+		await logFd.close();
 
-		child.stdout?.on("data", (data: Buffer) => {
-			fileHandle.write(`[stdout] ${data.toString()}`).catch(() => {});
-		});
-
-		child.stderr?.on("data", (data: Buffer) => {
-			fileHandle.write(`[stderr] ${data.toString()}`).catch(() => {});
-		});
-
-		// Handle child exit to clean up
-		child.on("exit", (code, signal) => {
-			fileHandle
-				.write(`[exit] Process exited with code ${code}, signal ${signal}\n`)
-				.catch(() => {});
-			fileHandle.close().catch(() => {});
-		});
-
-		// Detach from parent
+		// Detach from parent - no event listeners needed since stdio is directly redirected
 		// Note: The child process writes its own PID file in runForeground()
 		child.unref();
 


### PR DESCRIPTION
## Summary

修复  命令默认行为（不带  标志时）不会保持在后台的问题。

## 问题

在之前的 commit 修复 bunfs 路径泄露后，daemon 的 spawn 行为改为使用 pipe 来捕获 stdout/stderr 并写入日志文件。这导致父进程需要保持事件监听器来处理子进程的输出，从而阻止了父进程退出。

## 解决方案

- 将 stdio 从 pipe 改为直接使用文件描述符重定向
- 移除 stdout/stderr data 事件监听器和 exit 事件监听器
- 父进程 spawn 后立即关闭文件描述符并退出

## 验证

- ✅ 所有 CLI 测试通过 (209 pass, 0 fail)
- ✅ 不会回退上一个 commit 的 bunfs 路径修复
- ✅  现在立即返回命令行，daemon 在后台运行