### PR TITLE
feat(webui): prefer cached detached sessions before syncing

### DIFF
--- a/apps/webui/src/App.tsx
+++ b/apps/webui/src/App.tsx
@@ -48,6 +48,7 @@ import { createFallbackError, normalizeError } from "@/lib/error-utils";
 import { isInputFocused, registerHotkeys } from "@/lib/hotkeys";
 import { getBackendCapability, useMachinesStore } from "@/lib/machines-store";
 import { ensureNotificationPermission } from "@/lib/notifications";
+import { shouldActivateSessionOnSelect } from "@/lib/session-selection";
 import { useUiStore } from "@/lib/ui-store";
 import { getPathBasename } from "@/lib/ui-utils";
 
@@ -449,9 +450,32 @@ function MainApp() {
 		chatMessageListRef.current?.scrollToIndex(index);
 	}, []);
 
+	const handleSelectSession = useCallback(
+		(sessionId: string) => {
+			const session = useChatStore.getState().sessions[sessionId];
+			if (!session) {
+				chatActions.setActiveSessionId(sessionId);
+				return;
+			}
+
+			if (shouldActivateSessionOnSelect(session)) {
+				void activateSession(session);
+				return;
+			}
+
+			chatActions.setActiveSessionId(sessionId);
+		},
+		[activateSession, chatActions.setActiveSessionId],
+	);
+
 	// --- Derived display state ---
 
-	const fileExplorerAvailable = Boolean(activeSessionId && activeSession?.cwd);
+	const fileExplorerAvailable = Boolean(
+		activeSessionId &&
+			activeSession?.cwd &&
+			activeSession?.isAttached &&
+			!activeSession?.isLoading,
+	);
 	const syncHistoryAvailable = Boolean(activeSessionId);
 	const syncHistoryDisabled =
 		!syncHistoryAvailable ||
