### PR TITLE
fix(webui): use dialog for create session modal

### DIFF
--- a/apps/webui/src/components/app/CreateSessionDialog.tsx
+++ b/apps/webui/src/components/app/CreateSessionDialog.tsx
@@ -8,17 +8,14 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { WorkingDirectoryDialog } from "@/components/app/WorkingDirectoryDialog";
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
 	InputGroup,
@@ -228,17 +225,17 @@ export function CreateSessionDialog({
 	]);
 
 	return (
-		<AlertDialog open={open} onOpenChange={onOpenChange}>
-			<AlertDialogContent
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
 				size="default"
 				className="w-[100vw] max-w-none sm:w-[92vw] sm:max-w-[92vw] lg:max-w-4xl"
 			>
-				<AlertDialogHeader>
-					<AlertDialogTitle>{t("session.createTitle")}</AlertDialogTitle>
-					<AlertDialogDescription>
+				<div className="grid gap-1.5 text-center sm:text-left">
+					<DialogTitle>{t("session.createTitle")}</DialogTitle>
+					<DialogDescription>
 						{t("session.createDescription")}
-					</AlertDialogDescription>
-				</AlertDialogHeader>
+					</DialogDescription>
+				</div>
 				{machineDisplayName ? (
 					<div className="text-muted-foreground flex items-center gap-1.5 text-sm">
 						<HugeiconsIcon
@@ -397,9 +394,6 @@ export function CreateSessionDialog({
 											}}
 											placeholder={t("session.worktree.branchPlaceholder")}
 										/>
-										<p className="text-muted-foreground text-xs">
-											{t("session.worktree.branchHint")}
-										</p>
 									</div>
 									<div className="flex flex-col gap-1">
 										<Label htmlFor="worktree-base-branch">
@@ -458,9 +452,11 @@ export function CreateSessionDialog({
 						machineId={selectedMachineId ?? undefined}
 					/>
 				</div>
-				<AlertDialogFooter>
-					<AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-					<AlertDialogAction
+				<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						{t("common.cancel")}
+					</Button>
+					<Button
 						disabled={
 							isCreating ||
 							!draftBackendId ||
@@ -468,15 +464,12 @@ export function CreateSessionDialog({
 							!selectedMachineId ||
 							isWorktreeCreateDisabled
 						}
-						onClick={(event) => {
-							event.preventDefault();
-							onCreate();
-						}}
+						onClick={onCreate}
 					>
 						{isCreating ? t("common.creating") : t("common.create")}
-					</AlertDialogAction>
-				</AlertDialogFooter>
-			</AlertDialogContent>
-		</AlertDialog>
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
 	);
 }

--- a/apps/webui/src/components/app/__tests__/CreateSessionDialog.test.tsx
+++ b/apps/webui/src/components/app/__tests__/CreateSessionDialog.test.tsx
@@ -89,8 +89,6 @@ vi.mock("react-i18next", () => ({
 				"session.worktree.branchLabel": "New branch",
 				"session.worktree.branchPlaceholder":
 					"Leave blank for a random name, or enter feat/my-feature…",
-				"session.worktree.branchHint":
-					"A random branch name is suggested automatically. Edit it only if you want something specific.",
 				"session.worktree.baseBranchLabel": "Based on",
 				"session.worktree.baseBranchPlaceholder": "Select base branch",
 				"session.worktree.pathLabel": "Worktree path",
@@ -142,40 +140,28 @@ vi.mock("@/components/app/WorkingDirectoryDialog", () => ({
 	WorkingDirectoryDialog: () => null,
 }));
 
-vi.mock("@/components/ui/alert-dialog", () => ({
-	AlertDialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-	AlertDialogContent: ({ children }: { children: ReactNode }) => (
+vi.mock("@/components/ui/dialog", () => ({
+	Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	DialogContent: ({ children }: { children: ReactNode }) => (
 		<div>{children}</div>
 	),
-	AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+	DialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	DialogDescription: ({ children }: { children: ReactNode }) => (
 		<div>{children}</div>
 	),
-	AlertDialogTitle: ({ children }: { children: ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogDescription: ({ children }: { children: ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogFooter: ({ children }: { children: ReactNode }) => (
-		<div>{children}</div>
-	),
-	AlertDialogCancel: ({ children }: { children: ReactNode }) => (
-		<button type="button">{children}</button>
-	),
-	AlertDialogAction: ({
+}));
+
+vi.mock("@/components/ui/button", () => ({
+	Button: ({
 		children,
 		disabled,
 		onClick,
 	}: {
 		children: ReactNode;
 		disabled?: boolean;
-		onClick?: (event: { preventDefault: () => void }) => void;
+		onClick?: () => void;
 	}) => (
-		<button
-			type="button"
-			disabled={disabled}
-			onClick={() => onClick?.({ preventDefault() {} })}
-		>
+		<button type="button" disabled={disabled} onClick={onClick}>
 			{children}
 		</button>
 	),
@@ -343,11 +329,6 @@ describe("CreateSessionDialog", () => {
 		expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
 		expect(
 			screen.getByText("/tmp/worktrees/repo/brisk-comet-x7"),
-		).toBeInTheDocument();
-		expect(
-			screen.getByText(
-				"A random branch name is suggested automatically. Edit it only if you want something specific.",
-			),
 		).toBeInTheDocument();
 	});
 

--- a/apps/webui/src/components/ui/dialog.tsx
+++ b/apps/webui/src/components/ui/dialog.tsx
@@ -38,15 +38,19 @@ function DialogOverlay({
 
 function DialogContent({
 	className,
+	size = "default",
 	...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+	size?: "default" | "sm";
+}) {
 	return (
 		<DialogPortal>
 			<DialogOverlay />
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
+				data-size={size}
 				className={cn(
-					"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 fixed top-1/2 left-1/2 z-50 grid w-full max-w-sm -translate-x-1/2 -translate-y-1/2 gap-4 rounded-none p-4 ring-1 outline-none duration-100 sm:rounded-lg",
+					"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-none p-4 ring-1 outline-none duration-100 data-[size=default]:max-w-sm data-[size=sm]:max-w-sm sm:rounded-lg",
 					className,
 				)}
 				{...props}

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -99,7 +99,6 @@
 			"enable": "Create in new worktree",
 			"branchLabel": "New branch",
 			"branchPlaceholder": "Leave blank for a random name, or enter feat/my-feature…",
-			"branchHint": "A random branch name is suggested automatically. Edit it only if you want something specific.",
 			"baseBranchLabel": "Based on",
 			"baseBranchPlaceholder": "Select base branch (default: HEAD)",
 			"pathLabel": "Worktree path",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -99,7 +99,6 @@
 			"enable": "在新 Worktree 中创建",
 			"branchLabel": "新分支",
 			"branchPlaceholder": "留空可自动生成，或输入例如 feat/my-feature…",
-			"branchHint": "会自动建议一个随机分支名；只有在你想自定义时才需要修改。",
 			"baseBranchLabel": "基于分支",
 			"baseBranchPlaceholder": "选择基准分支（默认：HEAD）",
 			"pathLabel": "Worktree 路径",


### PR DESCRIPTION
## Summary
- switch the create session modal from AlertDialog to Dialog so worktree controls behave like a normal form
- remove the obsolete worktree branch hint text from the UI and i18n
- update the create session dialog test fixture to match the new modal structure

## Testing
- pnpm format
- pnpm lint
- pnpm build
- pnpm -C apps/webui test:run -- src/components/app/__tests__/CreateSessionDialog.test.tsx