### PR TITLE
fix(worktree): use real git branch names for base branch selection

### DIFF
--- a/apps/mobvibe-cli/src/lib/__tests__/git-utils.test.ts
+++ b/apps/mobvibe-cli/src/lib/__tests__/git-utils.test.ts
@@ -21,6 +21,7 @@ const {
 	isGitRepo,
 	getGitRepoRoot,
 	getGitBranch,
+	getGitBranches,
 	getGitStatus,
 	getFileDiff,
 	aggregateDirStatus,
@@ -186,6 +187,48 @@ describe("git-utils", () => {
 			const result = await getGitBranch("/home/user/project");
 
 			expect(result).toBeUndefined();
+		});
+	});
+
+	describe("getGitBranches", () => {
+		it("keeps the real branch name separate from upstream and tracking info", async () => {
+			execFileQueue.push({
+				stdout: [
+					"refs/heads/main\tmain\t*\torigin/main\t[ahead 2, behind 1]",
+					"refs/heads/feature/worktree-fix\tfeature/worktree-fix\t\torigin/feature/worktree-fix\t",
+					"refs/remotes/origin/main\torigin/main\t\t\t",
+				].join("\n"),
+				stderr: "",
+			});
+
+			const result = await getGitBranches("/home/user/project");
+
+			expect(result).toEqual([
+				{
+					name: "main",
+					displayName: "main (HEAD)",
+					current: true,
+					remote: undefined,
+					upstream: "origin/main",
+					aheadBehind: { ahead: 2, behind: 1 },
+				},
+				{
+					name: "feature/worktree-fix",
+					displayName: "feature/worktree-fix",
+					current: false,
+					remote: undefined,
+					upstream: "origin/feature/worktree-fix",
+					aheadBehind: undefined,
+				},
+				{
+					name: "origin/main",
+					displayName: "origin/main",
+					current: false,
+					remote: "origin",
+					upstream: undefined,
+					aheadBehind: undefined,
+				},
+			]);
 		});
 	});
 

--- a/apps/mobvibe-cli/src/lib/git-utils.ts
+++ b/apps/mobvibe-cli/src/lib/git-utils.ts
@@ -730,7 +730,7 @@ export async function getGitBranches(cwd: string): Promise<GitBranch[]> {
 			[
 				"branch",
 				"-a",
-				"--format=%(refname:short)%(HEAD)%(upstream:short)%(upstream:track)",
+				"--format=%(refname)%x09%(refname:short)%x09%(HEAD)%x09%(upstream:short)%x09%(upstream:track)",
 			],
 			{ cwd, maxBuffer: MAX_BUFFER },
 		);
