### PR TITLE
fix(webui): improve mobile command palette and header

### DIFF
--- a/apps/webui/src/components/app/AppHeader.tsx
+++ b/apps/webui/src/components/app/AppHeader.tsx
@@ -1,5 +1,6 @@
 import {
 	FolderOpenIcon,
+	GitBranchIcon,
 	Refresh01Icon,
 	Refresh03Icon,
 	Search01Icon,
@@ -73,33 +74,111 @@ export const AppHeader = memo(function AppHeader({
 	forceReloadDisabled = false,
 }: AppHeaderProps) {
 	const { t } = useTranslation();
+	const executionModeIcon =
+		executionMode === "worktree" ? GitBranchIcon : FolderOpenIcon;
 
 	return (
-		<header className="bg-background/80 border-b px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))] backdrop-blur shrink-0">
-			<div className="mx-auto flex w-full max-w-5xl items-center gap-2">
-				<Button
-					variant="outline"
-					size="icon"
-					className="md:hidden"
-					onClick={onOpenMobileMenu}
-					aria-label={t("common.toggleMenu", "Toggle menu")}
-				>
-					☰
-				</Button>
-				<Button
-					variant="outline"
-					size="icon-sm"
-					onClick={() => onOpenCommandPalette?.()}
-					aria-label={t("commandPalette.openCommandPalette")}
-					title={t("commandPalette.openCommandPalette")}
-				>
-					<HugeiconsIcon
-						icon={Search01Icon}
-						strokeWidth={2}
-						aria-hidden="true"
-					/>
-				</Button>
-				<div className="flex flex-1 flex-wrap items-center gap-2">
+		<header className="bg-background/80 border-b px-3 pb-2.5 pt-[calc(0.625rem+env(safe-area-inset-top))] backdrop-blur shrink-0 sm:px-4 sm:pb-3 sm:pt-[calc(0.75rem+env(safe-area-inset-top))]">
+			<div className="mx-auto flex w-full max-w-5xl flex-col gap-1.5 sm:gap-2">
+				<div className="flex items-center justify-between gap-1.5 sm:gap-2">
+					<div className="flex items-center gap-1.5 sm:gap-2">
+						<Button
+							variant="outline"
+							size="icon-sm"
+							className="md:hidden"
+							onClick={onOpenMobileMenu}
+							aria-label={t("common.toggleMenu", "Toggle menu")}
+						>
+							☰
+						</Button>
+						<Button
+							variant="outline"
+							size="icon-sm"
+							onClick={() => onOpenCommandPalette?.()}
+							aria-label={t("commandPalette.openCommandPalette")}
+							title={t("commandPalette.openCommandPalette")}
+						>
+							<HugeiconsIcon
+								icon={Search01Icon}
+								strokeWidth={2}
+								aria-hidden="true"
+							/>
+						</Button>
+					</div>
+					<div className="flex items-center gap-1.5 sm:gap-2">
+						{showSyncHistory ? (
+							<Button
+								variant="outline"
+								size="icon-sm"
+								aria-label={t("session.syncHistory")}
+								title={t("session.syncHistory")}
+								disabled={syncHistoryDisabled}
+								onClick={() => onSyncHistory?.()}
+							>
+								<HugeiconsIcon
+									icon={Refresh03Icon}
+									strokeWidth={2}
+									aria-hidden="true"
+								/>
+							</Button>
+						) : null}
+						{showForceReload ? (
+							<AlertDialog>
+								<AlertDialogTrigger asChild>
+									<Button
+										variant="destructive"
+										size="icon-sm"
+										aria-label={t("session.forceReloadTitle")}
+										title={t("session.forceReloadTitle")}
+										disabled={forceReloadDisabled}
+									>
+										<HugeiconsIcon
+											icon={Refresh01Icon}
+											strokeWidth={2}
+											aria-hidden="true"
+										/>
+									</Button>
+								</AlertDialogTrigger>
+								<AlertDialogContent size="sm">
+									<AlertDialogHeader>
+										<AlertDialogTitle>
+											{t("session.forceReloadTitle")}
+										</AlertDialogTitle>
+										<AlertDialogDescription>
+											{t("session.forceReloadDescription")}
+										</AlertDialogDescription>
+									</AlertDialogHeader>
+									<AlertDialogFooter>
+										<AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+										<AlertDialogAction
+											variant="destructive"
+											onClick={() => onForceReload?.()}
+										>
+											{t("session.forceReloadConfirm")}
+										</AlertDialogAction>
+									</AlertDialogFooter>
+								</AlertDialogContent>
+							</AlertDialog>
+						) : null}
+						{showFileExplorer ? (
+							<Button
+								variant="outline"
+								size="icon-sm"
+								aria-label={t("fileExplorer.openFileExplorer")}
+								disabled={fileExplorerDisabled}
+								onClick={() => onOpenFileExplorer?.()}
+							>
+								<HugeiconsIcon
+									icon={FolderOpenIcon}
+									strokeWidth={2}
+									aria-hidden="true"
+								/>
+							</Button>
+						) : null}
+						<UserMenu />
+					</div>
+				</div>
+				<div className="flex min-w-0 flex-wrap items-center gap-1.5 sm:gap-2">
 					{backendLabel ? (
 						<Badge variant="outline" className="shrink-0">
 							{backendLabel}
@@ -115,88 +194,38 @@ export const AppHeader = memo(function AppHeader({
 						</Badge>
 					) : null}
 					{executionMode ? (
-						<Badge variant="outline">
-							{t(`session.context.${executionMode}`)}
+						<Badge
+							variant="outline"
+							className="px-1.5"
+							title={t(`session.context.${executionMode}`)}
+						>
+							<HugeiconsIcon
+								icon={executionModeIcon}
+								strokeWidth={2}
+								aria-hidden="true"
+							/>
 						</Badge>
 					) : null}
-					{branchLabel ? <Badge variant="outline">{branchLabel}</Badge> : null}
+					{branchLabel ? (
+						<Badge
+							variant="outline"
+							className="max-w-full truncate"
+							title={branchLabel}
+						>
+							{branchLabel}
+						</Badge>
+					) : null}
 					{subdirectoryLabel ? (
-						<Badge variant="outline" title={subdirectoryLabel}>
+						<Badge
+							variant="outline"
+							className="max-w-full truncate"
+							title={subdirectoryLabel}
+						>
 							{t("session.context.subdir", { path: subdirectoryLabel })}
 						</Badge>
 					) : null}
 					{plan && plan.length > 0 ? <PlanIndicator plan={plan} /> : null}
 				</div>
-				{showSyncHistory ? (
-					<Button
-						variant="outline"
-						size="sm"
-						aria-label={t("session.syncHistory")}
-						title={t("session.syncHistory")}
-						disabled={syncHistoryDisabled}
-						onClick={() => onSyncHistory?.()}
-					>
-						<HugeiconsIcon
-							icon={Refresh03Icon}
-							strokeWidth={2}
-							aria-hidden="true"
-						/>
-					</Button>
-				) : null}
-				{showForceReload ? (
-					<AlertDialog>
-						<AlertDialogTrigger asChild>
-							<Button
-								variant="destructive"
-								size="sm"
-								aria-label={t("session.forceReloadTitle")}
-								title={t("session.forceReloadTitle")}
-								disabled={forceReloadDisabled}
-							>
-								<HugeiconsIcon
-									icon={Refresh01Icon}
-									strokeWidth={2}
-									aria-hidden="true"
-								/>
-							</Button>
-						</AlertDialogTrigger>
-						<AlertDialogContent size="sm">
-							<AlertDialogHeader>
-								<AlertDialogTitle>
-									{t("session.forceReloadTitle")}
-								</AlertDialogTitle>
-								<AlertDialogDescription>
-									{t("session.forceReloadDescription")}
-								</AlertDialogDescription>
-							</AlertDialogHeader>
-							<AlertDialogFooter>
-								<AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-								<AlertDialogAction
-									variant="destructive"
-									onClick={() => onForceReload?.()}
-								>
-									{t("session.forceReloadConfirm")}
-								</AlertDialogAction>
-							</AlertDialogFooter>
-						</AlertDialogContent>
-					</AlertDialog>
-				) : null}
-				{showFileExplorer ? (
-					<Button
-						variant="outline"
-						size="icon-sm"
-						aria-label={t("fileExplorer.openFileExplorer")}
-						disabled={fileExplorerDisabled}
-						onClick={() => onOpenFileExplorer?.()}
-					>
-						<HugeiconsIcon
-							icon={FolderOpenIcon}
-							strokeWidth={2}
-							aria-hidden="true"
-						/>
-					</Button>
-				) : null}
-				<UserMenu />
 			</div>
 
 			{loadingMessage ? (

--- a/apps/webui/src/components/app/CommandPalette.tsx
+++ b/apps/webui/src/components/app/CommandPalette.tsx
@@ -24,7 +24,13 @@ import { useShallow } from "zustand/react/shallow";
 import { GitStatusIndicator } from "@/components/app/git-status-indicator";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { ThemeProvider, useTheme } from "@/components/theme-provider";
-import { AlertDialog, AlertDialogContent } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { fetchSessionFsResources, fetchSessionGitStatus } from "@/lib/api";
 import { useChatStore } from "@/lib/chat-store";
 import { createFallbackError } from "@/lib/error-utils";
@@ -374,7 +380,9 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 		if (open) {
 			setQuery("");
 			setSelectedIndex(0);
-			requestAnimationFrame(() => inputRef.current?.focus());
+			if (window.matchMedia?.("(min-width: 640px)")?.matches) {
+				requestAnimationFrame(() => inputRef.current?.focus());
+			}
 		}
 	}, [open]);
 
@@ -457,10 +465,13 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 	}, [isFileMode, selectedIndex, totalItems, virtualizer]);
 
 	return (
-		<AlertDialog open={open} onOpenChange={onOpenChange}>
-			<AlertDialogContent className="flex h-[100svh] w-[100vw] !max-w-none flex-col overflow-hidden translate-x-0 translate-y-0 rounded-none p-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0 top-0 left-0 sm:h-auto sm:max-h-[28rem] sm:!w-[36rem] sm:!max-w-[36rem] sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-lg sm:top-1/2 sm:left-1/2">
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="top-[calc(env(safe-area-inset-top)+0.5rem)] left-1/2 flex h-[min(32rem,calc(100svh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-1rem))] !max-h-[calc(100svh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-1rem)] w-[calc(100vw-1rem)] !max-w-[calc(100vw-1rem)] min-h-0 -translate-x-1/2 translate-y-0 flex-col overflow-hidden rounded-xl p-0 sm:top-1/2 sm:h-auto sm:max-h-[28rem] sm:w-[36rem] sm:!max-w-[36rem] sm:-translate-y-1/2 sm:rounded-lg">
+				<DialogTitle className="sr-only">
+					{t("commandPalette.openCommandPalette")}
+				</DialogTitle>
 				{/* Search input */}
-				<div className="border-b px-4 py-3">
+				<div className="border-b px-3 py-3 sm:px-4">
 					<div className="flex items-center gap-2">
 						<HugeiconsIcon
 							icon={Search01Icon}
@@ -490,6 +501,8 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 							<button
 								type="button"
 								className="text-muted-foreground hover:text-foreground"
+								aria-label={t("common.clear")}
+								title={t("common.clear")}
 								onClick={() => setQuery("")}
 							>
 								<HugeiconsIcon
@@ -500,6 +513,22 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 								/>
 							</button>
 						) : null}
+						<DialogClose asChild>
+							<Button
+								type="button"
+								variant="ghost"
+								size="icon-sm"
+								aria-label={t("common.close")}
+								title={t("common.close")}
+							>
+								<HugeiconsIcon
+									icon={Cancel01Icon}
+									strokeWidth={2}
+									className="h-4 w-4"
+									aria-hidden="true"
+								/>
+							</Button>
+						</DialogClose>
 					</div>
 					{isFileMode ? (
 						<div className="text-muted-foreground mt-1 text-xs">
@@ -513,7 +542,7 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 					ref={listRef}
 					id="command-palette-list"
 					role="listbox"
-					className="flex-1 overflow-y-auto"
+					className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
 				>
 					{totalItems === 0 ? (
 						<div className="text-muted-foreground flex items-center justify-center px-4 py-8 text-sm">
@@ -627,8 +656,8 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 						})
 					)}
 				</div>
-			</AlertDialogContent>
-		</AlertDialog>
+			</DialogContent>
+		</Dialog>
 	);
 }
 

--- a/apps/webui/src/components/app/__tests__/AppHeader.test.tsx
+++ b/apps/webui/src/components/app/__tests__/AppHeader.test.tsx
@@ -108,11 +108,13 @@ vi.mock("@/components/ui/badge", () => ({
 	Badge: ({
 		children,
 		variant,
+		...props
 	}: {
 		children: React.ReactNode;
 		variant?: string;
+		[key: string]: unknown;
 	}) => (
-		<span data-testid="badge" data-variant={variant}>
+		<span data-testid="badge" data-variant={variant} {...props}>
 			{children}
 		</span>
 	),
@@ -270,7 +272,7 @@ describe("AppHeader", () => {
 			});
 
 			expect(screen.getByText("mobvibe")).toBeInTheDocument();
-			expect(screen.getByText("Worktree")).toBeInTheDocument();
+			expect(screen.getByTitle("Worktree")).toBeInTheDocument();
 			expect(screen.getByText("feat/detection-fix")).toBeInTheDocument();
 			expect(screen.getByText("Subdir: apps/webui")).toBeInTheDocument();
 		});

--- a/apps/webui/src/components/app/__tests__/CommandPalette.test.tsx
+++ b/apps/webui/src/components/app/__tests__/CommandPalette.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type React from "react";
+import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CommandPalette } from "../CommandPalette";
 
@@ -10,6 +10,8 @@ vi.mock("react-i18next", () => ({
 	useTranslation: () => ({
 		t: (key: string) => {
 			const translations: Record<string, string> = {
+				"common.clear": "Clear",
+				"common.close": "Close",
 				"commandPalette.searchPlaceholder": "Type a command or search...",
 				"commandPalette.newSession": "New Session",
 				"commandPalette.archiveSession": "Archive Session",
@@ -41,6 +43,10 @@ vi.mock("react-i18next", () => ({
 
 // Mock react-router-dom
 const mockNavigate = vi.fn();
+const mockDialogOnOpenChange = vi.hoisted(() => ({
+	value: undefined as undefined | ((open: boolean) => void),
+}));
+
 vi.mock("react-router-dom", () => ({
 	useNavigate: () => mockNavigate,
 	MemoryRouter: ({ children }: { children: React.ReactNode }) => (
@@ -139,18 +145,38 @@ vi.mock("@tanstack/react-virtual", () => ({
 	}),
 }));
 
-// Mock AlertDialog
-vi.mock("@/components/ui/alert-dialog", () => ({
-	AlertDialog: ({
+// Mock Dialog
+vi.mock("@/components/ui/dialog", () => ({
+	Dialog: ({
 		children,
 		open,
+		onOpenChange,
 	}: {
 		children: React.ReactNode;
 		open?: boolean;
-	}) => (open ? <div data-testid="alert-dialog">{children}</div> : null),
-	AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
-		<div data-testid="alert-dialog-content">{children}</div>
+		onOpenChange?: (open: boolean) => void;
+	}) => {
+		mockDialogOnOpenChange.value = onOpenChange;
+		return open ? <div data-testid="dialog">{children}</div> : null;
+	},
+	DialogContent: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="dialog-content">{children}</div>
 	),
+	DialogClose: ({
+		children,
+	}: {
+		children: React.ReactNode;
+		asChild?: boolean;
+	}) =>
+		React.isValidElement<{ onClick?: () => void }>(children)
+			? React.cloneElement(children, {
+					onClick: () => {
+						children.props.onClick?.();
+						mockDialogOnOpenChange.value?.(false);
+					},
+				})
+			: children,
+	DialogTitle: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 describe("CommandPalette", () => {
@@ -178,6 +204,7 @@ describe("CommandPalette", () => {
 			},
 		});
 		vi.clearAllMocks();
+		mockDialogOnOpenChange.value = undefined;
 		// Reset store mocks
 		mockChatStore.value.sessions = {};
 		mockChatStore.value.activeSessionId = undefined;
@@ -186,12 +213,12 @@ describe("CommandPalette", () => {
 	describe("Rendering", () => {
 		it("renders when open is true", () => {
 			renderCommandPalette({ open: true });
-			expect(screen.getByTestId("alert-dialog")).toBeInTheDocument();
+			expect(screen.getByTestId("dialog")).toBeInTheDocument();
 		});
 
 		it("does not render when open is false", () => {
 			renderCommandPalette({ open: false });
-			expect(screen.queryByTestId("alert-dialog")).not.toBeInTheDocument();
+			expect(screen.queryByTestId("dialog")).not.toBeInTheDocument();
 		});
 
 		it("shows search placeholder", () => {
@@ -245,10 +272,19 @@ describe("CommandPalette", () => {
 			expect(input).toHaveValue("test");
 
 			// Find and click clear button
-			const clearButton = screen.getByRole("button", { name: "" });
+			const clearButton = screen.getByRole("button", { name: "Clear" });
 			await user.click(clearButton);
 
 			expect(input).toHaveValue("");
+		});
+
+		it("closes when the close button is clicked", async () => {
+			renderCommandPalette();
+			const user = userEvent.setup();
+
+			await user.click(screen.getByLabelText("Close"));
+
+			expect(mockOnOpenChange).toHaveBeenCalledWith(false);
 		});
 	});
 

--- a/apps/webui/src/components/ui/dialog.tsx
+++ b/apps/webui/src/components/ui/dialog.tsx
@@ -1,0 +1,99 @@
+import { Dialog as DialogPrimitive } from "radix-ui";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Dialog({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+	return (
+		<DialogPrimitive.Overlay
+			data-slot="dialog-overlay"
+			className={cn(
+				"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogContent({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+	return (
+		<DialogPortal>
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				data-slot="dialog-content"
+				className={cn(
+					"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 fixed top-1/2 left-1/2 z-50 grid w-full max-w-sm -translate-x-1/2 -translate-y-1/2 gap-4 rounded-none p-4 ring-1 outline-none duration-100 sm:rounded-lg",
+					className,
+				)}
+				{...props}
+			/>
+		</DialogPortal>
+	);
+}
+
+function DialogClose({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return (
+		<DialogPrimitive.Title
+			data-slot="dialog-title"
+			className={cn("text-sm font-medium", className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+	return (
+		<DialogPrimitive.Description
+			data-slot="dialog-description"
+			className={cn("text-muted-foreground text-xs/relaxed", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Dialog,
+	DialogTrigger,
+	DialogPortal,
+	DialogOverlay,
+	DialogContent,
+	DialogClose,
+	DialogTitle,
+	DialogDescription,
+};

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -8,6 +8,7 @@
 		},
 		"loading": "Loading...",
 		"archive": "Archive",
+		"clear": "Clear",
 		"close": "Close",
 		"cancel": "Cancel",
 		"confirm": "Confirm",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -8,6 +8,7 @@
 		},
 		"loading": "加载中...",
 		"archive": "归档",
+		"clear": "清除",
 		"close": "关闭",
 		"cancel": "取消",
 		"confirm": "确认",


### PR DESCRIPTION
## Summary
- switch the command palette to a regular dialog so mobile no longer gets trapped in a full-screen alert dialog
- tighten the mobile session header layout and replace the worktree badge with a compact icon treatment
- update related tests and translations for the new mobile interactions

## Verification
- pnpm install
- pnpm format
- pnpm lint
- pnpm test:run
- pnpm build