### PR TITLE
fix(webui): close mobile sidebar before opening dialogs

### DIFF
--- a/apps/webui/src/components/app/AppSidebar.tsx
+++ b/apps/webui/src/components/app/AppSidebar.tsx
@@ -1,10 +1,20 @@
 import { AddCircleIcon, Refresh01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { memo, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RegisterMachineDialog } from "@/components/machines/RegisterMachineDialog";
 import { SessionSidebar } from "@/components/session/SessionSidebar";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { ResizeHandle } from "@/components/ui/ResizeHandle";
 import {
@@ -34,6 +44,17 @@ export type AppSidebarProps = {
 	mutations: SessionMutationsSnapshot;
 };
 
+type ArchiveTarget =
+	| {
+			type: "single";
+			sessionId: string;
+	  }
+	| {
+			type: "bulk";
+			sessionIds: string[];
+	  }
+	| null;
+
 export const AppSidebar = memo(function AppSidebar({
 	sessions,
 	activeSessionId,
@@ -53,8 +74,89 @@ export const AppSidebar = memo(function AppSidebar({
 		sessionSidebarWidth,
 		setSessionSidebarWidth,
 	} = useUiStore();
+	const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
+	const [archiveTarget, setArchiveTarget] = useState<ArchiveTarget>(null);
+
+	const handleCreateSessionRequest = useCallback(
+		(mode: "workspace" | "session") => {
+			setMobileMenuOpen(false);
+			onCreateSession(mode);
+		},
+		[onCreateSession, setMobileMenuOpen],
+	);
+
+	const handleArchiveSessionRequest = useCallback(
+		(sessionId: string) => {
+			setMobileMenuOpen(false);
+			setArchiveTarget({ type: "single", sessionId });
+		},
+		[setMobileMenuOpen],
+	);
+
+	const handleArchiveAllSessionsRequest = useCallback(
+		(sessionIds: string[]) => {
+			setMobileMenuOpen(false);
+			setArchiveTarget({ type: "bulk", sessionIds });
+		},
+		[setMobileMenuOpen],
+	);
+
+	const handleArchiveConfirm = useCallback(() => {
+		if (!archiveTarget) {
+			return;
+		}
+		if (archiveTarget.type === "single") {
+			onArchiveSession(archiveTarget.sessionId);
+		} else {
+			onArchiveAllSessions(archiveTarget.sessionIds);
+		}
+		setArchiveTarget(null);
+	}, [archiveTarget, onArchiveAllSessions, onArchiveSession]);
+
+	const handleOpenRegisterMachineDialog = useCallback(() => {
+		setMobileMenuOpen(false);
+		setRegisterDialogOpen(true);
+	}, [setMobileMenuOpen]);
+
 	return (
 		<>
+			<RegisterMachineDialog
+				open={registerDialogOpen}
+				onOpenChange={setRegisterDialogOpen}
+			/>
+			<AlertDialog
+				open={archiveTarget !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setArchiveTarget(null);
+					}
+				}}
+			>
+				<AlertDialogContent size="sm">
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							{archiveTarget?.type === "bulk"
+								? t("session.archiveAllTitle")
+								: t("session.archiveTitle")}
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							{archiveTarget?.type === "bulk"
+								? t("session.archiveAllDescription", {
+										count: archiveTarget.sessionIds.length,
+									})
+								: t("session.archiveDescription")}
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+						<AlertDialogAction onClick={handleArchiveConfirm}>
+							{archiveTarget?.type === "bulk"
+								? t("session.archiveAllConfirm")
+								: t("session.archiveConfirm")}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 			<aside
 				className="bg-background/80 border-r hidden flex-col px-4 py-4 md:flex min-h-0 overflow-hidden"
 				style={{ width: sessionSidebarWidth }}
@@ -62,11 +164,11 @@ export const AppSidebar = memo(function AppSidebar({
 				<SessionSidebar
 					sessions={sessions}
 					activeSessionId={activeSessionId}
-					onCreateSession={onCreateSession}
+					onCreateSession={handleCreateSessionRequest}
 					onSelectSession={onSelectSession}
 					onEditSubmit={onEditSubmit}
-					onArchiveSession={onArchiveSession}
-					onArchiveAllSessions={onArchiveAllSessions}
+					onArchiveSessionRequest={handleArchiveSessionRequest}
+					onArchiveAllSessionsRequest={handleArchiveAllSessionsRequest}
 					isBulkArchiving={isBulkArchiving}
 					isCreating={isCreating}
 					mutations={mutations}
@@ -81,19 +183,21 @@ export const AppSidebar = memo(function AppSidebar({
 			{mobileMenuOpen ? (
 				<div className="fixed inset-0 z-[60] flex md:hidden pt-[env(safe-area-inset-top)]">
 					<div className="bg-background/90 border-r w-80 p-0 flex h-full overflow-hidden">
-						<MobileMachineColumn />
+						<MobileMachineColumn
+							onAddMachine={handleOpenRegisterMachineDialog}
+						/>
 						<div className="flex-1 p-4 overflow-hidden flex flex-col min-w-0">
 							<SessionSidebar
 								sessions={sessions}
 								activeSessionId={activeSessionId}
-								onCreateSession={onCreateSession}
+								onCreateSession={handleCreateSessionRequest}
 								onSelectSession={(sessionId) => {
 									onSelectSession(sessionId);
 									setMobileMenuOpen(false);
 								}}
 								onEditSubmit={onEditSubmit}
-								onArchiveSession={onArchiveSession}
-								onArchiveAllSessions={onArchiveAllSessions}
+								onArchiveSessionRequest={handleArchiveSessionRequest}
+								onArchiveAllSessionsRequest={handleArchiveAllSessionsRequest}
 								isBulkArchiving={isBulkArchiving}
 								isCreating={isCreating}
 								mutations={mutations}
@@ -112,7 +216,7 @@ export const AppSidebar = memo(function AppSidebar({
 	);
 });
 
-function MobileMachineColumn() {
+function MobileMachineColumn({ onAddMachine }: { onAddMachine: () => void }) {
 	const { t } = useTranslation();
 	const {
 		machines,
@@ -123,7 +227,6 @@ function MobileMachineColumn() {
 	const machinesQuery = useMachinesQuery();
 	const queryClient = useQueryClient();
 	const discoverSessionsMutation = useDiscoverSessionsMutation();
-	const [registerDialogOpen, setRegisterDialogOpen] = useState(false);
 	const { selectedWorkspaceByMachine } = useUiStore();
 
 	const machineList = Object.values(machines).sort((a, b) => {
@@ -158,10 +261,6 @@ function MobileMachineColumn() {
 
 	return (
 		<TooltipProvider delayDuration={300}>
-			<RegisterMachineDialog
-				open={registerDialogOpen}
-				onOpenChange={setRegisterDialogOpen}
-			/>
 			<div className="w-14 flex-shrink-0 flex flex-col items-center gap-2 py-3 border-r bg-background/50">
 				<div className="flex flex-col items-center gap-1 text-xs font-semibold text-muted-foreground mb-1">
 					<span>{t("machines.title")}</span>
@@ -208,7 +307,7 @@ function MobileMachineColumn() {
 						<Button
 							variant="ghost"
 							size="icon-sm"
-							onClick={() => setRegisterDialogOpen(true)}
+							onClick={onAddMachine}
 							className="mt-auto"
 							aria-label={t("machines.register")}
 						>

--- a/apps/webui/src/components/app/__tests__/AppSidebar.test.tsx
+++ b/apps/webui/src/components/app/__tests__/AppSidebar.test.tsx
@@ -1,0 +1,252 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useMachinesStore } from "@/lib/machines-store";
+import { useUiStore } from "@/lib/ui-store";
+import { AppSidebar } from "../AppSidebar";
+
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string, options?: Record<string, number>) => {
+			const translations: Record<string, string> = {
+				"common.closeMenu": "Close menu",
+				"common.cancel": "Cancel",
+				"machines.title": "Machines",
+				"machines.refresh": "Refresh",
+				"machines.register": "Register Machine",
+				"machines.empty": "No machines",
+				"session.archiveTitle": "Archive session",
+				"session.archiveDescription": "Archive this session",
+				"session.archiveConfirm": "Confirm archive",
+				"session.archiveAllTitle": "Archive all sessions",
+				"session.archiveAllDescription": `Archive ${options?.count ?? 0} sessions`,
+				"session.archiveAllConfirm": "Confirm archive all",
+			};
+			return translations[key] ?? key;
+		},
+	}),
+}));
+
+vi.mock("@hugeicons/react", () => ({
+	HugeiconsIcon: () => <span data-testid="icon" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+	Button: ({
+		children,
+		onClick,
+		...props
+	}: {
+		children: ReactNode;
+		onClick?: () => void;
+		[key: string]: unknown;
+	}) => (
+		<button type="button" onClick={onClick} {...props}>
+			{children}
+		</button>
+	),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+	Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+	TooltipTrigger: ({
+		children,
+	}: {
+		children: ReactNode;
+		asChild?: boolean;
+	}) => <>{children}</>,
+	TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+	TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/ResizeHandle", () => ({
+	ResizeHandle: () => null,
+}));
+
+vi.mock("@/components/machines/RegisterMachineDialog", () => ({
+	RegisterMachineDialog: ({
+		open,
+	}: {
+		open: boolean;
+		onOpenChange: (open: boolean) => void;
+	}) =>
+		open ? (
+			<div data-testid="register-machine-dialog">Register dialog</div>
+		) : null,
+}));
+
+vi.mock("@/components/session/SessionSidebar", () => ({
+	SessionSidebar: ({
+		onCreateSession,
+		onArchiveSessionRequest,
+		onArchiveAllSessionsRequest,
+	}: {
+		onCreateSession: (mode: "workspace" | "session") => void;
+		onArchiveSessionRequest: (sessionId: string) => void;
+		onArchiveAllSessionsRequest: (sessionIds: string[]) => void;
+	}) => (
+		<div>
+			<button type="button" onClick={() => onCreateSession("session")}>
+				New Session
+			</button>
+			<button
+				type="button"
+				onClick={() => onArchiveSessionRequest("session-1")}
+			>
+				Archive One
+			</button>
+			<button
+				type="button"
+				onClick={() => onArchiveAllSessionsRequest(["session-1", "session-2"])}
+			>
+				Archive All
+			</button>
+		</div>
+	),
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+	AlertDialog: ({
+		children,
+		open,
+	}: {
+		children: ReactNode;
+		open?: boolean;
+		onOpenChange?: (open: boolean) => void;
+	}) => (open ? <div data-testid="archive-dialog">{children}</div> : null),
+	AlertDialogContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	AlertDialogFooter: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	AlertDialogAction: ({
+		children,
+		onClick,
+	}: {
+		children: ReactNode;
+		onClick?: () => void;
+	}) => (
+		<button type="button" onClick={onClick}>
+			{children}
+		</button>
+	),
+	AlertDialogCancel: ({ children }: { children: ReactNode }) => (
+		<button type="button">{children}</button>
+	),
+}));
+
+vi.mock("@/hooks/useMachinesQuery", () => ({
+	useMachinesQuery: () => ({
+		refetch: vi.fn().mockResolvedValue({ data: { machines: [] } }),
+	}),
+}));
+
+vi.mock("@/hooks/useSessionQueries", () => ({
+	useDiscoverSessionsMutation: () => ({
+		mutateAsync: vi.fn().mockResolvedValue({ backendCapabilities: {} }),
+	}),
+}));
+
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: { retry: false },
+	},
+});
+
+const renderSidebar = (
+	props?: Partial<React.ComponentProps<typeof AppSidebar>>,
+) =>
+	render(
+		<QueryClientProvider client={queryClient}>
+			<AppSidebar
+				sessions={[]}
+				activeSessionId={undefined}
+				onCreateSession={props?.onCreateSession ?? vi.fn()}
+				onSelectSession={props?.onSelectSession ?? vi.fn()}
+				onEditSubmit={props?.onEditSubmit ?? vi.fn()}
+				onArchiveSession={props?.onArchiveSession ?? vi.fn()}
+				onArchiveAllSessions={props?.onArchiveAllSessions ?? vi.fn()}
+				isBulkArchiving={props?.isBulkArchiving ?? false}
+				isCreating={props?.isCreating ?? false}
+				mutations={
+					props?.mutations ?? {
+						loadSessionPending: false,
+						loadSessionVariables: undefined,
+						reloadSessionPending: false,
+						reloadSessionVariables: undefined,
+					}
+				}
+			/>
+		</QueryClientProvider>,
+	);
+
+describe("AppSidebar mobile modal flow", () => {
+	beforeEach(() => {
+		useUiStore.setState({
+			mobileMenuOpen: true,
+			sessionSidebarWidth: 256,
+			selectedWorkspaceByMachine: {},
+		});
+		useMachinesStore.setState({
+			machines: {
+				"machine-1": {
+					machineId: "machine-1",
+					hostname: "dev-box",
+					connected: true,
+				},
+			},
+			selectedMachineId: "machine-1",
+		});
+	});
+
+	it("closes the mobile menu when opening create session", async () => {
+		const onCreateSession = vi.fn();
+		const user = userEvent.setup();
+		renderSidebar({ onCreateSession });
+
+		await user.click(screen.getAllByText("New Session")[0]!);
+
+		expect(onCreateSession).toHaveBeenCalledWith("session");
+		expect(useUiStore.getState().mobileMenuOpen).toBe(false);
+		expect(
+			screen.queryByRole("button", { name: "Close menu" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("keeps the register-machine dialog mounted after closing the mobile menu", async () => {
+		const user = userEvent.setup();
+		renderSidebar();
+
+		await user.click(screen.getByRole("button", { name: "Register Machine" }));
+
+		expect(useUiStore.getState().mobileMenuOpen).toBe(false);
+		expect(screen.getByTestId("register-machine-dialog")).toBeInTheDocument();
+	});
+
+	it("keeps archive confirmation open after closing the mobile menu", async () => {
+		const onArchiveSession = vi.fn();
+		const user = userEvent.setup();
+		renderSidebar({ onArchiveSession });
+
+		await user.click(screen.getAllByText("Archive One")[0]!);
+
+		expect(useUiStore.getState().mobileMenuOpen).toBe(false);
+		expect(screen.getByTestId("archive-dialog")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: "Confirm archive" }));
+
+		expect(onArchiveSession).toHaveBeenCalledWith("session-1");
+	});
+});

--- a/apps/webui/src/components/session/SessionSidebar.tsx
+++ b/apps/webui/src/components/session/SessionSidebar.tsx
@@ -6,18 +6,8 @@ import {
 	MoreHorizontalIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -78,8 +68,8 @@ type SessionSidebarProps = {
 	onCreateSession: (mode: "workspace" | "session") => void;
 	onSelectSession: (sessionId: string) => void;
 	onEditSubmit: () => void;
-	onArchiveSession: (sessionId: string) => void;
-	onArchiveAllSessions: (sessionIds: string[]) => void;
+	onArchiveSessionRequest: (sessionId: string) => void;
+	onArchiveAllSessionsRequest: (sessionIds: string[]) => void;
 	isBulkArchiving?: boolean;
 	isCreating: boolean;
 	mutations: SessionMutationsSnapshot;
@@ -91,8 +81,8 @@ export const SessionSidebar = ({
 	onCreateSession,
 	onSelectSession,
 	onEditSubmit,
-	onArchiveSession,
-	onArchiveAllSessions,
+	onArchiveSessionRequest,
+	onArchiveAllSessionsRequest,
 	isBulkArchiving,
 	isCreating,
 	mutations,
@@ -112,29 +102,6 @@ export const SessionSidebar = ({
 		selectedWorkspaceByMachine,
 	} = useUiStore();
 	const { selectedMachineId } = useMachinesStore();
-
-	// Shared archive confirmation dialog state
-	const [archiveTarget, setArchiveTarget] = useState<
-		| {
-				type: "single";
-				sessionId: string;
-		  }
-		| {
-				type: "bulk";
-				sessionIds: string[];
-		  }
-		| null
-	>(null);
-
-	const handleArchiveConfirm = useCallback(() => {
-		if (!archiveTarget) return;
-		if (archiveTarget.type === "single") {
-			onArchiveSession(archiveTarget.sessionId);
-		} else {
-			onArchiveAllSessions(archiveTarget.sessionIds);
-		}
-		setArchiveTarget(null);
-	}, [archiveTarget, onArchiveSession, onArchiveAllSessions]);
 
 	// Current workspace label for header display
 	const currentWorkspace = useMemo(() => {
@@ -248,7 +215,10 @@ export const SessionSidebar = ({
 				{sidebarTab === "workspaces" ? (
 					<div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overscroll-contain">
 						{selectedMachineId ? (
-							<WorkspaceList machineId={selectedMachineId} />
+							<WorkspaceList
+								machineId={selectedMachineId}
+								onEmptyCreateSession={() => onCreateSession("workspace")}
+							/>
 						) : (
 							<div className="text-muted-foreground text-xs">
 								{t("workspace.empty")}
@@ -312,12 +282,9 @@ export const SessionSidebar = ({
 													className="text-muted-foreground h-5 px-1.5 text-[10px]"
 													disabled={isBulkArchiving}
 													onClick={() =>
-														setArchiveTarget({
-															type: "bulk",
-															sessionIds: group.sessions.map(
-																(s) => s.sessionId,
-															),
-														})
+														onArchiveAllSessionsRequest(
+															group.sessions.map((s) => s.sessionId),
+														)
 													}
 												>
 													{t("session.archiveAll")}
@@ -348,10 +315,7 @@ export const SessionSidebar = ({
 														onEditSubmit={onEditSubmit}
 														onEditingTitleChange={setEditingTitle}
 														onArchive={() =>
-															setArchiveTarget({
-																type: "single",
-																sessionId: session.sessionId,
-															})
+															onArchiveSessionRequest(session.sessionId)
 														}
 													/>
 												))}
@@ -363,39 +327,6 @@ export const SessionSidebar = ({
 						</div>
 					</>
 				) : null}
-
-				{/* Shared archive confirmation dialog */}
-				<AlertDialog
-					open={archiveTarget !== null}
-					onOpenChange={(open) => {
-						if (!open) setArchiveTarget(null);
-					}}
-				>
-					<AlertDialogContent size="sm">
-						<AlertDialogHeader>
-							<AlertDialogTitle>
-								{archiveTarget?.type === "bulk"
-									? t("session.archiveAllTitle")
-									: t("session.archiveTitle")}
-							</AlertDialogTitle>
-							<AlertDialogDescription>
-								{archiveTarget?.type === "bulk"
-									? t("session.archiveAllDescription", {
-											count: archiveTarget.sessionIds.length,
-										})
-									: t("session.archiveDescription")}
-							</AlertDialogDescription>
-						</AlertDialogHeader>
-						<AlertDialogFooter>
-							<AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-							<AlertDialogAction onClick={handleArchiveConfirm}>
-								{archiveTarget?.type === "bulk"
-									? t("session.archiveAllConfirm")
-									: t("session.archiveConfirm")}
-							</AlertDialogAction>
-						</AlertDialogFooter>
-					</AlertDialogContent>
-				</AlertDialog>
 			</div>
 		</TooltipProvider>
 	);
@@ -467,7 +398,8 @@ const SessionListItem = ({
 							"mt-1.5 h-2 w-2 shrink-0 rounded-full",
 							statusDotClass[displayStatus],
 						)}
-						aria-label={statusTooltip ?? undefined}
+						aria-hidden="true"
+						title={statusTooltip ?? undefined}
 					/>
 				</TooltipTrigger>
 				{statusTooltip ? (

--- a/apps/webui/src/components/workspace/WorkspaceList.tsx
+++ b/apps/webui/src/components/workspace/WorkspaceList.tsx
@@ -11,19 +11,19 @@ import { collectWorkspaces } from "@/lib/workspace-utils";
 
 type WorkspaceListProps = {
 	machineId: string;
+	onEmptyCreateSession: () => void;
 };
 
-export function WorkspaceList({ machineId }: WorkspaceListProps) {
+export function WorkspaceList({
+	machineId,
+	onEmptyCreateSession,
+}: WorkspaceListProps) {
 	const { t } = useTranslation();
 	const { sessions } = useChatStore();
 	const { machines, setSelectedMachineId, updateBackendCapabilities } =
 		useMachinesStore();
-	const {
-		selectedWorkspaceByMachine,
-		setSelectedWorkspace,
-		setCreateDialogOpen,
-		setSidebarTab,
-	} = useUiStore();
+	const { selectedWorkspaceByMachine, setSelectedWorkspace, setSidebarTab } =
+		useUiStore();
 	const discoverSessionsMutation = useDiscoverSessionsMutation();
 
 	const workspaceList = useMemo(
@@ -113,7 +113,7 @@ export function WorkspaceList({ machineId }: WorkspaceListProps) {
 
 	const handleEmptyClick = () => {
 		setSelectedMachineId(machineId);
-		setCreateDialogOpen(true);
+		onEmptyCreateSession();
 	};
 
 	if (isValidating && validWorkspaces.length === 0) {

--- a/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
@@ -183,6 +183,15 @@ describe("useSessionHandlers — handleOpenCreateDialog", () => {
 		expect(uiActions.setDraftCwd).toHaveBeenCalledWith("/projects/foo");
 	});
 
+	it("closes the mobile menu before opening the create dialog", () => {
+		const { result } = renderHandlers();
+
+		result.current.handleOpenCreateDialog();
+
+		expect(uiActions.setMobileMenuOpen).toHaveBeenCalledWith(false);
+		expect(uiActions.setCreateDialogOpen).toHaveBeenCalledWith(true);
+	});
+
 	it("falls back to active session cwd when on same machine", () => {
 		const activeSession = createBaseSession({
 			machineId: "machine-1",

--- a/apps/webui/src/hooks/useSessionHandlers.ts
+++ b/apps/webui/src/hooks/useSessionHandlers.ts
@@ -167,6 +167,7 @@ export function useSessionHandlers({
 
 		uiActions.setDraftCwd(initialCwd);
 		uiActions.resetDraftWorktree();
+		uiActions.setMobileMenuOpen(false);
 		uiActions.setCreateDialogOpen(true);
 	};
 

--- a/apps/webui/tests/machine-workspaces.test.tsx
+++ b/apps/webui/tests/machine-workspaces.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/lib/chat-store";
@@ -9,9 +10,8 @@ import { useMachinesStore } from "../src/lib/machines-store";
 import { useUiStore } from "../src/lib/ui-store";
 
 // Mock the API module so useQueries calls resolve/reject as we control
-vi.mock("../src/lib/api", async () => {
-	const actual =
-		await vi.importActual<typeof import("../src/lib/api")>("../src/lib/api");
+vi.mock("@/lib/api", async () => {
+	const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
 	return {
 		...actual,
 		fetchFsEntries: vi.fn(),
@@ -23,7 +23,7 @@ vi.mock("../src/hooks/useSessionQueries", () => ({
 	useDiscoverSessionsMutation: () => ({ mutate: vi.fn() }),
 }));
 
-import { fetchFsEntries } from "../src/lib/api";
+import { fetchFsEntries } from "@/lib/api";
 
 const MACHINE_ID = "machine-1";
 
@@ -49,6 +49,7 @@ const buildSession = (
 });
 
 let queryClient: QueryClient;
+let onEmptyCreateSession: ReturnType<typeof vi.fn>;
 
 const Wrapper = ({ children }: { children: ReactNode }) => (
 	<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -60,6 +61,7 @@ beforeEach(() => {
 			queries: { retry: false },
 		},
 	});
+	onEmptyCreateSession = vi.fn();
 
 	// Set up machine as connected
 	useMachinesStore.setState({
@@ -125,7 +127,10 @@ describe("WorkspaceList validation effect", () => {
 
 		render(
 			<Wrapper>
-				<WorkspaceList machineId={MACHINE_ID} />
+				<WorkspaceList
+					machineId={MACHINE_ID}
+					onEmptyCreateSession={onEmptyCreateSession}
+				/>
 			</Wrapper>,
 		);
 
@@ -157,7 +162,10 @@ describe("WorkspaceList validation effect", () => {
 
 		render(
 			<Wrapper>
-				<WorkspaceList machineId={MACHINE_ID} />
+				<WorkspaceList
+					machineId={MACHINE_ID}
+					onEmptyCreateSession={onEmptyCreateSession}
+				/>
 			</Wrapper>,
 		);
 
@@ -189,7 +197,10 @@ describe("WorkspaceList validation effect", () => {
 
 		render(
 			<Wrapper>
-				<WorkspaceList machineId={MACHINE_ID} />
+				<WorkspaceList
+					machineId={MACHINE_ID}
+					onEmptyCreateSession={onEmptyCreateSession}
+				/>
 			</Wrapper>,
 		);
 
@@ -209,7 +220,10 @@ describe("WorkspaceList validation effect", () => {
 
 		const { container } = render(
 			<Wrapper>
-				<WorkspaceList machineId={MACHINE_ID} />
+				<WorkspaceList
+					machineId={MACHINE_ID}
+					onEmptyCreateSession={onEmptyCreateSession}
+				/>
 			</Wrapper>,
 		);
 
@@ -237,7 +251,10 @@ describe("WorkspaceList validation effect", () => {
 
 		render(
 			<Wrapper>
-				<WorkspaceList machineId={MACHINE_ID} />
+				<WorkspaceList
+					machineId={MACHINE_ID}
+					onEmptyCreateSession={onEmptyCreateSession}
+				/>
 			</Wrapper>,
 		);
 
@@ -247,5 +264,24 @@ describe("WorkspaceList validation effect", () => {
 			const state = useUiStore.getState();
 			expect(state.selectedWorkspaceByMachine[MACHINE_ID]).toBe(cwdA);
 		});
+	});
+
+	it("routes empty-state create actions through the callback", async () => {
+		useChatStore.setState({ sessions: {} });
+		const user = userEvent.setup();
+
+		render(
+			<Wrapper>
+				<WorkspaceList
+					machineId={MACHINE_ID}
+					onEmptyCreateSession={onEmptyCreateSession}
+				/>
+			</Wrapper>,
+		);
+
+		await user.click(document.querySelector("button")!);
+
+		expect(onEmptyCreateSession).toHaveBeenCalledTimes(1);
+		expect(useMachinesStore.getState().selectedMachineId).toBe(MACHINE_ID);
 	});
 });

--- a/apps/webui/tests/session-sidebar.test.tsx
+++ b/apps/webui/tests/session-sidebar.test.tsx
@@ -18,46 +18,6 @@ const defaultMutations: SessionMutationsSnapshot = {
 
 // --- mocks ---
 
-vi.mock("../src/components/ui/alert-dialog", () => ({
-	AlertDialog: ({
-		children,
-		open,
-	}: {
-		children: React.ReactNode;
-		open?: boolean;
-		onOpenChange?: (v: boolean) => void;
-	}) => (open ? <div>{children}</div> : null),
-	AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogHeader: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogTitle: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogFooter: ({ children }: { children: React.ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogAction: ({
-		children,
-		...props
-	}: {
-		children: React.ReactNode;
-		[key: string]: unknown;
-	}) => <button {...props}>{children}</button>,
-	AlertDialogCancel: ({
-		children,
-		...props
-	}: {
-		children: React.ReactNode;
-		[key: string]: unknown;
-	}) => <button {...props}>{children}</button>,
-}));
-
 vi.mock("../src/components/ui/dropdown-menu", () => ({
 	DropdownMenu: ({ children }: { children: React.ReactNode }) => (
 		<div>{children}</div>
@@ -137,8 +97,12 @@ const renderSidebar = (
 					onCreateSession={options?.onCreateSession ?? (() => {})}
 					onSelectSession={options?.onSelectSession ?? (() => {})}
 					onEditSubmit={options?.onEditSubmit ?? (() => {})}
-					onArchiveSession={options?.onArchiveSession ?? (() => {})}
-					onArchiveAllSessions={options?.onArchiveAllSessions ?? (() => {})}
+					onArchiveSessionRequest={
+						options?.onArchiveSessionRequest ?? (() => {})
+					}
+					onArchiveAllSessionsRequest={
+						options?.onArchiveAllSessionsRequest ?? (() => {})
+					}
 					isBulkArchiving={options?.isBulkArchiving ?? false}
 					isCreating={options?.isCreating ?? false}
 					mutations={options?.mutations ?? defaultMutations}
@@ -474,8 +438,8 @@ describe("SessionSidebar", () => {
 			).toBeInTheDocument();
 		});
 
-		it("opens confirm dialog and calls onArchiveAllSessions on confirm", async () => {
-			const onArchiveAllSessions = vi.fn();
+		it("emits archive-all intent immediately", async () => {
+			const onArchiveAllSessionsRequest = vi.fn();
 			const user = userEvent.setup();
 			renderSidebar(
 				[
@@ -492,15 +456,12 @@ describe("SessionSidebar", () => {
 						backendLabel: "Backend",
 					}),
 				],
-				{ onArchiveAllSessions },
+				{ onArchiveAllSessionsRequest },
 			);
 
-			// Click Archive All to open dialog
 			await user.click(screen.getByText(i18n.t("session.archiveAll")));
-			// Dialog should now be open — click confirm
-			await user.click(screen.getByText(i18n.t("session.archiveAllConfirm")));
 
-			expect(onArchiveAllSessions).toHaveBeenCalledWith(["s1", "s2"]);
+			expect(onArchiveAllSessionsRequest).toHaveBeenCalledWith(["s1", "s2"]);
 		});
 
 		it("is disabled when isBulkArchiving is true", () => {
@@ -529,19 +490,16 @@ describe("SessionSidebar", () => {
 	});
 
 	describe("Archive single session", () => {
-		it("opens confirm dialog via dropdown and calls onArchiveSession", async () => {
-			const onArchiveSession = vi.fn();
+		it("emits archive intent via dropdown", async () => {
+			const onArchiveSessionRequest = vi.fn();
 			const user = userEvent.setup();
 			renderSidebar([buildSession({ sessionId: "s1", title: "My Session" })], {
-				onArchiveSession,
+				onArchiveSessionRequest,
 			});
 
-			// Click archive in dropdown
 			await user.click(screen.getByText(i18n.t("common.archive")));
-			// Dialog should be open — click confirm
-			await user.click(screen.getByText(i18n.t("session.archiveConfirm")));
 
-			expect(onArchiveSession).toHaveBeenCalledWith("s1");
+			expect(onArchiveSessionRequest).toHaveBeenCalledWith("s1");
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- close the mobile sidebar before opening new-session and sidebar-triggered dialogs
- hoist mobile archive/register dialogs out of the sidebar overlay so they stay mounted after the sidebar closes
- route workspace empty-state creation through the shared create-session flow and add mobile regression tests

## Testing
- pnpm -C packages/shared build
- pnpm -C apps/webui exec vitest run ./src/components/app/__tests__/AppSidebar.test.tsx ./tests/session-sidebar.test.tsx ./tests/machine-workspaces.test.tsx ./src/hooks/__tests__/useSessionHandlers.test.tsx
- pnpm -C apps/webui lint
- pnpm -C apps/webui build
- pnpm build