### PR TITLE
fix(webui): keep mobile input beneath sidebar

### DIFF
--- a/apps/webui/src/components/app/AppSidebar.tsx
+++ b/apps/webui/src/components/app/AppSidebar.tsx
@@ -79,7 +79,7 @@ export const AppSidebar = memo(function AppSidebar({
 				}
 			/>
 			{mobileMenuOpen ? (
-				<div className="fixed inset-0 z-50 flex md:hidden pt-[env(safe-area-inset-top)]">
+				<div className="fixed inset-0 z-[60] flex md:hidden pt-[env(safe-area-inset-top)]">
 					<div className="bg-background/90 border-r w-80 p-0 flex h-full overflow-hidden">
 						<MobileMachineColumn />
 						<div className="flex-1 p-4 overflow-hidden flex flex-col min-w-0">

--- a/apps/webui/src/components/app/ChatFooter.tsx
+++ b/apps/webui/src/components/app/ChatFooter.tsx
@@ -984,7 +984,7 @@ export function ChatFooter({
 			style={isMobile ? { bottom: "var(--kb-height, 0px)" } : undefined}
 			className={cn(
 				"bg-background/90 px-4 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] shrink-0",
-				isMobile && "fixed inset-x-0 bottom-0 z-50",
+				isMobile && "fixed inset-x-0 bottom-0 z-40",
 			)}
 		>
 			<div className="mx-auto w-full max-w-5xl">


### PR DESCRIPTION
## Summary
- lower the mobile chat footer layer so it stays beneath overlays
- keep the mobile sidebar above the input when the menu is open

## Testing
- pnpm install
- pnpm build (interrupted before completion)