### PR TITLE
fix: restore worktree base branch listing

### DIFF
--- a/apps/mobvibe-cli/src/lib/__tests__/git-utils.test.ts
+++ b/apps/mobvibe-cli/src/lib/__tests__/git-utils.test.ts
@@ -229,6 +229,46 @@ describe("git-utils", () => {
 					aheadBehind: undefined,
 				},
 			]);
+			expect(mockExecFileAsync).toHaveBeenCalledWith(
+				"git",
+				[
+					"branch",
+					"-a",
+					"--format=%(refname)\t%(refname:short)\t%(HEAD)\t%(upstream:short)\t%(upstream:track)",
+				],
+				expect.objectContaining({ cwd: "/home/user/project" }),
+			);
+		});
+
+		it("accepts git output that contains literal %x09 separators", async () => {
+			execFileQueue.push({
+				stdout: [
+					"refs/heads/main%x09main%x09*%x09origin/main%x09[ahead 1]",
+					"refs/remotes/origin/main%x09origin/main%x09%x09%x09",
+				].join("\n"),
+				stderr: "",
+			});
+
+			const result = await getGitBranches("/home/user/project");
+
+			expect(result).toEqual([
+				{
+					name: "main",
+					displayName: "main (HEAD)",
+					current: true,
+					remote: undefined,
+					upstream: "origin/main",
+					aheadBehind: { ahead: 1, behind: 0 },
+				},
+				{
+					name: "origin/main",
+					displayName: "origin/main",
+					current: false,
+					remote: "origin",
+					upstream: undefined,
+					aheadBehind: undefined,
+				},
+			]);
 		});
 	});
 

--- a/apps/mobvibe-cli/src/lib/git-utils.ts
+++ b/apps/mobvibe-cli/src/lib/git-utils.ts
@@ -730,7 +730,7 @@ export async function getGitBranches(cwd: string): Promise<GitBranch[]> {
 			[
 				"branch",
 				"-a",
-				"--format=%(refname)%x09%(refname:short)%x09%(HEAD)%x09%(upstream:short)%x09%(upstream:track)",
+				"--format=%(refname)\t%(refname:short)\t%(HEAD)\t%(upstream:short)\t%(upstream:track)",
 			],
 			{ cwd, maxBuffer: MAX_BUFFER },
 		);
@@ -738,13 +738,14 @@ export async function getGitBranches(cwd: string): Promise<GitBranch[]> {
 		const branches: GitBranch[] = [];
 
 		for (const line of stdout.split("\n").filter(Boolean)) {
+			const delimiter = line.includes("\t") ? "\t" : "%x09";
 			const [
 				fullRef = "",
 				shortRef = "",
 				headMarker = "",
 				upstreamRef = "",
 				tracking = "",
-			] = line.split("\t");
+			] = line.split(delimiter);
 			const name = shortRef.trim();
 			if (!name) {
 				continue;


### PR DESCRIPTION
## Summary
- make git branch parsing tolerate both real tab separators and literal `%x09` output
- keep structured branch parsing for worktree base-branch selection
- add regression coverage for both output formats

## Root cause
The worktree create dialog was rendering an empty base-branch list because `getGitBranches()` assumed `git branch --format` would always expand `%x09` into tabs. On some setups Git returns literal `%x09`, so the parser produced zero branches and the dropdown opened with an empty list.

## Testing
- pnpm -C apps/mobvibe-cli test -- src/lib/__tests__/git-utils.test.ts