### PR TITLE
fix(webui): restore sync history and stabilize e2e

### DIFF
--- a/apps/webui/playwright.config.ts
+++ b/apps/webui/playwright.config.ts
@@ -3,6 +3,16 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "@playwright/test";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
+const runOffset = process.env.CI ? 0 : process.pid % 1000;
+const gatewayPort = Number(
+	process.env.PLAYWRIGHT_GATEWAY_PORT ?? String(33005 + runOffset),
+);
+const webPort = Number(
+	process.env.PLAYWRIGHT_WEB_PORT ?? String(34173 + runOffset),
+);
+
+process.env.PLAYWRIGHT_GATEWAY_PORT = String(gatewayPort);
+process.env.PLAYWRIGHT_WEB_PORT = String(webPort);
 
 export default defineConfig({
 	testDir: "./tests/e2e",
@@ -12,20 +22,20 @@ export default defineConfig({
 		timeout: 10_000,
 	},
 	use: {
-		baseURL: "http://127.0.0.1:4173",
+		baseURL: `http://127.0.0.1:${webPort}`,
 		headless: true,
 	},
 	webServer: [
 		{
-			command: "node tests/e2e/fake-gateway.mjs",
-			port: 3005,
-			reuseExistingServer: true,
+			command: `PLAYWRIGHT_GATEWAY_PORT=${gatewayPort} node tests/e2e/fake-gateway.mjs`,
+			port: gatewayPort,
+			reuseExistingServer: false,
 			cwd: dirname,
 		},
 		{
-			command: "VITE_GATEWAY_URL= pnpm exec vite --host 127.0.0.1 --port 4173",
-			port: 4173,
-			reuseExistingServer: true,
+			command: `VITE_GATEWAY_URL= VITE_API_GATEWAY_URL=http://127.0.0.1:${gatewayPort} pnpm exec vite --host 127.0.0.1 --port ${webPort}`,
+			port: webPort,
+			reuseExistingServer: false,
 			cwd: dirname,
 		},
 	],

--- a/apps/webui/src/hooks/__tests__/useSessionBackfill.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionBackfill.test.tsx
@@ -2,13 +2,29 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSessionBackfill } from "@/hooks/use-session-backfill";
 
-// Mock fetch globally
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+const mockFetch = vi.hoisted(() => vi.fn());
+const envState = vi.hoisted(() => ({
+	isTauri: false,
+	authToken: null as string | null,
+}));
+
+vi.mock("@/lib/auth", () => ({
+	isInTauri: () => envState.isTauri,
+}));
+
+vi.mock("@/lib/auth-token", () => ({
+	getAuthToken: () => envState.authToken,
+}));
+
+vi.mock("@/lib/tauri-fetch", () => ({
+	platformFetch: mockFetch,
+}));
 
 describe("useSessionBackfill", () => {
 	beforeEach(() => {
 		mockFetch.mockReset();
+		envState.isTauri = false;
+		envState.authToken = null;
 	});
 
 	it("P0-3: does not call onComplete when revision mismatch occurs", async () => {
@@ -263,8 +279,10 @@ describe("useSessionBackfill", () => {
 		);
 
 		// Start first backfill (revision 1)
-		const firstBackfill = act(async () => {
-			await result.current.startBackfill("session-1", 1, 0);
+		let firstBackfill: Promise<void>;
+		await act(async () => {
+			firstBackfill = result.current.startBackfill("session-1", 1, 0);
+			await Promise.resolve();
 		});
 
 		// Immediately start second backfill (revision 2) - should cancel first
@@ -293,7 +311,7 @@ describe("useSessionBackfill", () => {
 				}),
 		});
 
-		await firstBackfill;
+		await firstBackfill!;
 
 		// Only the second backfill's onComplete should be called
 		// (first is cancelled due to abort or generation mismatch)
@@ -342,5 +360,43 @@ describe("useSessionBackfill", () => {
 		expect(onEvents).not.toHaveBeenCalled();
 		expect(onError).not.toHaveBeenCalled();
 		expect(onComplete).not.toHaveBeenCalled();
+	});
+
+	it("uses the stored Tauri auth token for backfill requests", async () => {
+		envState.isTauri = true;
+		envState.authToken = "tauri-test-token";
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					sessionId: "session-1",
+					machineId: "machine-1",
+					revision: 1,
+					events: [],
+					hasMore: false,
+				}),
+		});
+
+		const { result } = renderHook(() =>
+			useSessionBackfill({
+				gatewayUrl: "http://localhost:3005",
+				onEvents: vi.fn(),
+			}),
+		);
+
+		await act(async () => {
+			await result.current.startBackfill("session-1", 1, 0);
+		});
+
+		expect(mockFetch).toHaveBeenCalledWith(
+			"http://localhost:3005/acp/session/events?sessionId=session-1&revision=1&afterSeq=0&limit=100",
+			expect.objectContaining({
+				credentials: "omit",
+				headers: expect.objectContaining({
+					Authorization: "Bearer tauri-test-token",
+				}),
+			}),
+		);
 	});
 });

--- a/apps/webui/src/hooks/__tests__/useSocket.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSocket.test.tsx
@@ -13,12 +13,23 @@ const mockStoreState = vi.hoisted(
 	() =>
 		({
 			sessions: {} as Record<string, ChatSession>,
-		}) as { sessions: Record<string, ChatSession> },
+			restoreSessionMessages: vi.fn(),
+		}) as {
+			sessions: Record<string, ChatSession>;
+			restoreSessionMessages: ChatStoreActions["restoreSessionMessages"];
+		},
 );
 
 const storeListeners = vi.hoisted(
 	() => new Set<(state: typeof mockStoreState) => void>(),
 );
