### PR TITLE
Auto-name new worktrees by default

### DIFF
--- a/apps/gateway/src/routes/sessions.ts
+++ b/apps/gateway/src/routes/sessions.ts
@@ -137,12 +137,14 @@ export function setupSessionRoutes(
 			const worktreeOptions =
 				worktree &&
 				typeof worktree === "object" &&
-				typeof worktree.branch === "string" &&
-				worktree.branch.trim().length > 0 &&
 				typeof worktree.sourceCwd === "string" &&
 				worktree.sourceCwd.trim().length > 0
 					? {
-							branch: worktree.branch.trim(),
+							branch:
+								typeof worktree.branch === "string" &&
+								worktree.branch.trim().length > 0
+									? worktree.branch.trim()
+									: undefined,
 							baseBranch:
 								typeof worktree.baseBranch === "string" &&
 								worktree.baseBranch.trim().length > 0

--- a/apps/mobvibe-cli/src/acp/__tests__/session-manager.test.ts
+++ b/apps/mobvibe-cli/src/acp/__tests__/session-manager.test.ts
@@ -23,11 +23,15 @@ mock.module("../../lib/logger.js", () => ({
 }));
 
 const mockIsGitRepo = mock(() => Promise.resolve(true));
-const mockCreateGitWorktree = mock(() =>
-	Promise.resolve({
-		path: "/tmp/mobvibe-test/worktrees/project/feat-branch",
-		branch: "feat-branch",
-	}),
+const mockCreateGitWorktree = mock(
+	(
+		_cwd: string,
+		opts: { branch: string; targetPath: string; baseBranch?: string },
+	) =>
+		Promise.resolve({
+			path: opts.targetPath,
+			branch: opts.branch,
+		}),
 );
 const mockResolveGitProjectContext = mock((cwd: string) =>
 	Promise.resolve({
@@ -374,6 +378,40 @@ describe("SessionManager", () => {
 			expect(created.workspaceRootCwd).toBe("/home/user/project");
 			expect(created.worktreeSourceCwd).toBe("/home/user/project");
 			expect(created.worktreeBranch).toBe("feat-branch");
+		});
+
+		it("generates a default branch name when a worktree branch is omitted", async () => {
+			mockCreateGitWorktree.mockImplementationOnce((_cwd, opts) =>
+				Promise.resolve({
+					path: opts.targetPath,
+					branch: opts.branch,
+				}),
+			);
+
+			const created = await sessionManager.createSession({
+				cwd: "/home/user/project/apps/webui",
+				backendId: "backend-1",
+				worktree: {
+					sourceCwd: "/home/user/project",
+					relativeCwd: "apps/webui",
+				},
+			});
+
+			expect(mockCreateGitWorktree).toHaveBeenCalledTimes(1);
+			const worktreeOptions = mockCreateGitWorktree.mock.calls[0]?.[1] as
+				| { branch: string; targetPath: string; baseBranch?: string }
+				| undefined;
+			expect(worktreeOptions).toBeDefined();
+			if (!worktreeOptions) {
+				throw new Error("Expected createGitWorktree to be called");
+			}
+			expect(worktreeOptions.branch).toMatch(/^[a-z]+-[a-z]+-[a-z0-9]{2}$/);
+			expect(worktreeOptions.targetPath).toBe(
+				`/tmp/mobvibe-test/worktrees/project/${worktreeOptions.branch}`,
+			);
+			expect(created.cwd).toBe(`${worktreeOptions.targetPath}/apps/webui`);
+			expect(created.worktreeBranch).toBe(worktreeOptions.branch);
+			expect(created.worktreeSourceCwd).toBe("/home/user/project");
 		});
 
 		it("rejects worktree relative paths that escape the worktree root", async () => {

--- a/apps/mobvibe-cli/src/acp/session-manager.ts
+++ b/apps/mobvibe-cli/src/acp/session-manager.ts
@@ -19,6 +19,7 @@ import {
 	type DiscoverSessionsRpcResult,
 	type PermissionDecisionPayload,
 	type PermissionRequestPayload,
+	resolveWorktreeBranchName,
 	type SessionEvent,
 	type SessionEventKind,
 	type SessionEventsParams,
@@ -26,6 +27,7 @@ import {
 	type SessionSummary,
 	type SessionsChangedPayload,
 	type StopReason,
+	sanitizeWorktreeBranchForPath,
 } from "@mobvibe/shared";
 import type { AcpBackendConfig, CliConfig } from "../config.js";
 import type { CliCryptoService } from "../e2ee/crypto-service.js";
@@ -790,7 +792,8 @@ export class SessionManager {
 				);
 			}
 
-			const sanitizedBranch = options.worktree.branch.replace(/[/\\]/g, "-");
+			const branch = resolveWorktreeBranchName(options.worktree.branch);
+			const sanitizedBranch = sanitizeWorktreeBranchForPath(branch);
 			const repoName = path.basename(repoDir);
 			const targetPath = path.join(
 				this.config.worktreeBaseDir,
@@ -801,7 +804,7 @@ export class SessionManager {
 			logger.info(
 				{
 					repoDir,
-					branch: options.worktree.branch,
+					branch,
 					baseBranch: options.worktree.baseBranch,
 					targetPath,
 				},
@@ -810,7 +813,7 @@ export class SessionManager {
 
 			try {
 				const result = await createGitWorktree(repoDir, {
-					branch: options.worktree.branch,
+					branch,
 					targetPath,
 					baseBranch: options.worktree.baseBranch,
 				});
@@ -835,7 +838,7 @@ export class SessionManager {
 			}
 
 			worktreeSourceCwd = repoDir;
-			worktreeBranch = options.worktree.branch;
+			worktreeBranch = branch;
 			workspaceRootCwd = repoDir;
 		} else if (options.cwd) {
 			const projectContext = await resolveGitProjectContext(options.cwd);

--- a/apps/webui/src/components/app/CreateSessionDialog.tsx
+++ b/apps/webui/src/components/app/CreateSessionDialog.tsx
@@ -1,5 +1,9 @@
 import { ComputerIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	generateDefaultWorktreeBranchName,
+	sanitizeWorktreeBranchForPath,
+} from "@mobvibe/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -49,8 +53,6 @@ export type CreateSessionDialogProps = {
 	onCreate: () => void;
 };
 
-/** Sanitize branch name for worktree path preview */
-const sanitizeBranch = (branch: string) => branch.replace(/[/\\]/g, "-");
 const getBranchOptionLabel = (branch: {
 	name: string;
 	displayName?: string;
@@ -66,18 +68,22 @@ export function CreateSessionDialog({
 }: CreateSessionDialogProps) {
 	const { t } = useTranslation();
 	const [directoryDialogOpen, setDirectoryDialogOpen] = useState(false);
+	const [hasUserEditedWorktreeBranch, setHasUserEditedWorktreeBranch] =
+		useState(false);
 	const {
 		draftTitle,
 		draftBackendId,
 		draftCwd,
 		draftWorktreeEnabled,
 		draftWorktreeBranch,
+		draftWorktreeSuggestedBranch,
 		draftWorktreeBaseBranch,
 		setDraftTitle,
 		setDraftBackendId,
 		setDraftCwd,
 		setDraftWorktreeEnabled,
 		setDraftWorktreeBranch,
+		setDraftWorktreeSuggestedBranch,
 		setDraftWorktreeBaseBranch,
 	} = useUiStore();
 	const { selectedMachineId, machines } = useMachinesStore();
@@ -128,18 +134,17 @@ export function CreateSessionDialog({
 		branchesQuery.isFetched;
 	const isWorktreeCreateDisabled =
 		draftWorktreeEnabled &&
-		(isGitContextStale ||
-			branchesQuery.isFetching ||
-			branchesQuery.isError ||
-			!draftWorktreeBranch.trim());
+		(isGitContextStale || branchesQuery.isFetching || branchesQuery.isError);
+	const effectiveWorktreeBranch =
+		draftWorktreeBranch.trim() || draftWorktreeSuggestedBranch?.trim() || "";
 
 	// Worktree path preview using CLI-configured base dir
 	const worktreePathPreview = useMemo(() => {
-		if (!repoName || !draftWorktreeBranch) return "";
-		const sanitized = sanitizeBranch(draftWorktreeBranch);
+		if (!repoName || !effectiveWorktreeBranch) return "";
+		const sanitized = sanitizeWorktreeBranchForPath(effectiveWorktreeBranch);
 		const base = worktreeBaseDir ?? "~/.mobvibe/worktrees";
 		return `${base}/${repoName}/${sanitized}`;
-	}, [draftWorktreeBranch, repoName, worktreeBaseDir]);
+	}, [effectiveWorktreeBranch, repoName, worktreeBaseDir]);
 
 	const worktreeExecutionPathPreview = useMemo(() => {
 		if (!worktreePathPreview) return "";
@@ -150,8 +155,15 @@ export function CreateSessionDialog({
 	useEffect(() => {
 		if (!open) {
 			setDirectoryDialogOpen(false);
+			setHasUserEditedWorktreeBranch(false);
 		}
 	}, [open]);
+
+	useEffect(() => {
+		if (!draftWorktreeEnabled) {
+			setHasUserEditedWorktreeBranch(false);
+		}
+	}, [draftWorktreeEnabled]);
 
 	useEffect(() => {
 		if (!open || draftCwd || !selectedMachineId) {
@@ -185,6 +197,34 @@ export function CreateSessionDialog({
 		isGitRepo,
 		draftWorktreeEnabled,
 		setDraftWorktreeEnabled,
+	]);
+
+	useEffect(() => {
+		if (
+			!open ||
+			!draftWorktreeEnabled ||
+			!hasResolvedGitContext ||
+			!isGitRepo
+		) {
+			return;
+		}
+		if (!draftWorktreeSuggestedBranch) {
+			setDraftWorktreeSuggestedBranch(generateDefaultWorktreeBranchName());
+			return;
+		}
+		if (!draftWorktreeBranch.trim() && !hasUserEditedWorktreeBranch) {
+			setDraftWorktreeBranch(draftWorktreeSuggestedBranch);
+		}
+	}, [
+		draftWorktreeBranch,
+		draftWorktreeEnabled,
+		draftWorktreeSuggestedBranch,
+		hasResolvedGitContext,
+		hasUserEditedWorktreeBranch,
+		isGitRepo,
+		open,
+		setDraftWorktreeBranch,
+		setDraftWorktreeSuggestedBranch,
 	]);
 
 	return (
@@ -351,9 +391,15 @@ export function CreateSessionDialog({
 											name="worktree-branch"
 											autoComplete="off"
 											value={draftWorktreeBranch}
-											onChange={(e) => setDraftWorktreeBranch(e.target.value)}
+											onChange={(event) => {
+												setHasUserEditedWorktreeBranch(true);
+												setDraftWorktreeBranch(event.target.value);
+											}}
 											placeholder={t("session.worktree.branchPlaceholder")}
 										/>
+										<p className="text-muted-foreground text-xs">
+											{t("session.worktree.branchHint")}
+										</p>
 									</div>
 									<div className="flex flex-col gap-1">
 										<Label htmlFor="worktree-base-branch">

--- a/apps/webui/src/components/app/__tests__/CreateSessionDialog.test.tsx
+++ b/apps/webui/src/components/app/__tests__/CreateSessionDialog.test.tsx
@@ -14,12 +14,14 @@ const mockUiState = vi.hoisted(() => ({
 	draftCwd: "/repo/apps/webui",
 	draftWorktreeEnabled: true,
 	draftWorktreeBranch: "feat/live-cwd",
+	draftWorktreeSuggestedBranch: "brisk-comet-x7",
 	draftWorktreeBaseBranch: "main",
 	setDraftTitle: vi.fn(),
 	setDraftBackendId: vi.fn(),
 	setDraftCwd: vi.fn(),
 	setDraftWorktreeEnabled: vi.fn(),
 	setDraftWorktreeBranch: vi.fn(),
+	setDraftWorktreeSuggestedBranch: vi.fn(),
 	setDraftWorktreeBaseBranch: vi.fn(),
 }));
 
@@ -85,7 +87,10 @@ vi.mock("react-i18next", () => ({
 				"session.projectDetection.nonGitHint": "Non-git folder",
 				"session.worktree.enable": "Create in new worktree",
 				"session.worktree.branchLabel": "New branch",
-				"session.worktree.branchPlaceholder": "feat/example",
+				"session.worktree.branchPlaceholder":
+					"Leave blank for a random name, or enter feat/my-feature…",
+				"session.worktree.branchHint":
+					"A random branch name is suggested automatically. Edit it only if you want something specific.",
 				"session.worktree.baseBranchLabel": "Based on",
 				"session.worktree.baseBranchPlaceholder": "Select base branch",
 				"session.worktree.pathLabel": "Worktree path",
@@ -121,6 +126,17 @@ vi.mock("@tanstack/react-query", async () => {
 vi.mock("@/hooks/useDebouncedValue", () => ({
 	useDebouncedValue: () => mockDebouncedValue.cwd,
 }));
+
+vi.mock("@mobvibe/shared", async () => {
+	const actual =
+		await vi.importActual<typeof import("@mobvibe/shared")>("@mobvibe/shared");
+	return {
+		...actual,
+		generateDefaultWorktreeBranchName: () => "brisk-comet-x7",
+		sanitizeWorktreeBranchForPath: (branch: string) =>
+			branch.replace(/[/\\]/g, "-"),
+	};
+});
 
 vi.mock("@/components/app/WorkingDirectoryDialog", () => ({
 	WorkingDirectoryDialog: () => null,
@@ -246,6 +262,7 @@ describe("CreateSessionDialog", () => {
 		mockUiState.draftCwd = "/repo/apps/webui";
 		mockUiState.draftWorktreeEnabled = true;
 		mockUiState.draftWorktreeBranch = "feat/live-cwd";
+		mockUiState.draftWorktreeSuggestedBranch = "brisk-comet-x7";
 		mockUiState.draftWorktreeBaseBranch = "main";
 		mockDebouncedValue.cwd = "/repo/apps/webui";
 		mockQueryState.branches = {
@@ -306,6 +323,52 @@ describe("CreateSessionDialog", () => {
 
 		expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
 		expect(screen.getByText("Checking project...")).toBeInTheDocument();
+	});
+
+	it("keeps create enabled and shows the suggested path when the branch input is blank", () => {
+		mockUiState.draftWorktreeBranch = "";
+
+		render(
+			<CreateSessionDialog
+				open
+				onOpenChange={vi.fn()}
+				availableBackends={[
+					{ backendId: "backend-1", backendLabel: "Backend 1" },
+				]}
+				isCreating={false}
+				onCreate={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
+		expect(
+			screen.getByText("/tmp/worktrees/repo/brisk-comet-x7"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"A random branch name is suggested automatically. Edit it only if you want something specific.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("autofills the suggested branch when worktree mode starts with an empty branch", () => {
+		mockUiState.draftWorktreeBranch = "";
+
+		render(
+			<CreateSessionDialog
+				open
+				onOpenChange={vi.fn()}
+				availableBackends={[
+					{ backendId: "backend-1", backendLabel: "Backend 1" },
+				]}
+				isCreating={false}
+				onCreate={vi.fn()}
+			/>,
+		);
+
+		expect(mockUiState.setDraftWorktreeBranch).toHaveBeenCalledWith(
+			"brisk-comet-x7",
+		);
 	});
 
 	it("renders branch display labels while keeping the raw branch name as the option value", () => {

--- a/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
@@ -25,6 +25,7 @@ const mockUiStoreState = vi.hoisted(() => ({
 	draftCwd: undefined as string | undefined,
 	draftWorktreeEnabled: false,
 	draftWorktreeBranch: "",
+	draftWorktreeSuggestedBranch: undefined as string | undefined,
 	draftWorktreeBaseBranch: undefined as string | undefined,
 	chatDrafts: {} as Record<
 		string,
@@ -169,6 +170,7 @@ describe("useSessionHandlers — handleOpenCreateDialog", () => {
 		mockUiStoreState.draftCwd = undefined;
 		mockUiStoreState.draftWorktreeEnabled = false;
 		mockUiStoreState.draftWorktreeBranch = "";
+		mockUiStoreState.draftWorktreeSuggestedBranch = undefined;
 		mockUiStoreState.draftWorktreeBaseBranch = undefined;
 		mockUiStoreState.chatDrafts = {};
 		mockUiStoreState.clearChatDraft.mockReset();
@@ -400,6 +402,7 @@ describe("useSessionHandlers — handleCreateSession", () => {
 		mockUiStoreState.draftCwd = "/projects/repo/apps/webui";
 		mockUiStoreState.draftWorktreeEnabled = true;
 		mockUiStoreState.draftWorktreeBranch = "feat/live-cwd";
+		mockUiStoreState.draftWorktreeSuggestedBranch = undefined;
 		mockUiStoreState.draftWorktreeBaseBranch = "main";
 		vi.clearAllMocks();
 	});
@@ -456,6 +459,39 @@ describe("useSessionHandlers — handleCreateSession", () => {
 				scope: "request",
 			}),
 		);
+	});
+
+	it("uses the suggested worktree branch when the input is blank", async () => {
+		mockUiStoreState.draftWorktreeBranch = "";
+		mockUiStoreState.draftWorktreeSuggestedBranch = "brisk-comet-x7";
+		vi.mocked(apiModule.fetchGitBranchesForCwd).mockResolvedValue({
+			isGitRepo: true,
+			branches: [],
+			repoRoot: "/projects/repo",
+			relativeCwd: "apps/webui",
+			repoName: "repo",
+			isRepoRoot: false,
+		});
+		vi.mocked(mutations.createSessionMutation.mutateAsync).mockResolvedValue(
+			{},
+		);
+
+		const { result } = renderHandlers();
+
+		await result.current.handleCreateSession();
+
+		expect(mutations.createSessionMutation.mutateAsync).toHaveBeenCalledWith({
+			backendId: "backend-1",
+			cwd: "/projects/repo/apps/webui",
+			title: "Feature Session",
+			machineId: "machine-1",
+			worktree: {
+				branch: "brisk-comet-x7",
+				baseBranch: "main",
+				sourceCwd: "/projects/repo",
+				relativeCwd: "apps/webui",
+			},
+		});
 	});
 });
 

--- a/apps/webui/src/hooks/useSessionHandlers.ts
+++ b/apps/webui/src/hooks/useSessionHandlers.ts
@@ -1,3 +1,4 @@
+import { resolveWorktreeBranchName } from "@mobvibe/shared";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { PermissionResultNotification } from "@/lib/acp";
@@ -22,7 +23,7 @@ type Mutations = {
 			title?: string;
 			machineId: string;
 			worktree?: {
-				branch: string;
+				branch?: string;
 				baseBranch?: string;
 				sourceCwd: string;
 				relativeCwd?: string;
@@ -173,6 +174,7 @@ export function useSessionHandlers({
 			draftCwd,
 			draftWorktreeEnabled,
 			draftWorktreeBranch,
+			draftWorktreeSuggestedBranch,
 			draftWorktreeBaseBranch,
 		} = useUiStore.getState();
 		if (!selectedMachineId) {
@@ -200,7 +202,7 @@ export function useSessionHandlers({
 
 		let worktree:
 			| {
-					branch: string;
+					branch?: string;
 					baseBranch?: string;
 					sourceCwd: string;
 					relativeCwd?: string;
@@ -208,10 +210,9 @@ export function useSessionHandlers({
 			| undefined;
 
 		if (draftWorktreeEnabled) {
-			const branch = draftWorktreeBranch.trim();
-			if (!branch) {
-				return;
-			}
+			const branch = resolveWorktreeBranchName(
+				draftWorktreeBranch.trim() || draftWorktreeSuggestedBranch,
+			);
 
 			try {
 				const projectContext = await fetchGitBranchesForCwd({

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -98,7 +98,8 @@
 		"worktree": {
 			"enable": "Create in new worktree",
 			"branchLabel": "New branch",
-			"branchPlaceholder": "e.g. feat/my-feature",
+			"branchPlaceholder": "Leave blank for a random name, or enter feat/my-feature…",
+			"branchHint": "A random branch name is suggested automatically. Edit it only if you want something specific.",
 			"baseBranchLabel": "Based on",
 			"baseBranchPlaceholder": "Select base branch (default: HEAD)",
 			"pathLabel": "Worktree path",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -98,7 +98,8 @@
 		"worktree": {
 			"enable": "在新 Worktree 中创建",
 			"branchLabel": "新分支",
-			"branchPlaceholder": "例如 feat/my-feature",
+			"branchPlaceholder": "留空可自动生成，或输入例如 feat/my-feature…",
+			"branchHint": "会自动建议一个随机分支名；只有在你想自定义时才需要修改。",
 			"baseBranchLabel": "基于分支",
 			"baseBranchPlaceholder": "选择基准分支（默认：HEAD）",
 			"pathLabel": "Worktree 路径",

--- a/apps/webui/src/lib/api.ts
+++ b/apps/webui/src/lib/api.ts
@@ -294,7 +294,7 @@ export const createSession = async (payload?: {
 	backendId?: string;
 	machineId?: string;
 	worktree?: {
-		branch: string;
+		branch?: string;
 		baseBranch?: string;
 		sourceCwd: string;
 		relativeCwd?: string;

--- a/apps/webui/src/lib/ui-store.ts
+++ b/apps/webui/src/lib/ui-store.ts
@@ -76,6 +76,7 @@ type UiState = {
 	draftCwd?: string;
 	draftWorktreeEnabled: boolean;
 	draftWorktreeBranch: string;
+	draftWorktreeSuggestedBranch?: string;
 	draftWorktreeBaseBranch?: string;
 	chatDrafts: Record<string, ChatDraft>;
 	selectedWorkspaceByMachine: Record<string, string>;
@@ -96,6 +97,7 @@ type UiState = {
 	setDraftCwd: (value?: string) => void;
 	setDraftWorktreeEnabled: (value: boolean) => void;
 	setDraftWorktreeBranch: (value: string) => void;
+	setDraftWorktreeSuggestedBranch: (value?: string) => void;
 	setDraftWorktreeBaseBranch: (value?: string) => void;
 	resetDraftWorktree: () => void;
 	setChatDraft: (sessionId: string, draft: ChatDraft) => void;
@@ -120,6 +122,7 @@ export const useUiStore = create<UiState>((set) => ({
 	draftCwd: undefined,
 	draftWorktreeEnabled: false,
 	draftWorktreeBranch: "",
+	draftWorktreeSuggestedBranch: undefined,
 	draftWorktreeBaseBranch: undefined,
 	chatDrafts: {},
 	selectedWorkspaceByMachine: {},
@@ -151,12 +154,15 @@ export const useUiStore = create<UiState>((set) => ({
 	setDraftCwd: (value) => set({ draftCwd: value }),
 	setDraftWorktreeEnabled: (value) => set({ draftWorktreeEnabled: value }),
 	setDraftWorktreeBranch: (value) => set({ draftWorktreeBranch: value }),
+	setDraftWorktreeSuggestedBranch: (value) =>
+		set({ draftWorktreeSuggestedBranch: value }),
 	setDraftWorktreeBaseBranch: (value) =>
 		set({ draftWorktreeBaseBranch: value }),
 	resetDraftWorktree: () =>
 		set({
 			draftWorktreeEnabled: false,
 			draftWorktreeBranch: "",
+			draftWorktreeSuggestedBranch: undefined,
 			draftWorktreeBaseBranch: undefined,
 		}),
 	setChatDraft: (sessionId, draft) =>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -207,6 +207,10 @@ export type {
 	StreamErrorPayload,
 	WebuiToGatewayEvents,
 } from "./types/socket-events.js";
-
 // Validation utilities (Zod schemas from SDK)
 export { parseSessionNotification } from "./validation/acp-schemas.js";
+export {
+	generateDefaultWorktreeBranchName,
+	resolveWorktreeBranchName,
+	sanitizeWorktreeBranchForPath,
+} from "./worktree-names.js";

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -134,8 +134,8 @@ export type RpcResponse<TResult> = {
 
 // Worktree options for session creation
 export type CreateSessionWorktreeOptions = {
-	/** New branch name to create */
-	branch: string;
+	/** New branch name to create; auto-generated if omitted */
+	branch?: string;
 	/** Base branch to create from (defaults to current HEAD) */
 	baseBranch?: string;
 	/** Original repo directory */

--- a/packages/shared/src/worktree-names.ts
+++ b/packages/shared/src/worktree-names.ts
@@ -1,0 +1,116 @@
+const WORKTREE_ADJECTIVES = [
+	"amber",
+	"brisk",
+	"calm",
+	"clever",
+	"cosmic",
+	"curious",
+	"dapper",
+	"eager",
+	"fancy",
+	"gentle",
+	"glossy",
+	"jolly",
+	"lively",
+	"lucky",
+	"mellow",
+	"misty",
+	"nimble",
+	"odd",
+	"peppy",
+	"quiet",
+	"rapid",
+	"shiny",
+	"snug",
+	"spry",
+	"sturdy",
+	"sunny",
+	"swift",
+	"tidy",
+	"vivid",
+	"wavy",
+	"whimsy",
+	"zesty",
+] as const;
+
+const WORKTREE_NOUNS = [
+	"anchor",
+	"beacon",
+	"bloom",
+	"breeze",
+	"comet",
+	"drift",
+	"ember",
+	"falcon",
+	"feather",
+	"forest",
+	"galaxy",
+	"harbor",
+	"island",
+	"lantern",
+	"meadow",
+	"meteor",
+	"nebula",
+	"oasis",
+	"orbit",
+	"otter",
+	"paddle",
+	"pebble",
+	"pine",
+	"ripple",
+	"rocket",
+	"shadow",
+	"signal",
+	"sparrow",
+	"summit",
+	"thunder",
+	"valley",
+	"voyage",
+] as const;
+
+type WorktreeNameOptions = {
+	randomInt?: (max: number) => number;
+};
+
+const createRandomInt = (): ((max: number) => number) => {
+	const cryptoRef = globalThis.crypto;
+	if (cryptoRef?.getRandomValues) {
+		return (max) => {
+			if (!Number.isInteger(max) || max <= 0) {
+				throw new Error("max must be a positive integer");
+			}
+			const values = new Uint32Array(1);
+			cryptoRef.getRandomValues(values);
+			return values[0] % max;
+		};
+	}
+	return (max) => {
+		if (!Number.isInteger(max) || max <= 0) {
+			throw new Error("max must be a positive integer");
+		}
+		return Math.floor(Math.random() * max);
+	};
+};
+
+export const generateDefaultWorktreeBranchName = (
+	options?: WorktreeNameOptions,
+): string => {
+	const randomInt = options?.randomInt ?? createRandomInt();
+	const adjective = WORKTREE_ADJECTIVES[randomInt(WORKTREE_ADJECTIVES.length)];
+	const noun = WORKTREE_NOUNS[randomInt(WORKTREE_NOUNS.length)];
+	const suffix = randomInt(36 ** 2)
+		.toString(36)
+		.padStart(2, "0");
+	return `${adjective}-${noun}-${suffix}`;
+};
+
+export const resolveWorktreeBranchName = (
+	branch?: string | null,
+	options?: WorktreeNameOptions,
+): string => {
+	const trimmed = branch?.trim();
+	return trimmed ? trimmed : generateDefaultWorktreeBranchName(options);
+};
+
+export const sanitizeWorktreeBranchForPath = (branch: string): string =>
+	branch.replace(/[/\\]/g, "-");


### PR DESCRIPTION
## Summary
- add a shared generator for default worktree branch names and reuse it in the UI and CLI
- prefill a suggested branch name in the create-session dialog while keeping the field editable
- allow blank or omitted worktree branches at the API boundary and cover the fallback flow with tests

## Testing
- pnpm -C apps/webui test:run -- src/components/app/__tests__/CreateSessionDialog.test.tsx src/hooks/__tests__/useSessionHandlers.test.tsx
- pnpm -C apps/mobvibe-cli test -- src/acp/__tests__/session-manager.test.ts
- pnpm format
- pnpm lint
- pnpm build