### PR TITLE
fix(webui): bootstrap e2ee for restored sessions

### DIFF
--- a/apps/webui/src/App.tsx
+++ b/apps/webui/src/App.tsx
@@ -42,7 +42,7 @@ import { useSocket } from "@/hooks/useSocket";
 import type { SessionsResponse } from "@/lib/api";
 import { getAuthClient, isInTauri } from "@/lib/auth";
 import { useChatStore } from "@/lib/chat-store";
-import { e2ee } from "@/lib/e2ee";
+import { bootstrapSessionE2EE, e2ee } from "@/lib/e2ee";
 import { createFallbackError, normalizeError } from "@/lib/error-utils";
 import { isInputFocused, registerHotkeys } from "@/lib/hotkeys";
 import { getBackendCapability, useMachinesStore } from "@/lib/machines-store";
@@ -99,6 +99,7 @@ function MainApp() {
 			setInputContents: s.setInputContents,
 			setSending: s.setSending,
 			setCanceling: s.setCanceling,
+			setSessionE2EEStatus: s.setSessionE2EEStatus,
 			setStreamError: s.setStreamError,
 			updateSessionMeta: s.updateSessionMeta,
 			addUserMessage: s.addUserMessage,
@@ -273,26 +274,14 @@ function MainApp() {
 
 	useEffect(() => {
 		if (sessionsQuery.data?.sessions) {
-			// Always attempt DEK unwrap — no-op when no paired secrets exist.
-			// Removing the isEnabled() gate ensures that DEKs are unwrapped
-			// immediately after pairing (when the sessions query re-fires),
-			// and triggers onDekReady to flush any buffered encrypted events.
-			for (const session of sessionsQuery.data.sessions) {
-				if (session.wrappedDek) {
-					e2ee.unwrapSessionDek(session.sessionId, session.wrappedDek);
-				}
-			}
 			chatActions.syncSessions(sessionsQuery.data.sessions);
 
-			// Set E2EE status for all sessions
+			// Bootstrap session DEKs and keep runtime E2EE status in sync.
 			const { setSessionE2EEStatus } = useChatStore.getState();
 			for (const session of sessionsQuery.data.sessions) {
 				setSessionE2EEStatus(
 					session.sessionId,
-					e2ee.getSessionE2EEStatus(
-						session.sessionId,
-						Boolean(session.wrappedDek),
-					),
+					bootstrapSessionE2EE(session.sessionId, session.wrappedDek),
 				);
 			}
 		}

--- a/apps/webui/src/__tests__/app-session-restore.test.tsx
+++ b/apps/webui/src/__tests__/app-session-restore.test.tsx
@@ -302,12 +302,20 @@ const mockE2EE = vi.hoisted(() => ({
 	}),
 	unwrapSessionDek: vi.fn(),
 	unwrapAllSessionDeks: vi.fn(),
-	getSessionE2EEStatus: vi.fn(() => "ready"),
+	getSessionE2EEStatus: vi.fn(
+		(_sessionId: string, _hasWrappedDek: boolean) => "ready",
+	),
 	setPairedSecret: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/e2ee", () => ({
 	e2ee: mockE2EE,
+	bootstrapSessionE2EE: vi.fn((sessionId: string, wrappedDek?: string) => {
+		if (wrappedDek) {
+			mockE2EE.unwrapSessionDek(sessionId, wrappedDek);
+		}
+		return mockE2EE.getSessionE2EEStatus(sessionId, Boolean(wrappedDek));
+	}),
 }));
 
 vi.mock("@/lib/notifications", () => ({

--- a/apps/webui/src/__tests__/e2ee.test.ts
+++ b/apps/webui/src/__tests__/e2ee.test.ts
@@ -60,7 +60,7 @@ function makeEvent(sessionId: string, payload: unknown): SessionEvent {
 	};
 }
 
-const { e2ee } = await import("@/lib/e2ee");
+const { bootstrapSessionE2EE, e2ee } = await import("@/lib/e2ee");
 
 describe("E2EEManager", () => {
 	beforeEach(() => {
@@ -112,6 +112,27 @@ describe("E2EEManager", () => {
 			"wrapped-dek-base64",
 			expect.any(Uint8Array),
 			expect.any(Uint8Array),
+		);
+	});
+
+	it("bootstrapSessionE2EE returns none without wrappedDek", () => {
+		expect(bootstrapSessionE2EE("session-none")).toBe("none");
+		expect(mockUnwrapDEK).not.toHaveBeenCalled();
+	});
+
+	it("bootstrapSessionE2EE returns ok when unwrap succeeds", async () => {
+		await e2ee.addPairedSecret(btoa("test-secret"));
+		expect(bootstrapSessionE2EE("session-ok", "wrapped-dek")).toBe("ok");
+		expect(mockUnwrapDEK).toHaveBeenCalledWith(
+			"wrapped-dek",
+			expect.any(Uint8Array),
+			expect.any(Uint8Array),
+		);
+	});
+
+	it("bootstrapSessionE2EE returns missing_key when unwrap fails", () => {
+		expect(bootstrapSessionE2EE("session-missing", "wrapped-dek")).toBe(
+			"missing_key",
 		);
 	});
 

--- a/apps/webui/src/hooks/__tests__/useSessionMutations.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionMutations.test.tsx
@@ -25,6 +25,12 @@ vi.mock("@/lib/chat-store", async (importOriginal) => {
 	};
 });
 
+const mockBootstrapSessionE2EE = vi.hoisted(() => vi.fn(() => "ok"));
+
+vi.mock("@/lib/e2ee", () => ({
+	bootstrapSessionE2EE: mockBootstrapSessionE2EE,
+}));
+
 // Mock the API module
 vi.mock("@/lib/api", async () => {
 	const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
@@ -84,6 +90,7 @@ describe("useSessionMutations", () => {
 		updateSessionCursor: vi.fn(),
 		setSessionBackfilling: vi.fn(),
 		resetSessionForRevision: vi.fn(),
+		setSessionE2EEStatus: vi.fn(),
 	});
 
 	const wrapper = ({ children }: { children: ReactNode }) => (
@@ -122,6 +129,7 @@ describe("useSessionMutations", () => {
 				availableModels: [],
 				availableCommands: [],
 				machineId: "machine-1",
+				wrappedDek: "wrapped-dek-1",
 			};
 			vi.mocked(apiModule.createSession).mockResolvedValue(mockSession);
 
@@ -163,11 +171,84 @@ describe("useSessionMutations", () => {
 			expect(mockStore.setActiveSessionId).toHaveBeenLastCalledWith(
 				"new-session",
 			);
+			expect(mockBootstrapSessionE2EE).toHaveBeenCalledWith(
+				"new-session",
+				"wrapped-dek-1",
+			);
+			expect(mockStore.setSessionE2EEStatus).toHaveBeenCalledWith(
+				"new-session",
+				"ok",
+			);
 			expect(mockStore.setLastCreatedCwd).toHaveBeenCalledWith(
 				"machine-1",
 				mockSession.cwd,
 			);
 			expect(mockStore.setAppError).toHaveBeenCalledWith(undefined);
+		});
+
+		it("sets missing_key when wrappedDek exists but bootstrap cannot unwrap", async () => {
+			const mockSession: apiModule.CreateSessionResponse = {
+				sessionId: "encrypted-session",
+				title: "Encrypted Session",
+				backendId: "backend-1",
+				backendLabel: "Backend 1",
+				createdAt: "2025-01-01T00:00:00Z",
+				updatedAt: "2025-01-01T00:00:00Z",
+				cwd: "/repo",
+				machineId: "machine-1",
+				wrappedDek: "wrapped-dek-missing",
+			};
+			mockBootstrapSessionE2EE.mockReturnValueOnce("missing_key");
+			vi.mocked(apiModule.createSession).mockResolvedValue(mockSession);
+
+			const { result } = renderHook(() => useSessionMutations(mockStore), {
+				wrapper,
+			});
+
+			await result.current.createSessionMutation.mutateAsync({
+				backendId: "backend-1",
+				machineId: "machine-1",
+				cwd: "/repo",
+			});
+
+			expect(mockStore.setSessionE2EEStatus).toHaveBeenCalledWith(
+				"encrypted-session",
+				"missing_key",
+			);
+		});
+
+		it("sets none when createSession response has no wrappedDek", async () => {
+			const mockSession: apiModule.CreateSessionResponse = {
+				sessionId: "plain-session",
+				title: "Plain Session",
+				backendId: "backend-1",
+				backendLabel: "Backend 1",
+				createdAt: "2025-01-01T00:00:00Z",
+				updatedAt: "2025-01-01T00:00:00Z",
+				cwd: "/repo",
+				machineId: "machine-1",
+			};
+			mockBootstrapSessionE2EE.mockReturnValueOnce("none");
+			vi.mocked(apiModule.createSession).mockResolvedValue(mockSession);
+
+			const { result } = renderHook(() => useSessionMutations(mockStore), {
+				wrapper,
+			});
+
+			await result.current.createSessionMutation.mutateAsync({
+				backendId: "backend-1",
+				machineId: "machine-1",
+				cwd: "/repo",
+			});
+
+			expect(mockBootstrapSessionE2EE).toHaveBeenCalledWith(
+				"plain-session",
+				undefined,
+			);
+			expect(mockStore.setSessionE2EEStatus).toHaveBeenCalledWith(
+				"plain-session",
+				"none",
+			);
 		});
 
 		it("uses the original variables.cwd for lastCreatedCwd on plain subdirectory sessions", async () => {

--- a/apps/webui/src/hooks/__tests__/useSocket.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSocket.test.tsx
@@ -130,11 +130,19 @@ const mockE2EE = vi.hoisted(() => ({
 		};
 	}),
 	unwrapSessionDek: vi.fn(),
-	getSessionE2EEStatus: vi.fn(() => "ready"),
+	getSessionE2EEStatus: vi.fn(
+		(_sessionId: string, _hasWrappedDek: boolean) => "ready",
+	),
 }));
 
 vi.mock("@/lib/e2ee", () => ({
 	e2ee: mockE2EE,
+	bootstrapSessionE2EE: vi.fn((sessionId: string, wrappedDek?: string) => {
+		if (wrappedDek) {
+			mockE2EE.unwrapSessionDek(sessionId, wrappedDek);
+		}
+		return mockE2EE.getSessionE2EEStatus(sessionId, Boolean(wrappedDek));
+	}),
 }));
 
 vi.mock("@/lib/notifications", () => ({

--- a/apps/webui/src/hooks/useSessionMutations.ts
+++ b/apps/webui/src/hooks/useSessionMutations.ts
@@ -30,6 +30,7 @@ import type {
 	StatusVariant,
 } from "@/lib/chat-store";
 import { useChatStore } from "@/lib/chat-store";
+import { bootstrapSessionE2EE } from "@/lib/e2ee";
 import { createFallbackError, normalizeError } from "@/lib/error-utils";
 
 type SessionMetadata = Partial<
@@ -177,6 +178,10 @@ export interface ChatStoreActions {
 		lastAppliedSeq: number,
 	) => void;
 	resetSessionForRevision: (sessionId: string, newRevision: number) => void;
+	setSessionE2EEStatus: (
+		sessionId: string,
+		status: ChatSession["e2eeStatus"],
+	) => void;
 }
 
 const applySessionSummary = (
@@ -255,6 +260,11 @@ export function useSessionMutations(store: ChatStoreActions) {
 				worktreeBranch: data.worktreeBranch,
 				machineId: data.machineId,
 			});
+
+			store.setSessionE2EEStatus(
+				data.sessionId,
+				bootstrapSessionE2EE(data.sessionId, data.wrappedDek),
+			);
 
 			// Switch to real session
 			store.setActiveSessionId(data.sessionId);

--- a/apps/webui/src/hooks/useSocket.ts
+++ b/apps/webui/src/hooks/useSocket.ts
@@ -26,7 +26,7 @@ import {
 	type SessionRestoreSnapshot,
 	useChatStore,
 } from "@/lib/chat-store";
-import { e2ee } from "@/lib/e2ee";
+import { bootstrapSessionE2EE, e2ee } from "@/lib/e2ee";
 import { isErrorDetail } from "@/lib/error-utils";
 import { useMachinesStore } from "@/lib/machines-store";
 import {
@@ -565,25 +565,14 @@ export function useSocket({
 
 	handleSessionsChangedRef.current = (payload: SessionsChangedPayload) => {
 		const addedOrUpdated = [...payload.added, ...payload.updated];
-
-		// Unwrap DEKs from new/updated sessions (always attempt — no-op when
-		// no paired secrets exist; triggers onDekReady to flush buffered events)
-		for (const session of addedOrUpdated) {
-			if (session.wrappedDek) {
-				e2ee.unwrapSessionDek(session.sessionId, session.wrappedDek);
-			}
-		}
 		handleSessionsChanged(payload);
 
-		// Set E2EE status for added/updated sessions
+		// Bootstrap session DEKs and keep runtime E2EE status in sync.
 		const { setSessionE2EEStatus } = useChatStore.getState();
 		for (const session of addedOrUpdated) {
 			setSessionE2EEStatus(
 				session.sessionId,
-				e2ee.getSessionE2EEStatus(
-					session.sessionId,
-					Boolean(session.wrappedDek),
-				),
+				bootstrapSessionE2EE(session.sessionId, session.wrappedDek),
 			);
 		}
 

--- a/apps/webui/src/lib/e2ee.ts
+++ b/apps/webui/src/lib/e2ee.ts
@@ -296,3 +296,14 @@ class E2EEManager {
 }
 
 export const e2ee = new E2EEManager();
+
+export const bootstrapSessionE2EE = (
+	sessionId: string,
+	wrappedDek?: string,
+): E2EEStatus => {
+	if (!wrappedDek) {
+		return "none";
+	}
+	e2ee.unwrapSessionDek(sessionId, wrappedDek);
+	return e2ee.getSessionE2EEStatus(sessionId, true);
+};


### PR DESCRIPTION
## Summary
- centralize session DEK bootstrap in a shared helper and use it when sessions load, change over socket, or are created
- update runtime E2EE status immediately for restored and newly created sessions
- add coverage for `none`, `ok`, and `missing_key` bootstrap paths

## Validation
- `pnpm -C apps/webui test:run -- src/__tests__/app-session-restore.test.tsx src/__tests__/e2ee.test.ts src/hooks/__tests__/useSessionMutations.test.tsx src/hooks/__tests__/useSocket.test.tsx`
- `pnpm format`
- `pnpm lint`
- `pnpm build`