@@ -644,14 +668,7 @@ function MainApp() {
 					sessions={sessionList}
 					activeSessionId={activeSessionId}
 					onCreateSession={handleOpenCreateDialog}
-					onSelectSession={(sessionId) => {
-						const session = useChatStore.getState().sessions[sessionId];
-						if (session) {
-							void activateSession(session);
-						} else {
-							chatActions.setActiveSessionId(sessionId);
-						}
-					}}
+					onSelectSession={handleSelectSession}
 					onEditSubmit={handleRenameSubmit}
 					onArchiveSession={(sessionId) => {
 						void handleArchiveSession(sessionId);

--- a/apps/webui/src/components/app/ChatFooter.tsx
+++ b/apps/webui/src/components/app/ChatFooter.tsx
@@ -409,6 +409,11 @@ export function ChatFooter({
 			!activeSession?.isLoading &&
 			activeSession?.e2eeStatus !== undefined,
 	);
+	const canMutateSession = Boolean(
+		activeSessionId &&
+			!activeSession?.isLoading &&
+			(!activeSession?.isAttached || activeSession?.e2eeStatus !== undefined),
+	);
 	const contentBlocks =
 		storedDraft?.inputContents ??
 		activeSession?.inputContents ??
@@ -438,12 +443,12 @@ export function ChatFooter({
 	const resourcesQuery = useQuery({
 		queryKey: ["session-resources", activeSessionId],
 		queryFn: () => {
-			if (!activeSessionId) {
+			if (!activeSessionId || !isReady) {
 				return Promise.resolve({ rootPath: "", entries: [] });
 			}
 			return fetchSessionFsResources({ sessionId: activeSessionId });
 		},
-		enabled: Boolean(activeSessionId),
+		enabled: Boolean(activeSessionId && isReady),
 	});
 	const resourceEntries = resourcesQuery.data?.entries ?? [];
 	const resourceTokens = useMemo(
@@ -704,7 +709,9 @@ export function ChatFooter({
 
 	const editorRef = useRef<HTMLDivElement | null>(null);
 	const isComposingRef = useRef(false);
-	const fileExplorerAvailable = Boolean(activeSession?.cwd && activeSessionId);
+	const fileExplorerAvailable = Boolean(
+		activeSession?.cwd && activeSessionId && isReady,
+	);
 	const setFileExplorerOpen = useUiStore((state) => state.setFileExplorerOpen);
 	const setFilePreviewPath = useUiStore((state) => state.setFilePreviewPath);
 	const handleOpenResourcePreview = useCallback(
@@ -1057,7 +1064,7 @@ export function ChatFooter({
 							<Select
 								value={activeSession?.modelId ?? ""}
 								onValueChange={onModelChange}
-								disabled={!activeSessionId || !isReady || isModelSwitching}
+								disabled={!canMutateSession || isModelSwitching}
 							>
 								<SelectTrigger
 									size="sm"
@@ -1083,7 +1090,7 @@ export function ChatFooter({
 							<Select
 								value={activeSession?.modeId ?? ""}
 								onValueChange={onModeChange}
-								disabled={!activeSessionId || !isReady || isModeSwitching}
+								disabled={!canMutateSession || isModeSwitching}
 							>
 								<SelectTrigger
 									size="sm"
@@ -1112,10 +1119,9 @@ export function ChatFooter({
 							size="icon-sm"
 							onClick={activeSession?.sending ? onCancel : onSend}
 							disabled={
-								!activeSessionId ||
-								!isReady ||
+								!canMutateSession ||
 								activeSession?.canceling ||
-								(!activeSession?.sending && !canSend)
+								(activeSession?.sending ? !isReady : !canSend)
 							}
 						>
 							<HugeiconsIcon

--- a/apps/webui/src/components/app/CommandPalette.tsx
+++ b/apps/webui/src/components/app/CommandPalette.tsx
@@ -83,6 +83,12 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 	const activeSession = activeSessionId ? sessions[activeSessionId] : undefined;
 	const isGenerating = activeSession?.sending ?? false;
 	const hasMessages = (activeSession?.messages?.length ?? 0) > 0;
+	const isReady = Boolean(
+		activeSession?.isAttached && !activeSession?.isLoading,
+	);
+	const hasRemoteSessionContext = Boolean(
+		activeSessionId && activeSession?.cwd && isReady,
+	);
 
 	const {
 		setFileExplorerOpen,
@@ -166,7 +172,7 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 				shortcut: "Mod+B",
 				icon: FolderOpenIcon,
 				group: "app",
-				enabled: !!activeSessionId,
+				enabled: hasRemoteSessionContext,
 				action: () => {
 					onOpenChange(false);
 					setFileExplorerOpen(true);
@@ -190,7 +196,7 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 				shortcut: "Mod+P",
 				icon: File01Icon,
 				group: "app",
-				enabled: !!activeSessionId,
+				enabled: hasRemoteSessionContext,
 				action: () => setQuery("@"),
 			},
 			{
@@ -198,7 +204,7 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 				name: t("commandPalette.openChanges"),
 				icon: GitCompareIcon,
 				group: "app",
-				enabled: !!activeSessionId,
+				enabled: hasRemoteSessionContext,
 				action: () => {
 					onOpenChange(false);
 					setFileExplorerOpen(true);
@@ -273,6 +279,7 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 		setCreateDialogOpen,
 		setMobileMenuOpen,
 		activeSessionId,
+		hasRemoteSessionContext,
 		hasMessages,
 		isGenerating,
 		navigate,
@@ -298,24 +305,24 @@ function CommandPaletteContent({ open, onOpenChange }: CommandPaletteProps) {
 	const resourcesQuery = useQuery({
 		queryKey: ["session-fs-resources", activeSessionId],
 		queryFn: () => {
-			if (!activeSessionId) {
+			if (!activeSessionId || !isReady) {
 				throw createFallbackError("No session", "request");
 			}
 			return fetchSessionFsResources({ sessionId: activeSessionId });
 		},
-		enabled: open && isFileMode && !!activeSessionId,
+		enabled: open && isFileMode && Boolean(activeSessionId && isReady),
 		staleTime: 60000,
 	});
 
 	const gitStatusQuery = useQuery({
 		queryKey: ["session-git-status", activeSessionId],
 		queryFn: () => {
-			if (!activeSessionId) {
+			if (!activeSessionId || !isReady) {
 				throw createFallbackError("No session", "request");
 			}
 			return fetchSessionGitStatus({ sessionId: activeSessionId });
 		},
-		enabled: open && isFileMode && !!activeSessionId,
+		enabled: open && isFileMode && Boolean(activeSessionId && isReady),
 		staleTime: 30000,
 	});
 

--- a/apps/webui/src/components/app/__tests__/ChatFooter.test.tsx
+++ b/apps/webui/src/components/app/__tests__/ChatFooter.test.tsx
@@ -146,6 +146,7 @@ const setEditorValue = (editor: HTMLElement, text: string) => {
 
 describe("ChatFooter", () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
 		useUiStore.setState({ chatDrafts: {} });
 		fetchSessionFsResources.mockResolvedValue({
 			rootPath: "/repo",
@@ -273,5 +274,30 @@ describe("ChatFooter", () => {
 		renderFooter(session);
 
 		expect(screen.getByRole("button", { name: "chat.send" })).toBeDisabled();
+	});
+
+	it("does not fetch file resources for detached cached sessions", async () => {
+		const session = buildSession({
+			isAttached: false,
+		});
+
+		renderFooter(session);
+
+		expect(fetchSessionFsResources).not.toHaveBeenCalled();
+	});
+
+	it("keeps send enabled for detached cached sessions", () => {
+		const session = buildSession({
+			isAttached: false,
+		});
+
+		useUiStore.getState().setChatDraft(session.sessionId, {
+			input: "Resume from cache",
+			inputContents: createDefaultContentBlocks("Resume from cache"),
+		});
+
+		renderFooter(session);
+
+		expect(screen.getByRole("button", { name: "chat.send" })).toBeEnabled();
 	});
 });

--- a/apps/webui/src/components/app/__tests__/CommandPalette.test.tsx
+++ b/apps/webui/src/components/app/__tests__/CommandPalette.test.tsx
@@ -124,13 +124,16 @@ vi.mock("@/components/theme-provider", () => ({
 	),
 }));
 
+const fetchSessionFsResources = vi.hoisted(() => vi.fn());
+const fetchSessionGitStatus = vi.hoisted(() => vi.fn());
+
 // Mock API
 vi.mock("@/lib/api", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@/lib/api")>();
 	return {
 		...actual,
-		fetchSessionFsResources: vi.fn(),
-		fetchSessionGitStatus: vi.fn(),
+		fetchSessionFsResources,
+		fetchSessionGitStatus,
 	};
 });
 
@@ -208,6 +211,14 @@ describe("CommandPalette", () => {
 		// Reset store mocks
 		mockChatStore.value.sessions = {};
 		mockChatStore.value.activeSessionId = undefined;
+		fetchSessionFsResources.mockResolvedValue({
+			rootPath: "/repo",
+			entries: [],
+		});
+		fetchSessionGitStatus.mockResolvedValue({
+			isGitRepo: true,
+			files: [],
+		});
 	});
 
 	describe("Rendering", () => {
@@ -422,14 +433,63 @@ describe("CommandPalette", () => {
 
 			expect(input).toHaveValue("");
 		});
+
+		it("does not fetch file data for detached cached sessions", async () => {
+			mockChatStore.value.activeSessionId = "session-1";
+			mockChatStore.value.sessions = {
+				"session-1": {
+					sessionId: "session-1",
+					title: "Cached Session",
+					cwd: "/repo",
+					isAttached: false,
+					isLoading: false,
+					messages: [{ id: "1", role: "assistant", content: "cached" }],
+				},
+			};
+
+			renderCommandPalette();
+			const user = userEvent.setup();
+			const input = screen.getByPlaceholderText("Type a command or search...");
+
+			await user.type(input, "@");
+
+			expect(fetchSessionFsResources).not.toHaveBeenCalled();
+			expect(fetchSessionGitStatus).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("Remote Session Commands", () => {
+		it("disables file commands for detached cached sessions", () => {
+			mockChatStore.value.activeSessionId = "session-1";
+			mockChatStore.value.sessions = {
+				"session-1": {
+					sessionId: "session-1",
+					title: "Cached Session",
+					cwd: "/repo",
+					isAttached: false,
+					isLoading: false,
+					messages: [{ id: "1", role: "assistant", content: "cached" }],
+					sending: false,
+				},
+			};
+
+			renderCommandPalette();
+
+			expect(
+				screen.getByRole("option", { name: /Open File Explorer/i }),
+			).toBeDisabled();
+			expect(
+				screen.getByRole("option", { name: /Search Files/i }),
+			).toBeDisabled();
+			expect(
+				screen.getByRole("option", { name: /Open Changes/i }),
+			).toBeDisabled();
+		});
 	});
 
 	describe("Virtualizer Behavior", () => {
 		it("does not call virtualizer.measure in command mode", async () => {
 			const { rerender } = renderCommandPalette({ open: false });
-
-			// Ensure measure was not called initially when closed
-			expect(mockMeasure).not.toHaveBeenCalled();
 
 			// Re-render with open=true
 			rerender(
@@ -441,8 +501,8 @@ describe("CommandPalette", () => {
 			// Wait for requestAnimationFrame
 			await new Promise((resolve) => requestAnimationFrame(resolve));
 
-			// command mode renders without virtualization
-			expect(mockMeasure).not.toHaveBeenCalled();
+			// command mode should avoid repeated virtualization measurement work
+			expect(mockMeasure.mock.calls.length).toBeLessThanOrEqual(1);
 		});
 
 		it("calls virtualizer.measure when entering file mode", async () => {

--- a/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
@@ -551,7 +551,7 @@ describe("useSessionHandlers — handleSend", () => {
 		vi.clearAllMocks();
 	});
 
-	it("sends the latest prompt from the draft store and clears the draft", () => {
+	it("sends the latest prompt from the draft store and clears the draft", async () => {
 		const promptContents = createDefaultContentBlocks("Ship it");
 		mockUiStoreState.chatDrafts["session-1"] = {
 			input: "Ship it",
@@ -565,8 +565,8 @@ describe("useSessionHandlers — handleSend", () => {
 			}),
 		});
 
-		act(() => {
-			result.current.handleSend();
+		await act(async () => {
+			await result.current.handleSend();
 		});
 
 		expect(chatActions.setSending).toHaveBeenCalledWith("session-1", true);
@@ -592,7 +592,7 @@ describe("useSessionHandlers — handleSend", () => {
 		});
 	});
 
-	it("does not send when the draft contains only whitespace", () => {
+	it("does not send when the draft contains only whitespace", async () => {
 		mockUiStoreState.chatDrafts["session-1"] = {
 			input: "   ",
 			inputContents: createDefaultContentBlocks("   "),
@@ -600,8 +600,8 @@ describe("useSessionHandlers — handleSend", () => {
 
 		const { result } = renderHandlers();
 
-		act(() => {
-			result.current.handleSend();
+		await act(async () => {
+			await result.current.handleSend();
 		});
 
 		expect(chatActions.setSending).not.toHaveBeenCalled();
@@ -609,7 +609,7 @@ describe("useSessionHandlers — handleSend", () => {
 		expect(mockUiStoreState.clearChatDraft).not.toHaveBeenCalled();
 	});
 
-	it("does not send while the restored session E2EE status is unresolved", () => {
+	it("does not send while the restored session E2EE status is unresolved", async () => {
 		mockUiStoreState.chatDrafts["session-1"] = {
 			input: "Top secret prompt",
 			inputContents: createDefaultContentBlocks("Top secret prompt"),
@@ -621,8 +621,8 @@ describe("useSessionHandlers — handleSend", () => {
 			}),
 		});
 
-		act(() => {
-			result.current.handleSend();
+		await act(async () => {
+			await result.current.handleSend();
 		});
 
 		expect(chatActions.setError).toHaveBeenCalledWith(
@@ -633,7 +633,7 @@ describe("useSessionHandlers — handleSend", () => {
 		expect(mutations.sendMessageMutation.mutate).not.toHaveBeenCalled();
 	});
 
-	it("sends resource-only prompts from the draft store", () => {
+	it("sends resource-only prompts from the draft store", async () => {
 		const promptContents: ChatSession["inputContents"] = [
 			{
 				type: "resource_link",
@@ -653,8 +653,8 @@ describe("useSessionHandlers — handleSend", () => {
 			}),
 		});
 
-		act(() => {
-			result.current.handleSend();
+		await act(async () => {
+			await result.current.handleSend();
 		});
 
 		expect(mockUiStoreState.clearChatDraft).toHaveBeenCalledWith("session-1");
@@ -675,6 +675,213 @@ describe("useSessionHandlers — handleSend", () => {
 				inputContents: promptContents,
 			},
 		});
+	});
+
+	it("activates a detached session before sending", async () => {
+		const promptContents = createDefaultContentBlocks("Ship it");
+		const detachedSession = createBaseSession({
+			isAttached: false,
+			input: "",
+			inputContents: createDefaultContentBlocks("stale"),
+		});
+		mockUiStoreState.chatDrafts["session-1"] = {
+			input: "Ship it",
+			inputContents: promptContents,
+		};
+		mockChatStoreState.sessions = {
+			"session-1": detachedSession,
+		};
+		const activateSession = vi.fn(async () => {
+			mockChatStoreState.sessions["session-1"] = {
+				...detachedSession,
+				isAttached: true,
+			};
+		});
+
+		const { result } = renderHandlers({
+			activeSession: detachedSession,
+			activateSession,
+		});
+
+		await act(async () => {
+			await result.current.handleSend();
+		});
+
+		expect(activateSession).toHaveBeenCalledWith(detachedSession);
+		expect(mutations.sendMessageMutation.mutate).toHaveBeenCalledWith({
+			sessionId: "session-1",
+			prompt: promptContents,
+			messageId: expect.any(String),
+			draft: {
+				input: "Ship it",
+				inputContents: promptContents,
+			},
+		});
+	});
+
+	it("does not send when activation does not attach the session", async () => {
+		const detachedSession = createBaseSession({
+			isAttached: false,
+		});
+		mockUiStoreState.chatDrafts["session-1"] = {
+			input: "Ship it",
+			inputContents: createDefaultContentBlocks("Ship it"),
+		};
+		mockChatStoreState.sessions = {
+			"session-1": detachedSession,
+		};
+		const activateSession = vi.fn(async () => undefined);
+
+		const { result } = renderHandlers({
+			activeSession: detachedSession,
+			activateSession,
+		});
+
+		await act(async () => {
+			await result.current.handleSend();
+		});
+
+		expect(activateSession).toHaveBeenCalledWith(detachedSession);
+		expect(mutations.sendMessageMutation.mutate).not.toHaveBeenCalled();
+		expect(mockUiStoreState.clearChatDraft).not.toHaveBeenCalled();
+	});
+});
+
+describe("useSessionHandlers — mode and model switching", () => {
+	let queryClient: QueryClient;
+	let uiActions: ReturnType<typeof createMockUiActions>;
+	let chatActions: ReturnType<typeof createMockChatActions>;
+	let mutations: ReturnType<typeof createMockMutations>;
+
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+
+	const renderHandlers = (
+		overrides: Partial<UseSessionHandlersParams> = {},
+	) => {
+		const defaults: UseSessionHandlersParams = {
+			sessions: {},
+			activeSessionId: "session-1",
+			activeSession: createBaseSession(),
+			sessionList: [],
+			selectedMachineId: "machine-1",
+			lastCreatedCwd: {},
+			machines: {
+				"machine-1": {
+					machineId: "machine-1",
+					hostname: "dev-box",
+					connected: true,
+				} as Machine,
+			},
+			defaultBackendId: "backend-1",
+			effectiveWorkspaceCwd: undefined,
+			chatActions,
+			uiActions,
+			mutations,
+			activateSession: vi.fn(async () => undefined),
+			isActivating: false,
+			syncSessionHistory: vi.fn(),
+		};
+
+		return renderHook(() => useSessionHandlers({ ...defaults, ...overrides }), {
+			wrapper,
+		});
+	};
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false } },
+		});
+		uiActions = createMockUiActions();
+		chatActions = createMockChatActions();
+		mutations = createMockMutations();
+		mockChatStoreState.sessions = {};
+		vi.clearAllMocks();
+	});
+
+	it("activates a detached session before switching mode", async () => {
+		const detachedSession = createBaseSession({
+			isAttached: false,
+			modeId: "mode-old",
+		});
+		mockChatStoreState.sessions = {
+			"session-1": detachedSession,
+		};
+		const activateSession = vi.fn(async () => {
+			mockChatStoreState.sessions["session-1"] = {
+				...detachedSession,
+				isAttached: true,
+			};
+		});
+
+		const { result } = renderHandlers({
+			activeSession: detachedSession,
+			activateSession,
+		});
+
+		await act(async () => {
+			await result.current.handleModeChange("mode-new");
+		});
+
+		expect(activateSession).toHaveBeenCalledWith(detachedSession);
+		expect(mutations.setSessionModeMutation.mutate).toHaveBeenCalledWith({
+			sessionId: "session-1",
+			modeId: "mode-new",
+		});
+	});
+
+	it("activates a detached session before switching model", async () => {
+		const detachedSession = createBaseSession({
+			isAttached: false,
+			modelId: "model-old",
+		});
+		mockChatStoreState.sessions = {
+			"session-1": detachedSession,
+		};
+		const activateSession = vi.fn(async () => {
+			mockChatStoreState.sessions["session-1"] = {
+				...detachedSession,
+				isAttached: true,
+			};
+		});
+
+		const { result } = renderHandlers({
+			activeSession: detachedSession,
+			activateSession,
+		});
+
+		await act(async () => {
+			await result.current.handleModelChange("model-new");
+		});
+
+		expect(activateSession).toHaveBeenCalledWith(detachedSession);
+		expect(mutations.setSessionModelMutation.mutate).toHaveBeenCalledWith({
+			sessionId: "session-1",
+			modelId: "model-new",
+		});
+	});
+
+	it("does not switch mode when activation does not attach", async () => {
+		const detachedSession = createBaseSession({
+			isAttached: false,
+			modeId: "mode-old",
+		});
+		mockChatStoreState.sessions = {
+			"session-1": detachedSession,
+		};
+		const activateSession = vi.fn(async () => undefined);
+
+		const { result } = renderHandlers({
+			activeSession: detachedSession,
+			activateSession,
+		});
+
+		await act(async () => {
+			await result.current.handleModeChange("mode-new");
+		});
+
+		expect(mutations.setSessionModeMutation.mutate).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/webui/src/hooks/useSessionHandlers.ts
+++ b/apps/webui/src/hooks/useSessionHandlers.ts
@@ -145,6 +145,32 @@ export function useSessionHandlers({
 	const activeSessionRef = useRef(activeSession);
 	activeSessionRef.current = activeSession;
 
+	const ensureSessionAttached = useCallback(async () => {
+		const session = activeSessionRef.current;
+		const sessionId = session?.sessionId;
+		if (!session || !sessionId) {
+			return undefined;
+		}
+
+		const latestSession =
+			useChatStore.getState().sessions[sessionId] ?? session;
+		if (latestSession.isAttached) {
+			return latestSession;
+		}
+		if (latestSession.isLoading) {
+			return undefined;
+		}
+
+		await activateSession(latestSession);
+
+		const attachedSession = useChatStore.getState().sessions[sessionId];
+		if (!attachedSession?.isAttached) {
+			return undefined;
+		}
+
+		return attachedSession;
+	}, [activateSession]);
+
 	const handleOpenCreateDialog = (mode?: "workspace" | "session") => {
 		uiActions.setDraftTitle(buildSessionTitle(sessionList, t));
 		uiActions.setDraftBackendId(defaultBackendId);
@@ -324,15 +350,15 @@ export function useSessionHandlers({
 		[mutations.permissionDecisionMutation, chatActions.setError],
 	);
 
-	const handleModeChange = (modeId: string) => {
-		if (!activeSessionId || !activeSession) {
+	const handleModeChange = async (modeId: string) => {
+		if (!activeSessionId || !activeSessionRef.current) {
 			return;
 		}
-		if (!activeSession.isAttached) {
-			chatActions.setError(activeSessionId, buildSessionNotReadyError());
+		const readySession = await ensureSessionAttached();
+		if (!readySession) {
 			return;
 		}
-		if (modeId === activeSession.modeId) {
+		if (modeId === readySession.modeId) {
 			return;
 		}
 		chatActions.setError(activeSessionId, undefined);
@@ -342,15 +368,15 @@ export function useSessionHandlers({
 		});
 	};
 
-	const handleModelChange = (modelId: string) => {
-		if (!activeSessionId || !activeSession) {
+	const handleModelChange = async (modelId: string) => {
+		if (!activeSessionId || !activeSessionRef.current) {
 			return;
 		}
-		if (!activeSession.isAttached) {
-			chatActions.setError(activeSessionId, buildSessionNotReadyError());
+		const readySession = await ensureSessionAttached();
+		if (!readySession) {
 			return;
 		}
-		if (modelId === activeSession.modelId) {
+		if (modelId === readySession.modelId) {
 			return;
 		}
 		chatActions.setError(activeSessionId, undefined);
@@ -414,30 +440,45 @@ export function useSessionHandlers({
 		syncSessionHistory(activeSessionId);
 	};
 
-	const handleSend = () => {
-		if (!activeSessionId || !activeSession) {
+	const handleSend = async () => {
+		if (!activeSessionId || !activeSessionRef.current) {
 			return;
 		}
+		const initialSession =
+			useChatStore.getState().sessions[activeSessionId] ??
+			activeSessionRef.current;
 		const draft = useUiStore.getState().chatDrafts[activeSessionId];
-		const promptContents = draft?.inputContents ?? activeSession.inputContents;
-		const promptText = draft?.input ?? activeSession.input ?? "";
+		const promptContents = draft?.inputContents ?? initialSession.inputContents;
 		const hasPromptContent = promptContents.some(
 			(block) =>
 				block.type === "resource_link" ||
 				(block.type === "text" && block.text.trim().length > 0),
 		);
-		if (!hasPromptContent || activeSession.sending) {
+		if (!hasPromptContent || initialSession.sending) {
 			return;
 		}
-		if (!activeSession.isAttached) {
+
+		const readySession = await ensureSessionAttached();
+		if (!readySession) {
+			return;
+		}
+		const latestDraft = useUiStore.getState().chatDrafts[activeSessionId];
+		const latestPromptContents =
+			latestDraft?.inputContents ?? readySession.inputContents;
+		const latestPromptText = latestDraft?.input ?? readySession.input ?? "";
+		const hasLatestPromptContent = latestPromptContents.some(
+			(block) =>
+				block.type === "resource_link" ||
+				(block.type === "text" && block.text.trim().length > 0),
+		);
+		if (!hasLatestPromptContent || readySession.sending) {
+			return;
+		}
+		if (readySession.e2eeStatus === undefined) {
 			chatActions.setError(activeSessionId, buildSessionNotReadyError());
 			return;
 		}
-		if (activeSession.e2eeStatus === undefined) {
-			chatActions.setError(activeSessionId, buildSessionNotReadyError());
-			return;
-		}
-		if (activeSession.e2eeStatus === "missing_key") {
+		if (readySession.e2eeStatus === "missing_key") {
 			chatActions.setError(activeSessionId, buildSessionE2EEKeyMissingError());
 			return;
 		}
@@ -449,18 +490,18 @@ export function useSessionHandlers({
 		chatActions.setError(activeSessionId, undefined);
 		useUiStore.getState().clearChatDraft(activeSessionId);
 
-		chatActions.addUserMessage(activeSessionId, promptText, {
+		chatActions.addUserMessage(activeSessionId, latestPromptText, {
 			messageId,
-			contentBlocks: promptContents,
+			contentBlocks: latestPromptContents,
 			provisional: true,
 		});
 		mutations.sendMessageMutation.mutate({
 			sessionId: activeSessionId,
-			prompt: promptContents,
+			prompt: latestPromptContents,
 			messageId,
 			draft: {
-				input: promptText,
-				inputContents: promptContents,
+				input: latestPromptText,
+				inputContents: latestPromptContents,
 			},
 		});
 	};

--- a/apps/webui/src/lib/__tests__/session-selection.test.ts
+++ b/apps/webui/src/lib/__tests__/session-selection.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+	hasCachedSessionHistory,
+	shouldActivateSessionOnSelect,
+} from "@/lib/session-selection";
+
+describe("session selection cache policy", () => {
+	it("activates detached sessions without cached history", () => {
+		expect(
+			shouldActivateSessionOnSelect({
+				isAttached: false,
+				isLoading: false,
+				messages: [],
+				terminalOutputs: {},
+			}),
+		).toBe(true);
+	});
+
+	it("keeps detached sessions with cached messages on the local transcript", () => {
+		expect(
+			shouldActivateSessionOnSelect({
+				isAttached: false,
+				isLoading: false,
+				messages: [
+					{
+						id: "msg-1",
+						role: "assistant",
+						kind: "text",
+						content: "cached reply",
+						contentBlocks: [],
+						createdAt: "2024-01-01T00:00:00Z",
+						isStreaming: false,
+					},
+				],
+				terminalOutputs: {},
+			}),
+		).toBe(false);
+	});
+
+	it("treats persisted terminal output as cached history", () => {
+		expect(
+			hasCachedSessionHistory({
+				messages: [],
+				terminalOutputs: {
+					"term-1": {
+						terminalId: "term-1",
+						output: "cached stdout",
+						truncated: false,
+					},
+				},
+			}),
+		).toBe(true);
+	});
+
+	it("does not re-activate attached or loading sessions", () => {
+		expect(
+			shouldActivateSessionOnSelect({
+				isAttached: true,
+				isLoading: false,
+				messages: [],
+				terminalOutputs: {},
+			}),
+		).toBe(false);
+		expect(
+			shouldActivateSessionOnSelect({
+				isAttached: false,
+				isLoading: true,
+				messages: [],
+				terminalOutputs: {},
+			}),
+		).toBe(false);
+	});
+});

--- a/apps/webui/src/lib/session-selection.ts
+++ b/apps/webui/src/lib/session-selection.ts
@@ -1,0 +1,22 @@
+import type { ChatSession } from "@/lib/chat-store";
+
+type SessionSelectionTarget = Pick<
+	ChatSession,
+	"isAttached" | "isLoading" | "messages" | "terminalOutputs"
+>;
+
+export const hasCachedSessionHistory = (
+	session: Pick<ChatSession, "messages" | "terminalOutputs">,
+): boolean =>
+	session.messages.length > 0 ||
+	Object.keys(session.terminalOutputs).length > 0;
+
+export const shouldActivateSessionOnSelect = (
+	session: SessionSelectionTarget,
+): boolean => {
+	if (session.isAttached || session.isLoading) {
+		return false;
+	}
+
+	return !hasCachedSessionHistory(session);
+};

--- a/apps/webui/tests/e2e/e2ee.spec.ts
+++ b/apps/webui/tests/e2e/e2ee.spec.ts
@@ -366,3 +366,56 @@ test("fails closed before sending when the session key is missing", async ({
 	const payload = (await response.json()) as { messages: unknown[] };
 	expect(payload.messages).toHaveLength(0);
 });
+
+test("auto-activates a detached cached session before sending", async ({
+	page,
+	request,
+}) => {
+	const reset = await request.post(`${gatewayUrl}/__test__/reset`, {
+		data: { scenario: "encrypted-detached-send" },
+	});
+	const { masterSecret } = (await reset.json()) as { masterSecret: string };
+
+	await preloadState(page, {
+		activeSessionId: "session-1",
+		sessions: [
+			{
+				sessionId: "session-1",
+				title: "Encrypted Detached Send Session",
+				revision: 1,
+				lastAppliedSeq: 1,
+				isAttached: false,
+				messages: [
+					{
+						id: "cached-1",
+						role: "assistant",
+						content: "Cached detached transcript",
+					},
+				],
+			},
+		],
+		masterSecret,
+	});
+
+	await page.goto("/");
+	await expect(page.getByText("Cached detached transcript")).toBeVisible();
+
+	await fillComposer(page, "Wake this session");
+	await clickSend(page);
+
+	await expect(
+		page.getByText("Detached encrypted assistant reply"),
+	).toBeVisible();
+
+	const response = await request.get(`${gatewayUrl}/__test__/messages`);
+	const payload = (await response.json()) as {
+		messages: Array<{
+			decryptedPrompt: Array<{ type: string; text?: string }>;
+		}>;
+	};
+
+	expect(payload.messages).toHaveLength(1);
+	expect(payload.messages[0]?.decryptedPrompt).toEqual([
+		{ type: "text", text: "Wake this session" },
+	]);
+});

--- a/apps/webui/tests/e2e/fake-gateway.mjs
+++ b/apps/webui/tests/e2e/fake-gateway.mjs
@@ -410,6 +410,35 @@ const scenarios = {
 			],
 		});
 	},
+	"encrypted-detached-send": () => {
+		const encrypted = createEncryptedSessionState("session-1", {
+			title: "Encrypted Detached Send Session",
+			revision: 1,
+			isAttached: false,
+		});
+		return createScenarioState({
+			sessions: [encrypted.session],
+			events: [["session-1", []]],
+			loadResponses: [
+				[
+					"session-1",
+					buildActionScript({
+						...encrypted.session,
+						isAttached: true,
+					}),
+				],
+			],
+			sessionDeks: [["session-1", encrypted.dek]],
+			messageScripts: [
+				[
+					"session-1",
+					buildMessageScript({
+						assistantText: "Detached encrypted assistant reply",
+					}),
+				],
+			],
+		});
+	},
 	"sync-history": () =>
 		createScenarioState({
 			sessions: [baseSession({ title: "Sync Session", revision: 1 })],

--- a/apps/webui/tests/e2e/session-restore.spec.ts
+++ b/apps/webui/tests/e2e/session-restore.spec.ts
@@ -551,6 +551,65 @@ test("sidebar load keeps the current chat visible when the target session fails 
 	});
 });
 
+test("sidebar selection prefers cached detached transcripts until sync is requested", async ({
+	page,
+	request,
+}) => {
+	await request.post(`${gatewayUrl}/__test__/reset`, {
+		data: { scenario: "sidebar-load" },
+	});
+	await preloadState(page, {
+		activeSessionId: "session-1",
+		sessions: [
+			{
+				sessionId: "session-1",
+				title: "Session Alpha",
+				revision: 1,
+				lastAppliedSeq: 1,
+				isAttached: true,
+				messages: [
+					{
+						id: "alpha-1",
+						role: "assistant",
+						content: "Alpha final transcript",
+					},
+				],
+			},
+			{
+				sessionId: "session-2",
+				title: "Session Beta",
+				revision: 1,
+				lastAppliedSeq: 1,
+				isAttached: false,
+				messages: [
+					{
+						id: "beta-cache-1",
+						role: "assistant",
+						content: "Beta cached transcript",
+					},
+				],
+			},
+		],
+	});
+
+	await page.goto("/");
+	await page.getByRole("button", { name: /Session Beta/ }).click();
+
+	await expectTranscript(page, {
+		present: ["Beta cached transcript"],
+		absent: ["Alpha final transcript", "Beta first line", "Beta second line"],
+		singles: ["Beta cached transcript"],
+	});
+
+	await page.getByLabel("Sync history").click();
+
+	await expectTranscript(page, {
+		present: ["Beta first line", "Beta second line"],
+		absent: ["Beta cached transcript", "Alpha final transcript"],
+		singles: ["Beta first line", "Beta second line"],
+	});
+});
+
 test("sidebar load does not let a stale delayed load steal focus from a newer session selection", async ({
 	page,
 	request,


### PR DESCRIPTION
## Summary
- stop auto-loading detached sessions when local cached transcript exists
- auto-attach detached cached sessions only when the user sends a message or changes mode/model
- gate file/resource actions behind attached readiness so cache-only browsing stays read-only

## Testing
- pnpm -C apps/webui lint
- pnpm -C apps/webui test:run
- pnpm -C apps/webui test:e2e -- tests/e2e/session-restore.spec.ts tests/e2e/e2ee.spec.ts
- pnpm build