### PR TITLE
Fix issue 67 notification routing

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -208,10 +208,6 @@ const sessionRouter = new SessionRouter(cliRegistry);
 const webuiEmitter = setupWebuiHandlers(io, cliRegistry, userAffinity);
 const notificationService = new NotificationService({
 	config,
-	presence: {
-		hasUserConnections: webuiEmitter.hasUserConnections,
-		hasSessionSubscribers: webuiEmitter.hasSessionSubscribers,
-	},
 	resolveSessionTitle: (userId, sessionId) =>
 		cliRegistry
 			.getSessionsForUser(userId)

--- a/apps/gateway/src/services/notification-service.ts
+++ b/apps/gateway/src/services/notification-service.ts
@@ -10,14 +10,8 @@ import {
 	upsertWebPushSubscription,
 } from "./db-service.js";
 
-type PresenceResolver = {
-	hasUserConnections: (userId: string) => boolean;
-	hasSessionSubscribers: (sessionId: string, userId?: string) => boolean;
-};
-
 type NotificationServiceOptions = {
 	config: GatewayConfig;
-	presence: PresenceResolver;
 	resolveSessionTitle: (
 		userId: string,
 		sessionId: string,
@@ -89,38 +83,30 @@ export class NotificationService {
 			payload.toolCall?.title ??
 			(payload.toolCall?._meta?.name as string | undefined) ??
 			"Action required";
-		await this.sendBrowserPush(
-			userId,
-			{
-				title: sessionTitle
-					? `${sessionTitle}: Permission required`
-					: "Permission required",
-				body: toolLabel,
-				tag: `permission:${payload.requestId}`,
-				url: this.buildSessionUrl(payload.sessionId),
-				sessionId: payload.sessionId,
-			},
-			payload.sessionId,
-		);
+		await this.sendBrowserPush(userId, {
+			title: sessionTitle
+				? `${sessionTitle}: Permission required`
+				: "Permission required",
+			body: toolLabel,
+			tag: `permission:${payload.requestId}`,
+			url: this.buildSessionUrl(payload.sessionId),
+			sessionId: payload.sessionId,
+		});
 	}
 
 	async notifySessionEvent(userId: string, event: SessionEvent): Promise<void> {
 		switch (event.kind) {
 			case "turn_end":
-				await this.sendBrowserPush(
-					userId,
-					{
-						title: this.withSessionTitle(
-							userId,
-							event.sessionId,
-							"Response completed",
-						),
-						tag: `turn-end:${event.sessionId}:${event.revision}:${event.seq}`,
-						url: this.buildSessionUrl(event.sessionId),
-						sessionId: event.sessionId,
-					},
-					event.sessionId,
-				);
+				await this.sendBrowserPush(userId, {
+					title: this.withSessionTitle(
+						userId,
+						event.sessionId,
+						"Response completed",
+					),
+					tag: `turn-end:${event.sessionId}:${event.revision}:${event.seq}`,
+					url: this.buildSessionUrl(event.sessionId),
+					sessionId: event.sessionId,
+				});
 				return;
 			case "session_error": {
 				const payload =
@@ -131,21 +117,17 @@ export class NotificationService {
 								error?: { message?: string };
 							})
 						: undefined;
-				await this.sendBrowserPush(
-					userId,
-					{
-						title: this.withSessionTitle(
-							userId,
-							event.sessionId,
-							"Session error",
-						),
-						body: payload?.error?.message,
-						tag: `session-error:${event.sessionId}`,
-						url: this.buildSessionUrl(event.sessionId),
-						sessionId: event.sessionId,
-					},
-					event.sessionId,
-				);
+				await this.sendBrowserPush(userId, {
+					title: this.withSessionTitle(
+						userId,
+						event.sessionId,
+						"Session error",
+					),
+					body: payload?.error?.message,
+					tag: `session-error:${event.sessionId}`,
+					url: this.buildSessionUrl(event.sessionId),
+					sessionId: event.sessionId,
+				});
 				return;
 			}
 			default:
@@ -176,16 +158,8 @@ export class NotificationService {
 	private async sendBrowserPush(
 		userId: string,
 		payload: BrowserPushPayload,
-		sessionId?: string,
 	): Promise<void> {
 		if (!this.webPushEnabled) {
-			return;
-		}
-		if (
-			sessionId
-				? this.options.presence.hasSessionSubscribers(sessionId, userId)
-				: this.options.presence.hasUserConnections(userId)
-		) {
 			return;
 		}
 
@@ -225,7 +199,7 @@ export class NotificationService {
 		for (const result of deliveries) {
 			if (result.status === "rejected") {
 				logger.warn(
-					{ err: result.reason, userId, sessionId },
+					{ err: result.reason, userId, sessionId: payload.sessionId },
 					"browser_push_delivery_failed",
 				);
 			}

--- a/apps/gateway/src/socket/__tests__/cli-handlers.test.ts
+++ b/apps/gateway/src/socket/__tests__/cli-handlers.test.ts
@@ -177,6 +177,28 @@ describe("setupCliHandlers", () => {
 		);
 	});
 
+	it("does not dispatch permission notifications for inactive sessions", () => {
+		const info = createMockRegistrationInfo({ machineId: "machine-1" });
+		registry.register(socket, info, {
+			userId: "user-1",
+			deviceId: "device-123",
+		});
+		registry.updateSessions("socket-1", [
+			createMockSessionSummary({
+				sessionId: "session-1",
+				isAttached: false,
+			}),
+		]);
+
+		socketHandlers["permission:request"]?.({
+			sessionId: "session-1",
+			requestId: "request-1",
+			options: [],
+		});
+
+		expect(notificationService.notifyPermissionRequest).not.toHaveBeenCalled();
+	});
+
 	it("dispatches session event notifications", () => {
 		const info = createMockRegistrationInfo({ machineId: "machine-1" });
 		registry.register(socket, info, {
@@ -200,6 +222,31 @@ describe("setupCliHandlers", () => {
 				kind: "turn_end",
 			}),
 		);
+	});
+
+	it("does not dispatch session notifications for inactive sessions", () => {
+		const info = createMockRegistrationInfo({ machineId: "machine-1" });
+		registry.register(socket, info, {
+			userId: "user-1",
+			deviceId: "device-123",
+		});
+		registry.updateSessions("socket-1", [
+			createMockSessionSummary({
+				sessionId: "session-1",
+				isAttached: false,
+			}),
+		]);
+
+		socketHandlers["session:event"]?.({
+			sessionId: "session-1",
+			revision: 1,
+			seq: 9,
+			kind: "turn_end",
+			createdAt: new Date().toISOString(),
+			payload: {},
+		});
+
+		expect(notificationService.notifySessionEvent).not.toHaveBeenCalled();
 	});
 
 	it("does NOT emit detached for discovered (non-attached) sessions on disconnect", async () => {

--- a/apps/gateway/src/socket/cli-handlers.ts
+++ b/apps/gateway/src/socket/cli-handlers.ts
@@ -53,6 +53,19 @@ export function setupCliHandlers(
 ) {
 	const cliNamespace = io.of("/cli");
 
+	const isActiveCliSession = (
+		record: ReturnType<CliRegistry["getCliBySocketId"]>,
+		sessionId: string,
+	): boolean => {
+		if (!record) {
+			return false;
+		}
+		const session = record.sessions.find(
+			(candidate) => candidate.sessionId === sessionId,
+		);
+		return session ? session.isAttached !== false : true;
+	};
+
 	// Ensure crypto is ready for signature verification
 	const cryptoReady = initCrypto();
 
@@ -354,7 +367,11 @@ export function setupCliHandlers(
 				"permission_request_received",
 			);
 			emitToWebui("permission:request", payload, record.userId);
-			if (record.userId && notificationService) {
+			if (
+				record.userId &&
+				notificationService &&
+				isActiveCliSession(record, payload.sessionId)
+			) {
 				void notificationService.notifyPermissionRequest(
 					record.userId,
 					payload,
@@ -399,7 +416,11 @@ export function setupCliHandlers(
 				"session_event_received",
 			);
 			emitToWebui("session:event", event, record.userId);
-			if (record.userId && notificationService) {
+			if (
+				record.userId &&
+				notificationService &&
+				isActiveCliSession(record, event.sessionId)
+			) {
 				void notificationService.notifySessionEvent(record.userId, event);
 			}
 

--- a/apps/webui/src/lib/notifications.ts
+++ b/apps/webui/src/lib/notifications.ts
@@ -208,8 +208,21 @@ export const pushNotification = (
 export const ensureNotificationPermission = async (options?: {
 	isAuthenticated?: boolean;
 }) => {
-	// For Tauri, permissions are requested when sending notifications
 	if (isInTauri()) {
+		if (options?.isAuthenticated !== true) {
+			return;
+		}
+		try {
+			const { isPermissionGranted, requestPermission } = await import(
+				"@tauri-apps/plugin-notification"
+			);
+			const permissionGranted = await isPermissionGranted();
+			if (!permissionGranted) {
+				await requestPermission();
+			}
+		} catch {
+			return;
+		}
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- remove webui presence-based push suppression from gateway notifications
- gate notification dispatch from cli events on active attached sessions only
- request Tauri notification permission proactively after auth for Android/mobile

## Testing
- pnpm -C packages/shared lint
- pnpm -C packages/shared build
- pnpm -C apps/gateway lint
- pnpm -C apps/gateway exec vitest run src/socket/__tests__/cli-handlers.test.ts src/socket/__tests__/webui-handlers.test.ts
- pnpm -C apps/webui exec vitest run src/lib/__tests__/socket.test.ts
- pnpm -C apps/gateway build
- pnpm -C apps/webui build

Closes #67