### PR TITLE
fix(cli): handle Windows Bun virtual entrypoint in daemon respawn

### DIFF
--- a/apps/mobvibe-cli/src/daemon/__tests__/spawn-utils.test.ts
+++ b/apps/mobvibe-cli/src/daemon/__tests__/spawn-utils.test.ts
@@ -33,6 +33,16 @@ describe("buildForegroundSpawnArgs", () => {
 		).toEqual(["start", "--foreground"]);
 	});
 
+	test("drops Windows Bun virtual entrypoint from compiled binary argv", () => {
+		expect(
+			buildForegroundSpawnArgs([
+				"B:/Users/demo/AppData/Local/npx/_npx123/node_modules/@mobvibe/cli-win32-x64/bin/mobvibe.exe",
+				"B:/~BUN/root/mobvibe.exe",
+				"start",
+			]),
+		).toEqual(["start", "--foreground"]);
+	});
+
 	test("removes existing foreground flags before re-adding", () => {
 		expect(
 			buildForegroundSpawnArgs([

--- a/apps/mobvibe-cli/src/daemon/spawn-utils.ts
+++ b/apps/mobvibe-cli/src/daemon/spawn-utils.ts
@@ -1,7 +1,7 @@
 const FOREGROUND_FLAGS = new Set(["--foreground", "-f"]);
 
 const isBunVirtualEntrypoint = (arg: string): boolean =>
-	arg.startsWith("/$bunfs/");
+	arg.startsWith("/$bunfs/") || /^[A-Za-z]:\/~BUN\//.test(arg);
 
 export const buildForegroundSpawnArgs = (execArgv: string[]): string[] => {
 	const scriptOrCommandArg = execArgv[1];


### PR DESCRIPTION
## Summary
- recognize Bun's Windows virtual entrypoint path when rebuilding daemon foreground args
- prevent the compiled binary path from leaking into the respawned command on Windows
- add a regression test for the `B:/~BUN/...` argv shape reported in the issue

## Testing
- `pnpm format`
- `pnpm lint` (passes with existing warnings in `apps/mobvibe-cli/src/registry/agent-detector.ts` and `apps/webui` accessibility warnings)
- `pnpm build`
- `pnpm -C apps/mobvibe-cli test -- src/daemon/__tests__/spawn-utils.test.ts`

Closes #81