@@ -738,34 +738,34 @@ export async function getGitBranches(cwd: string): Promise<GitBranch[]> {
 		const branches: GitBranch[] = [];
 
 		for (const line of stdout.split("\n").filter(Boolean)) {
-			// Parse the format: name*upstream[ahead N, behind M]
-			const current = line.includes("*");
-			const cleanLine = line.replace("*", "");
-
-			// Simple parsing: first part is name, rest is upstream/tracking
-			const parts = cleanLine.split(/(?=\[)/);
-			const nameAndUpstream = parts[0].trim();
-			const tracking = parts[1]?.trim() || "";
-
-			// Check if remote branch
-			const isRemote = nameAndUpstream.startsWith("origin/");
+			const [
+				fullRef = "",
+				shortRef = "",
+				headMarker = "",
+				upstreamRef = "",
+				tracking = "",
+			] = line.split("\t");
+			const name = shortRef.trim();
+			if (!name) {
+				continue;
+			}
+			const current = headMarker.trim() === "*";
+			const upstream = upstreamRef.trim() || undefined;
+			const isRemote = fullRef.trim().startsWith("refs/remotes/");
 
 			// Parse ahead/behind
-			let ahead = 0;
-			let behind = 0;
-			const trackMatch = tracking.match(
-				/\[ahead (\d+)(?:, behind (\d+))?\]|\[behind (\d+)\]/,
-			);
-			if (trackMatch) {
-				ahead = Number.parseInt(trackMatch[1] || "0", 10);
-				behind = Number.parseInt(trackMatch[2] || trackMatch[3] || "0", 10);
-			}
+			const aheadMatch = tracking.match(/ahead (\d+)/);
+			const behindMatch = tracking.match(/behind (\d+)/);
+			const ahead = aheadMatch ? Number.parseInt(aheadMatch[1], 10) : 0;
+			const behind = behindMatch ? Number.parseInt(behindMatch[1], 10) : 0;
 
 			branches.push({
-				name: nameAndUpstream,
+				name,
+				displayName: current ? `${name} (HEAD)` : name,
 				current,
-				remote: isRemote ? "origin" : undefined,
-				aheadBehind: trackMatch ? { ahead, behind } : undefined,
+				remote: isRemote ? name.split("/")[0] : undefined,
+				upstream,
+				aheadBehind: ahead > 0 || behind > 0 ? { ahead, behind } : undefined,
 			});
 		}
 

--- a/apps/webui/src/components/app/BranchSelector.tsx
+++ b/apps/webui/src/components/app/BranchSelector.tsx
@@ -28,6 +28,12 @@ type BranchSelectorProps = {
 	onOpenChange: (open: boolean) => void;
 };
 
+const getBranchLabel = (branch: {
+	name: string;
+	displayName?: string;
+	current: boolean;
+}) => branch.displayName ?? `${branch.name}${branch.current ? " (HEAD)" : ""}`;
+
 export function BranchSelector({
 	sessionId,
 	currentBranch,
@@ -51,7 +57,7 @@ export function BranchSelector({
 			() =>
 				fuzzySearch({
 					items: branches,
-					getText: (b) => b.name,
+					getText: (b) => getBranchLabel(b),
 					query: searchQuery,
 				}),
 			[branches, searchQuery],
@@ -139,7 +145,7 @@ export function BranchSelector({
 									/>
 									<div className="flex min-w-0 flex-1 flex-col gap-0.5">
 										<FuzzyHighlight
-											text={branch.name}
+											text={getBranchLabel(branch)}
 											ranges={result.highlightRanges}
 											className="truncate font-medium"
 										/>

--- a/apps/webui/src/components/app/CreateSessionDialog.tsx
+++ b/apps/webui/src/components/app/CreateSessionDialog.tsx
@@ -51,6 +51,11 @@ export type CreateSessionDialogProps = {
 
 /** Sanitize branch name for worktree path preview */
 const sanitizeBranch = (branch: string) => branch.replace(/[/\\]/g, "-");
+const getBranchOptionLabel = (branch: {
+	name: string;
+	displayName?: string;
+	current: boolean;
+}) => branch.displayName ?? `${branch.name}${branch.current ? " (HEAD)" : ""}`;
 
 export function CreateSessionDialog({
 	open,
@@ -370,8 +375,7 @@ export function CreateSessionDialog({
 											<SelectContent>
 												{branches.map((b) => (
 													<SelectItem key={b.name} value={b.name}>
-														{b.name}
-														{b.current ? " (HEAD)" : ""}
+														{getBranchOptionLabel(b)}
 													</SelectItem>
 												))}
 											</SelectContent>

--- a/apps/webui/src/components/app/__tests__/CreateSessionDialog.test.tsx
+++ b/apps/webui/src/components/app/__tests__/CreateSessionDialog.test.tsx
@@ -45,7 +45,11 @@ const mockQueryState = vi.hoisted(() => ({
 		data: undefined as
 			| {
 					isGitRepo: boolean;
-					branches: Array<{ name: string; current?: boolean }>;
+					branches: Array<{
+						name: string;
+						displayName?: string;
+						current?: boolean;
+					}>;
 					repoRoot?: string;
 					repoName?: string;
 					relativeCwd?: string;
@@ -302,5 +306,44 @@ describe("CreateSessionDialog", () => {
 
 		expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
 		expect(screen.getByText("Checking project...")).toBeInTheDocument();
+	});
+
+	it("renders branch display labels while keeping the raw branch name as the option value", () => {
+		mockQueryState.branches = {
+			data: {
+				isGitRepo: true,
+				branches: [
+					{
+						name: "main",
+						displayName: "main (HEAD)",
+						current: true,
+					},
+				],
+				repoRoot: "/repo",
+				repoName: "repo",
+				relativeCwd: "apps/webui",
+				worktreeBaseDir: "/tmp/worktrees",
+			},
+			isFetching: false,
+			isFetched: true,
+			isError: false,
+		};
+
+		render(
+			<CreateSessionDialog
+				open
+				onOpenChange={vi.fn()}
+				availableBackends={[
+					{ backendId: "backend-1", backendLabel: "Backend 1" },
+				]}
+				isCreating={false}
+				onCreate={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("main (HEAD)")).toBeInTheDocument();
+		expect(
+			screen.getByText("main (HEAD)").closest("[data-value]"),
+		).toHaveAttribute("data-value", "main");
 	});
 });

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -443,6 +443,8 @@ export type GitBlameLine = {
 
 export type GitBranch = {
 	name: string;
+	/** Optional UI label; when omitted, render `name`. */
+	displayName?: string;
 	current: boolean;
 	remote?: string;
 	upstream?: string;


### PR DESCRIPTION
## Summary
- fix git branch parsing so worktree base branch selection always uses the real branch name
- separate branch display labels from submitted branch values in the create session flow
- add regression coverage for CLI parsing and the create session branch selector

Closes #65