+const backfillOptionsRef = vi.hoisted(() => ({
+	current: undefined as
+		| Parameters<
+				typeof import("@/hooks/use-session-backfill")["useSessionBackfill"]
+		  >[0]
+		| undefined,
+}));
 
 const setMockSessions = (sessions: Record<string, ChatSession>) => {
 	mockStoreState.sessions = sessions;
@@ -51,7 +62,14 @@ vi.mock("@/lib/chat-store", async (importOriginal) => {
 });
 
 vi.mock("@/hooks/use-session-backfill", () => ({
-	useSessionBackfill: () => mockBackfill,
+	useSessionBackfill: (
+		options: Parameters<
+			typeof import("@/hooks/use-session-backfill")["useSessionBackfill"]
+		>[0],
+	) => {
+		backfillOptionsRef.current = options;
+		return mockBackfill;
+	},
 }));
 
 const mockBackfill = vi.hoisted(() => ({
@@ -175,6 +193,9 @@ const createStore = (): ChatStoreActions => {
 		},
 	);
 
+	const restoreSessionMessages = vi.fn();
+	mockStoreState.restoreSessionMessages = restoreSessionMessages;
+
 	return {
 		sessions: {},
 		setActiveSessionId: vi.fn(),
@@ -208,7 +229,7 @@ const createStore = (): ChatStoreActions => {
 		appendTerminalOutput: vi.fn(),
 		handleSessionsChanged: vi.fn(),
 		clearSessionMessages: vi.fn(),
-		restoreSessionMessages: vi.fn(),
+		restoreSessionMessages,
 		updateSessionCursor,
 		resetSessionForRevision,
 	} as unknown as ChatStoreActions;
@@ -232,6 +253,7 @@ describe("useSocket (webui)", () => {
 	beforeEach(() => {
 		// Reset mock store state
 		setMockSessions({});
+		mockStoreState.restoreSessionMessages = vi.fn();
 		dekReadyListeners.clear();
 		decryptedPayloads.clear();
 
@@ -246,6 +268,7 @@ describe("useSocket (webui)", () => {
 		mockBackfill.cancelBackfill.mockReset();
 		mockBackfill.isBackfilling.mockReset();
 		mockBackfill.isBackfilling.mockReturnValue(false);
+		backfillOptionsRef.current = undefined;
 		mockE2EE.hasSessionDek.mockReset();
 		mockE2EE.hasSessionDek.mockReturnValue(true);
 		mockE2EE.decryptEvent.mockClear();
@@ -459,6 +482,83 @@ describe("useSocket (webui)", () => {
 				sessionId: "session-1",
 				machineId: "machine-1",
 				reason: "gateway_disconnect",
+			}),
+		);
+	});
+
+	it("restores the previous transcript when a manual sync backfill fails before replay", async () => {
+		const store = createStore();
+		const sessions = {
+			"session-1": buildSession({
+				sessionId: "session-1",
+				isAttached: true,
+				revision: 1,
+				lastAppliedSeq: 2,
+				messages: [
+					{
+						id: "msg-1",
+						role: "assistant",
+						kind: "text",
+						content: "stale transcript",
+						contentBlocks: [{ type: "text", text: "stale transcript" }],
+						createdAt: "2024-01-01T00:00:00Z",
+						isStreaming: false,
+					},
+				],
+			}),
+		};
+		setMockSessions({ ...sessions });
+
+		const { result } = renderHook(() =>
+			useSocket({
+				sessions,
+				appendAssistantChunk: store.appendAssistantChunk,
+				appendThoughtChunk: store.appendThoughtChunk,
+				confirmOrAppendUserMessage: store.confirmOrAppendUserMessage,
+				updateSessionMeta: store.updateSessionMeta,
+				setStreamError: store.setStreamError,
+				addPermissionRequest: store.addPermissionRequest,
+				setPermissionDecisionState: store.setPermissionDecisionState,
+				setPermissionOutcome: store.setPermissionOutcome,
+				addToolCall: store.addToolCall,
+				updateToolCall: store.updateToolCall,
+				appendTerminalOutput: store.appendTerminalOutput,
+				handleSessionsChanged: store.handleSessionsChanged,
+				markSessionAttached: store.markSessionAttached,
+				markSessionDetached: store.markSessionDetached,
+				createLocalSession: store.createLocalSession,
+				updateSessionCursor: store.updateSessionCursor,
+				resetSessionForRevision: store.resetSessionForRevision,
+			}),
+		);
+
+		act(() => {
+			result.current.syncSessionHistory("session-1");
+		});
+
+		setMockSessions({
+			"session-1": buildSession({
+				sessionId: "session-1",
+				isAttached: true,
+				revision: 1,
+				lastAppliedSeq: 0,
+				messages: [],
+			}),
+		});
+
+		act(() => {
+			backfillOptionsRef.current?.onError?.(
+				"session-1",
+				new Error("backfill failed"),
+			);
+		});
+
+		expect(store.restoreSessionMessages).toHaveBeenCalledWith(
+			"session-1",
+			sessions["session-1"].messages,
+			expect.objectContaining({
+				revision: 1,
+				lastAppliedSeq: 2,
 			}),
 		);
 	});

--- a/apps/webui/src/hooks/use-session-backfill.ts
+++ b/apps/webui/src/hooks/use-session-backfill.ts
@@ -1,6 +1,8 @@
 import type { SessionEvent, SessionEventsResponse } from "@mobvibe/shared";
 import { useCallback, useRef } from "react";
 import { isInTauri } from "@/lib/auth";
+import { getAuthToken } from "@/lib/auth-token";
+import { platformFetch } from "@/lib/tauri-fetch";
 
 type BackfillState = {
 	sessionId: string;
@@ -60,15 +62,17 @@ export function useSessionBackfill({
 			const headers: Record<string, string> = {
 				"Content-Type": "application/json",
 			};
-			if (authToken) {
-				headers.Authorization = `Bearer ${authToken}`;
+			const tauriEnv = isInTauri();
+			const token = authToken ?? (tauriEnv ? getAuthToken() : null);
+			if (token) {
+				headers.Authorization = `Bearer ${token}`;
 			}
 
-			const response = await fetch(url.toString(), {
+			const response = await platformFetch(url.toString(), {
 				method: "GET",
 				headers,
 				signal,
-				credentials: isInTauri() ? "omit" : "include",
+				credentials: tauriEnv ? "omit" : "include",
 			});
 
 			if (!response.ok) {

--- a/apps/webui/src/hooks/useSocket.ts
+++ b/apps/webui/src/hooks/useSocket.ts
@@ -20,7 +20,12 @@ import {
 	type SessionsChangedPayload,
 	type TerminalOutputEvent,
 } from "@/lib/acp";
-import { type ChatSession, useChatStore } from "@/lib/chat-store";
+import {
+	type ChatMessage,
+	type ChatSession,
+	type SessionRestoreSnapshot,
+	useChatStore,
+} from "@/lib/chat-store";
 import { e2ee } from "@/lib/e2ee";
 import { isErrorDetail } from "@/lib/error-utils";
 import { useMachinesStore } from "@/lib/machines-store";
@@ -137,6 +142,15 @@ export function useSocket({
 
 	// Buffer for encrypted events received before DEK is ready
 	const encryptedBufferRef = useRef<Map<string, SessionEvent[]>>(new Map());
+	const syncBackupsRef = useRef<
+		Map<
+			string,
+			{
+				messages: ChatMessage[];
+				snapshot: SessionRestoreSnapshot;
+			}
+		>
+	>(new Map());
 
 	// Track which sessions have triggered initial backfill
 	const initialBackfillTriggeredRef = useRef<Set<string>>(new Set());
@@ -410,35 +424,55 @@ export function useSocket({
 			flushPendingEventsRef.current?.(sessionId);
 		},
 		onComplete: (_sessionId) => {
-			// Backfill complete - nothing special needed
+			syncBackupsRef.current.delete(_sessionId);
 		},
 		onError: (sessionId, error) => {
 			console.error(`[backfill] Error for session ${sessionId}:`, error);
 			// Fall back to applying pending events best effort
 			const pending = pendingEventsRef.current.get(sessionId);
-			if (!pending || pending.length === 0) return;
+			if (pending && pending.length > 0) {
+				const cursor = getCursor(sessionId);
+				const sorted = pending
+					.filter((e) =>
+						cursor.revision === undefined
+							? true
+							: e.revision === cursor.revision,
+					)
+					.sort((a, b) => a.seq - b.seq);
 
-			const cursor = getCursor(sessionId);
-			const sorted = pending
-				.filter((e) =>
-					cursor.revision === undefined ? true : e.revision === cursor.revision,
-				)
-				.sort((a, b) => a.seq - b.seq);
-
-			let lastSeq = cursor.lastAppliedSeq;
-			for (const event of sorted) {
-				if (event.seq <= lastSeq) continue;
-				if (event.seq !== lastSeq + 1) break;
-				applySessionEventRef.current?.(event);
-				lastSeq = event.seq;
-				updateSessionCursor(sessionId, event.revision, event.seq);
+				let lastSeq = cursor.lastAppliedSeq;
+				for (const event of sorted) {
+					if (event.seq <= lastSeq) continue;
+					if (event.seq !== lastSeq + 1) break;
+					applySessionEventRef.current?.(event);
+					lastSeq = event.seq;
+					updateSessionCursor(sessionId, event.revision, event.seq);
+				}
+				pendingEventsRef.current.delete(sessionId);
 			}
-			pendingEventsRef.current.delete(sessionId);
+
+			const backup = syncBackupsRef.current.get(sessionId);
+			if (!backup) {
+				return;
+			}
+
+			const failedSession = useChatStore.getState().sessions[sessionId];
+			if (
+				failedSession &&
+				failedSession.messages.length === 0 &&
+				(failedSession.lastAppliedSeq ?? 0) === 0
+			) {
+				useChatStore
+					.getState()
+					.restoreSessionMessages(sessionId, backup.messages, backup.snapshot);
+			}
+			syncBackupsRef.current.delete(sessionId);
 		},
 		onRevisionMismatch: (sessionId, newRevision) => {
 			console.log(
 				`[backfill] Revision mismatch for ${sessionId}, resetting to revision ${newRevision}`,
 			);
+			syncBackupsRef.current.delete(sessionId);
 			resetSessionForRevision(sessionId, newRevision);
 			pendingEventsRef.current.delete(sessionId);
 
@@ -455,6 +489,17 @@ export function useSocket({
 			if (!session || session.sending) return;
 
 			const revision = session.revision ?? 1;
+			syncBackupsRef.current.set(sessionId, {
+				messages: [...session.messages],
+				snapshot: {
+					lastAppliedSeq: session.lastAppliedSeq,
+					revision: session.revision,
+					terminalOutputs: { ...session.terminalOutputs },
+					streamingMessageId: session.streamingMessageId,
+					streamingMessageRole: session.streamingMessageRole,
+					streamingThoughtId: session.streamingThoughtId,
+				},
+			});
 
 			// Full re-sync: clear all buffers, reset messages, replay from seq 0
 			pendingEventsRef.current.delete(sessionId);

--- a/apps/webui/src/lib/gateway-config.ts
+++ b/apps/webui/src/lib/gateway-config.ts
@@ -5,13 +5,16 @@ import { tauriStoreGet, tauriStoreSet } from "./tauri-store";
  * Get the gateway URL based on the current environment.
  *
  * Priority:
- * 1. VITE_GATEWAY_URL environment variable
+ * 1. VITE_API_GATEWAY_URL environment variable
+ * 2. VITE_GATEWAY_URL environment variable
  * 2. Stored URL from Tauri Store (for desktop/mobile apps)
  * 3. Default based on current window location (for web)
  */
 export const getGatewayUrl = async (): Promise<string> => {
-	// Check environment variable first
-	const envUrl = import.meta.env.VITE_GATEWAY_URL as string | undefined;
+	// Check environment variables first
+	const envUrl =
+		(import.meta.env.VITE_API_GATEWAY_URL as string | undefined) ??
+		(import.meta.env.VITE_GATEWAY_URL as string | undefined);
 	if (envUrl) {
 		return envUrl;
 	}
@@ -59,7 +62,9 @@ export const setGatewayUrl = async (url: string): Promise<void> => {
  * Useful for synchronous operations where async is not possible.
  */
 export const getDefaultGatewayUrl = (): string => {
-	const envUrl = import.meta.env.VITE_GATEWAY_URL as string | undefined;
+	const envUrl =
+		(import.meta.env.VITE_API_GATEWAY_URL as string | undefined) ??
+		(import.meta.env.VITE_GATEWAY_URL as string | undefined);
 	if (envUrl) {
 		return envUrl;
 	}

--- a/apps/webui/tests/e2e/fake-gateway.mjs
+++ b/apps/webui/tests/e2e/fake-gateway.mjs
@@ -12,7 +12,7 @@ import {
 } from "@mobvibe/shared";
 import { Server as SocketIOServer } from "socket.io";
 
-const PORT = 3005;
+const PORT = Number(process.env.PLAYWRIGHT_GATEWAY_PORT ?? "33005");
 const MACHINE_ID = "machine-1";
 const PRIMARY_MASTER_SECRET_BYTES = new Uint8Array(
 	Array.from({ length: 32 }, (_, index) => index + 1),

--- a/apps/webui/tests/e2e/test-helpers.ts
+++ b/apps/webui/tests/e2e/test-helpers.ts
@@ -1,7 +1,9 @@
 import { Buffer } from "node:buffer";
 import { expect, type Page } from "@playwright/test";
 
-export const gatewayUrl = "http://127.0.0.1:3005";
+const gatewayPort = process.env.PLAYWRIGHT_GATEWAY_PORT ?? "33005";
+
+export const gatewayUrl = `http://127.0.0.1:${gatewayPort}`;
 
 export const wrongMasterSecret = Buffer.from(
 	new Uint8Array(Array.from({ length: 32 }, (_, index) => 255 - index)),


### PR DESCRIPTION
## Summary
- route session backfill through platform fetch so Tauri sync history requests carry auth and succeed consistently
- restore the previous transcript when a manual sync/reload backfill fails before any replayed events arrive
- isolate Playwright web/gateway ports and split API gateway config from auth-enabled gateway config so e2e runs against the fake gateway without reusing stale local servers
- add regression coverage for backfill auth, sync rollback, and the affected session restore/e2ee flows

## Testing
- pnpm format
- pnpm lint
- pnpm build
- pnpm test:run