### PR TITLE
fix(webui): stabilize session ordering and collapse long lists

### DIFF
--- a/apps/webui/src/components/session/SessionSidebar.tsx
+++ b/apps/webui/src/components/session/SessionSidebar.tsx
@@ -25,6 +25,7 @@ import {
 import { WorkspaceList } from "@/components/workspace/WorkspaceList";
 import { type SessionListEntry } from "@/lib/chat-store";
 import { useMachinesStore } from "@/lib/machines-store";
+import { compareSessionsByRecency } from "@/lib/session-order";
 import {
 	getSessionDisplayStatus,
 	type SessionDisplayPhase,
@@ -33,6 +34,8 @@ import {
 import { useUiStore } from "@/lib/ui-store";
 import { formatRelativeTime, getPathBasename } from "@/lib/ui-utils";
 import { cn } from "@/lib/utils";
+
+const DEFAULT_VISIBLE_SESSION_COUNT = 8;
 
 const getSessionStamp = (session: SessionListEntry) =>
 	session.updatedAt ?? session.createdAt ?? "";
@@ -91,6 +94,7 @@ export const SessionSidebar = ({
 	const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(
 		{},
 	);
+	const [showAllSessions, setShowAllSessions] = useState(false);
 	const {
 		editingSessionId,
 		editingTitle,
@@ -118,7 +122,6 @@ export const SessionSidebar = ({
 				id: string;
 				label: string;
 				sessions: SessionListEntry[];
-				latestStamp: string;
 			}
 		>();
 
@@ -126,39 +129,46 @@ export const SessionSidebar = ({
 			const id = session.backendId?.trim() || "unknown";
 			const rawLabel = session.backendLabel ?? session.backendId ?? "";
 			const label = rawLabel.trim().length > 0 ? rawLabel : t("common.unknown");
-			const stamp = getSessionStamp(session);
 			const existing = groups.get(id);
 			if (!existing) {
 				groups.set(id, {
 					id,
 					label,
 					sessions: [session],
-					latestStamp: stamp,
 				});
 				continue;
 			}
 			existing.sessions.push(session);
-			if (stamp.localeCompare(existing.latestStamp) > 0) {
-				existing.latestStamp = stamp;
-			}
 		}
-
-		const compareSession = (left: SessionListEntry, right: SessionListEntry) =>
-			getSessionStamp(right).localeCompare(getSessionStamp(left));
 
 		const grouped = Array.from(groups.values());
 		for (const group of grouped) {
-			group.sessions.sort(compareSession);
+			group.sessions.sort(compareSessionsByRecency);
 		}
 
 		return grouped.sort((left, right) => {
-			const byRecent = right.latestStamp.localeCompare(left.latestStamp);
+			const byRecent = compareSessionsByRecency(
+				left.sessions[0],
+				right.sessions[0],
+			);
 			if (byRecent !== 0) {
 				return byRecent;
 			}
 			return left.label.localeCompare(right.label);
 		});
 	}, [sessions, t]);
+
+	const hiddenSessionCount = Math.max(
+		sessions.length - DEFAULT_VISIBLE_SESSION_COUNT,
+		0,
+	);
+
+	const handleToggleShowAllSessions = () => {
+		if (!showAllSessions) {
+			setExpandedGroups({});
+		}
+		setShowAllSessions((prev) => !prev);
+	};
 
 	return (
 		<TooltipProvider delayDuration={300}>
@@ -246,84 +256,116 @@ export const SessionSidebar = ({
 									{t("session.empty")}
 								</div>
 							) : null}
-							{groupedSessions.map((group) => {
-								const isExpanded = expandedGroups[group.id] ?? true;
-								return (
-									<div key={group.id} className="flex flex-col gap-1">
-										<div className="flex items-center justify-between">
-											<button
-												type="button"
-												className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-xs font-semibold"
-												aria-expanded={isExpanded}
-												onClick={() =>
-													setExpandedGroups((prev) => ({
-														...prev,
-														[group.id]: !(prev[group.id] ?? true),
-													}))
-												}
-											>
-												<HugeiconsIcon
-													icon={isExpanded ? ArrowDown01Icon : ArrowRight01Icon}
-													strokeWidth={2}
-													className="h-3.5 w-3.5 shrink-0"
-													aria-hidden="true"
-												/>
-												<span className="truncate">
-													{group.label}
-													<span className="ml-1 opacity-50">
-														({group.sessions.length})
-													</span>
-												</span>
-											</button>
-											{isExpanded && group.sessions.length > 1 ? (
-												<Button
-													size="xs"
-													variant="ghost"
-													className="text-muted-foreground h-5 px-1.5 text-[10px]"
-													disabled={isBulkArchiving}
+							{(() => {
+								let visibleSessionBudget = showAllSessions
+									? Number.POSITIVE_INFINITY
+									: DEFAULT_VISIBLE_SESSION_COUNT;
+
+								return groupedSessions.map((group) => {
+									const isExpanded = expandedGroups[group.id] ?? true;
+									const visibleSessions =
+										showAllSessions || !isExpanded
+											? group.sessions
+											: group.sessions.slice(0, visibleSessionBudget);
+									if (!showAllSessions && isExpanded) {
+										visibleSessionBudget -= visibleSessions.length;
+									}
+									if (visibleSessions.length === 0) {
+										return null;
+									}
+
+									return (
+										<div key={group.id} className="flex flex-col gap-1">
+											<div className="flex items-center justify-between">
+												<button
+													type="button"
+													className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-xs font-semibold"
+													aria-expanded={isExpanded}
 													onClick={() =>
-														onArchiveAllSessionsRequest(
-															group.sessions.map((s) => s.sessionId),
-														)
+														setExpandedGroups((prev) => ({
+															...prev,
+															[group.id]: !(prev[group.id] ?? true),
+														}))
 													}
 												>
-													{t("session.archiveAll")}
-												</Button>
-											) : null}
-										</div>
-										{isExpanded ? (
-											<div className="flex flex-col gap-0.5 pl-2">
-												{group.sessions.map((session) => (
-													<SessionListItem
-														key={session.sessionId}
-														session={session}
-														isActive={session.sessionId === activeSessionId}
-														isEditing={session.sessionId === editingSessionId}
-														editingTitle={editingTitle}
-														displayStatus={getSessionDisplayStatus(
-															session,
-															mutations,
-														)}
-														onSelect={onSelectSession}
-														onEdit={() =>
-															startEditingSession(
-																session.sessionId,
-																session.title,
+													<HugeiconsIcon
+														icon={
+															isExpanded ? ArrowDown01Icon : ArrowRight01Icon
+														}
+														strokeWidth={2}
+														className="h-3.5 w-3.5 shrink-0"
+														aria-hidden="true"
+													/>
+													<span className="truncate">
+														{group.label}
+														<span className="ml-1 opacity-50">
+															({group.sessions.length})
+														</span>
+													</span>
+												</button>
+												{isExpanded && group.sessions.length > 1 ? (
+													<Button
+														size="xs"
+														variant="ghost"
+														className="text-muted-foreground h-5 px-1.5 text-[10px]"
+														disabled={isBulkArchiving}
+														onClick={() =>
+															onArchiveAllSessionsRequest(
+																group.sessions.map((s) => s.sessionId),
 															)
 														}
-														onEditCancel={clearEditingSession}
-														onEditSubmit={onEditSubmit}
-														onEditingTitleChange={setEditingTitle}
-														onArchive={() =>
-															onArchiveSessionRequest(session.sessionId)
-														}
-													/>
-												))}
+													>
+														{t("session.archiveAll")}
+													</Button>
+												) : null}
 											</div>
-										) : null}
-									</div>
-								);
-							})}
+											{isExpanded ? (
+												<div className="flex flex-col gap-0.5 pl-2">
+													{visibleSessions.map((session) => (
+														<SessionListItem
+															key={session.sessionId}
+															session={session}
+															isActive={session.sessionId === activeSessionId}
+															isEditing={session.sessionId === editingSessionId}
+															editingTitle={editingTitle}
+															displayStatus={getSessionDisplayStatus(
+																session,
+																mutations,
+															)}
+															onSelect={onSelectSession}
+															onEdit={() =>
+																startEditingSession(
+																	session.sessionId,
+																	session.title,
+																)
+															}
+															onEditCancel={clearEditingSession}
+															onEditSubmit={onEditSubmit}
+															onEditingTitleChange={setEditingTitle}
+															onArchive={() =>
+																onArchiveSessionRequest(session.sessionId)
+															}
+														/>
+													))}
+												</div>
+											) : null}
+										</div>
+									);
+								});
+							})()}
+							{hiddenSessionCount > 0 ? (
+								<Button
+									type="button"
+									size="sm"
+									variant="ghost"
+									className="text-muted-foreground mt-1 justify-start px-2 text-xs"
+									onClick={handleToggleShowAllSessions}
+								>
+									{showAllSessions
+										? t("session.showLess")
+										: t("session.showMore", { count: hiddenSessionCount })}
+								</Button>
+							) : null}
 						</div>
 					</>
 				) : null}

--- a/apps/webui/src/hooks/__tests__/useSessionMutations.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionMutations.test.tsx
@@ -152,6 +152,8 @@ describe("useSessionMutations", () => {
 				title: "New Session",
 				backendId: "backend-1",
 				backendLabel: "Backend 1",
+				createdAt: mockSession.createdAt,
+				updatedAt: mockSession.updatedAt,
 				cwd: mockSession.cwd,
 				agentName: mockSession.agentName,
 				modelId: mockSession.modelId,
@@ -380,6 +382,8 @@ describe("useSessionMutations", () => {
 				title: "Custom Title",
 				backendId: "backend-1",
 				cwd: "/custom/path",
+				createdAt: expect.any(String),
+				updatedAt: expect.any(String),
 				isCreating: true,
 				machineId: "machine-2",
 			});

--- a/apps/webui/src/hooks/useSessionList.ts
+++ b/apps/webui/src/hooks/useSessionList.ts
@@ -6,6 +6,7 @@ import {
 	toSessionListEntry,
 	useChatStore,
 } from "@/lib/chat-store";
+import { compareSessionsByRecency } from "@/lib/session-order";
 import {
 	collectWorkspaces,
 	type WorkspaceSummary,
@@ -80,11 +81,7 @@ export function useSessionList({
 				return true;
 			});
 			return filtered
-				.sort((left, right) => {
-					const leftStamp = left.updatedAt ?? left.createdAt ?? "";
-					const rightStamp = right.updatedAt ?? right.createdAt ?? "";
-					return rightStamp.localeCompare(leftStamp);
-				})
+				.sort(compareSessionsByRecency)
 				.map((session) => serializeSessionEntry(toSessionListEntry(session)));
 		}),
 	);

--- a/apps/webui/src/hooks/useSessionMutations.ts
+++ b/apps/webui/src/hooks/useSessionMutations.ts
@@ -37,6 +37,8 @@ type SessionMetadata = Partial<
 	Pick<
 		ChatSession,
 		| "title"
+		| "createdAt"
+		| "updatedAt"
 		| "backendId"
 		| "backendLabel"
 		| "cwd"
@@ -224,6 +226,8 @@ export function useSessionMutations(store: ChatStoreActions) {
 				title: variables.title || t("session.creating"),
 				backendId: variables.backendId,
 				cwd: variables.cwd,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
 				isCreating: true,
 				machineId: variables.machineId,
 			});
@@ -254,6 +258,8 @@ export function useSessionMutations(store: ChatStoreActions) {
 				availableModes: data.availableModes,
 				availableModels: data.availableModels,
 				availableCommands: data.availableCommands,
+				createdAt: data.createdAt,
+				updatedAt: data.updatedAt,
 				worktreeSourceCwd: data.worktreeSourceCwd,
 				worktreeBranch: data.worktreeBranch,
 				machineId: data.machineId,

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -95,6 +95,8 @@
 		"archiveAllTitle": "Archive all sessions?",
 		"archiveAllDescription": "This will archive {{count}} session(s), ending their backend processes and hiding them from the list.",
 		"archiveAllConfirm": "Archive all",
+		"showMore": "Show {{count}} more sessions",
+		"showLess": "Show fewer sessions",
 		"worktree": {
 			"enable": "Create in new worktree",
 			"branchLabel": "New branch",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -95,6 +95,8 @@
 		"archiveAllTitle": "归档所有对话？",
 		"archiveAllDescription": "将归档 {{count}} 个对话，结束后端进程并从列表中隐藏。",
 		"archiveAllConfirm": "确认全部归档",
+		"showMore": "展开剩余 {{count}} 个对话",
+		"showLess": "收起对话列表",
 		"worktree": {
 			"enable": "在新 Worktree 中创建",
 			"branchLabel": "新分支",

--- a/apps/webui/src/lib/chat-store.ts
+++ b/apps/webui/src/lib/chat-store.ts
@@ -266,6 +266,13 @@ type ChatState = {
 			availableModes?: SessionModeOption[];
 			availableModels?: SessionModelOption[];
 			availableCommands?: AvailableCommand[];
+			createdAt?: string;
+			updatedAt?: string;
+			machineId?: string;
+			isCreating?: boolean;
+			worktreeSourceCwd?: string;
+			worktreeBranch?: string;
+			workspaceRootCwd?: string;
 		},
 	) => void;
 	syncSessions: (summaries: SessionSummary[]) => void;
@@ -543,7 +550,10 @@ const createSessionState = (
 		availableModes?: SessionModeOption[];
 		availableModels?: SessionModelOption[];
 		availableCommands?: AvailableCommand[];
+		createdAt?: string;
+		updatedAt?: string;
 		machineId?: string;
+		isCreating?: boolean;
 		worktreeSourceCwd?: string;
 		worktreeBranch?: string;
 		workspaceRootCwd?: string;
@@ -562,8 +572,8 @@ const createSessionState = (
 	canceling: false,
 	error: undefined,
 	streamError: undefined,
-	createdAt: undefined,
-	updatedAt: undefined,
+	createdAt: options?.createdAt,
+	updatedAt: options?.updatedAt,
 	backendId: options?.backendId,
 	backendLabel: options?.backendLabel,
 	cwd: options?.cwd,
@@ -576,6 +586,7 @@ const createSessionState = (
 	availableModels: options?.availableModels,
 	availableCommands: options?.availableCommands,
 	machineId: options?.machineId,
+	isCreating: options?.isCreating,
 	isAttached: false,
 	attachedAt: undefined,
 	detachedAt: undefined,
@@ -645,6 +656,7 @@ const mergeSessionFromSummary = (
 		availableModels: summary.availableModels ?? existing.availableModels,
 		availableCommands: summary.availableCommands ?? existing.availableCommands,
 		machineId: summary.machineId ?? existing.machineId,
+		isCreating: false,
 		isTitlePinned: summary.isTitlePinned ?? existing.isTitlePinned,
 		worktreeSourceCwd: summary.worktreeSourceCwd ?? existing.worktreeSourceCwd,
 		worktreeBranch: summary.worktreeBranch ?? existing.worktreeBranch,
@@ -821,9 +833,8 @@ export const useChatStore = create<ChatState>()(
 								added,
 							);
 						} else {
-							nextSessions[added.sessionId] = createSessionState(
-								added.sessionId,
-								{
+							nextSessions[added.sessionId] = mergeSessionFromSummary(
+								createSessionState(added.sessionId, {
 									title: added.title,
 									backendId: added.backendId,
 									backendLabel: added.backendLabel,
@@ -836,11 +847,14 @@ export const useChatStore = create<ChatState>()(
 									availableModes: added.availableModes,
 									availableModels: added.availableModels,
 									availableCommands: added.availableCommands,
+									createdAt: added.createdAt,
+									updatedAt: added.updatedAt,
 									machineId: added.machineId,
 									worktreeSourceCwd: added.worktreeSourceCwd,
 									worktreeBranch: added.worktreeBranch,
 									workspaceRootCwd: added.workspaceRootCwd,
-								},
+								}),
+								added,
 							);
 						}
 					}

--- a/apps/webui/src/lib/session-order.ts
+++ b/apps/webui/src/lib/session-order.ts
@@ -1,0 +1,56 @@
+type TimestampedSessionLike = {
+	sessionId: string;
+	createdAt?: string;
+	updatedAt?: string;
+};
+
+const INVALID_TIMESTAMP = Number.NEGATIVE_INFINITY;
+
+const parseTimestamp = (value?: string): number => {
+	if (!value) {
+		return INVALID_TIMESTAMP;
+	}
+
+	const parsed = Date.parse(value);
+	return Number.isNaN(parsed) ? INVALID_TIMESTAMP : parsed;
+};
+
+export const compareTimestampsByRecency = (
+	left?: string,
+	right?: string,
+): number => {
+	const leftTime = parseTimestamp(left);
+	const rightTime = parseTimestamp(right);
+
+	if (leftTime !== rightTime) {
+		return rightTime - leftTime;
+	}
+
+	return (right ?? "").localeCompare(left ?? "");
+};
+
+const getSessionRecencyTimestamp = (session: TimestampedSessionLike): string =>
+	session.updatedAt ?? session.createdAt ?? "";
+
+export const compareSessionsByRecency = (
+	left: TimestampedSessionLike,
+	right: TimestampedSessionLike,
+): number => {
+	const byRecent = compareTimestampsByRecency(
+		getSessionRecencyTimestamp(left),
+		getSessionRecencyTimestamp(right),
+	);
+	if (byRecent !== 0) {
+		return byRecent;
+	}
+
+	const byCreatedAt = compareTimestampsByRecency(
+		left.createdAt,
+		right.createdAt,
+	);
+	if (byCreatedAt !== 0) {
+		return byCreatedAt;
+	}
+
+	return left.sessionId.localeCompare(right.sessionId);
+};

--- a/apps/webui/src/lib/workspace-utils.ts
+++ b/apps/webui/src/lib/workspace-utils.ts
@@ -1,4 +1,5 @@
 import type { ChatSession } from "@/lib/chat-store";
+import { compareTimestampsByRecency } from "@/lib/session-order";
 import { getPathBasename } from "@/lib/ui-utils";
 
 export type WorkspaceSummary = {
@@ -6,12 +7,6 @@ export type WorkspaceSummary = {
 	cwd: string;
 	label: string;
 	updatedAt?: string;
-};
-
-const compareWorkspaceUpdatedAt = (left?: string, right?: string) => {
-	const leftStamp = left ?? "";
-	const rightStamp = right ?? "";
-	return rightStamp.localeCompare(leftStamp);
 };
 
 /**
@@ -49,7 +44,7 @@ export const collectWorkspaces = (
 			continue;
 		}
 
-		if (compareWorkspaceUpdatedAt(existing.updatedAt, updatedAt) > 0) {
+		if (compareTimestampsByRecency(existing.updatedAt, updatedAt) > 0) {
 			byCwd.set(groupKey, {
 				...existing,
 				updatedAt,
@@ -58,6 +53,6 @@ export const collectWorkspaces = (
 	}
 
 	return Array.from(byCwd.values()).sort((left, right) =>
-		compareWorkspaceUpdatedAt(left.updatedAt, right.updatedAt),
+		compareTimestampsByRecency(left.updatedAt, right.updatedAt),
 	);
 };

--- a/apps/webui/tests/chat-store.test.ts
+++ b/apps/webui/tests/chat-store.test.ts
@@ -35,13 +35,22 @@ describe("useChatStore", () => {
 	});
 
 	it("creates a local session when missing", () => {
+		const createdAt = "2025-01-01T00:00:00Z";
+		const updatedAt = "2025-01-01T00:00:00Z";
+
 		useChatStore.getState().createLocalSession("session-1", {
 			title: "Test conversation",
+			createdAt,
+			updatedAt,
+			isCreating: true,
 		});
 
 		const session = useChatStore.getState().sessions["session-1"];
 		expect(session).toBeTruthy();
 		expect(session.title).toBe("Test conversation");
+		expect(session.createdAt).toBe(createdAt);
+		expect(session.updatedAt).toBe(updatedAt);
+		expect(session.isCreating).toBe(true);
 		expect(session.isAttached).toBe(false);
 	});
 
@@ -125,9 +134,13 @@ describe("useChatStore", () => {
 
 	describe("handleSessionsChanged", () => {
 		it("adds new sessions from payload", () => {
+			const createdAt = "2025-02-01T00:00:00Z";
+			const updatedAt = "2025-02-01T01:00:00Z";
 			const newSession = createMockSessionSummary({
 				sessionId: "new-session-1",
 				title: "New Session",
+				createdAt,
+				updatedAt,
 				cwd: "/home/user/project",
 				machineId: "machine-1",
 			});
@@ -141,6 +154,9 @@ describe("useChatStore", () => {
 			const session = useChatStore.getState().sessions["new-session-1"];
 			expect(session).toBeTruthy();
 			expect(session.title).toBe("New Session");
+			expect(session.createdAt).toBe(createdAt);
+			expect(session.updatedAt).toBe(updatedAt);
+			expect(session.isCreating).toBe(false);
 			expect(session.cwd).toBe("/home/user/project");
 			expect(session.machineId).toBe("machine-1");
 		});

--- a/apps/webui/tests/session-sidebar.test.tsx
+++ b/apps/webui/tests/session-sidebar.test.tsx
@@ -257,6 +257,61 @@ describe("SessionSidebar", () => {
 		expect(screen.getByText(/1h ago/)).toBeInTheDocument();
 	});
 
+	it("limits the default visible session count and expands on demand", async () => {
+		const user = userEvent.setup();
+		const sessions = Array.from({ length: 9 }, (_, index) =>
+			buildSession({
+				sessionId: `session-${index + 1}`,
+				title: `Session ${index + 1}`,
+				backendId: "backend-a",
+				backendLabel: "Backend Alpha",
+				createdAt: `2024-01-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+				updatedAt: `2024-01-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+			}),
+		);
+
+		renderSidebar(sessions);
+
+		expect(screen.getByText("Session 9")).toBeInTheDocument();
+		expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole("button", {
+				name: i18n.t("session.showMore", { count: 1 }),
+			}),
+		);
+
+		expect(screen.getByText("Session 1")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", {
+				name: i18n.t("session.showLess"),
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("does not render empty group headers beyond the default limit", () => {
+		const sessions = Array.from({ length: 9 }, (_, index) =>
+			buildSession({
+				sessionId: `session-group-${index + 1}`,
+				title: `Grouped Session ${index + 1}`,
+				backendId: `backend-${index + 1}`,
+				backendLabel: `Backend ${index + 1}`,
+				createdAt: `2024-02-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+				updatedAt: `2024-02-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+			}),
+		);
+
+		renderSidebar(sessions);
+
+		expect(screen.getByText("Backend 9")).toBeInTheDocument();
+		expect(screen.queryByText("Backend 1")).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", {
+				name: i18n.t("session.showMore", { count: 1 }),
+			}),
+		).toBeInTheDocument();
+	});
+
 	it("shows status tooltip for loading session", () => {
 		renderSidebar([
 			buildSession({


### PR DESCRIPTION
## Summary
- add a default collapsed limit for long session lists with a show more/show less control
- stabilize session and workspace ordering with a shared recency comparator and ensure new sessions get timestamps immediately
- add regression coverage for optimistic creation, incremental session sync, and sidebar truncation behavior

## Testing
- pnpm -C apps/webui test:run -- tests/session-sidebar.test.tsx tests/chat-store.test.ts src/hooks/__tests__/useSessionMutations.test.tsx
- pnpm format
- pnpm lint
- pnpm build