### PR TITLE
fix(webui): surface history sync state and failed sends

### DIFF
--- a/apps/webui/src/App.tsx
+++ b/apps/webui/src/App.tsx
@@ -94,6 +94,8 @@ function MainApp() {
 			setAppError: s.setAppError,
 			setLastCreatedCwd: s.setLastCreatedCwd,
 			setSessionLoading: s.setSessionLoading,
+			setHistorySyncing: s.setHistorySyncing,
+			setHistorySyncWarning: s.setHistorySyncWarning,
 			markSessionAttached: s.markSessionAttached,
 			markSessionDetached: s.markSessionDetached,
 			createLocalSession: s.createLocalSession,
@@ -111,6 +113,7 @@ function MainApp() {
 			appendAssistantChunk: s.appendAssistantChunk,
 			appendThoughtChunk: s.appendThoughtChunk,
 			confirmOrAppendUserMessage: s.confirmOrAppendUserMessage,
+			markUserMessageFailed: s.markUserMessageFailed,
 			finalizeAssistantMessage: s.finalizeAssistantMessage,
 			addPermissionRequest: s.addPermissionRequest,
 			setPermissionDecisionState: s.setPermissionDecisionState,
@@ -454,6 +457,7 @@ function MainApp() {
 		!syncHistoryAvailable ||
 		Boolean(
 			activeSession?.isLoading ||
+				activeSession?.historySyncing ||
 				isActivating ||
 				isForceReloading ||
 				(activeSessionId && isBackfilling(activeSessionId)),
@@ -470,7 +474,13 @@ function MainApp() {
 	);
 	const forceReloadDisabled =
 		!forceReloadAvailable ||
-		Boolean(activeSession?.isLoading || isActivating || isForceReloading);
+		Boolean(
+			activeSession?.isLoading ||
+				activeSession?.historySyncing ||
+				isActivating ||
+				isForceReloading ||
+				(activeSessionId && isBackfilling(activeSessionId)),
+		);
 
 	useEffect(() => {
 		if (fileExplorerAvailable) {
@@ -508,6 +518,8 @@ function MainApp() {
 		t,
 	]);
 
+	const warningMessage = activeSession?.historySyncWarning?.message;
+
 	const loadingMessage = useMemo(() => {
 		if (
 			mutations.loadSessionMutation.isPending &&
@@ -539,8 +551,12 @@ function MainApp() {
 		) {
 			return t("session.switchingModel");
 		}
+		if (activeSession?.historySyncing) {
+			return t("session.syncingHistory");
+		}
 		return undefined;
 	}, [
+		activeSession?.historySyncing,
 		activeSessionId,
 		discoverSessionsMutation.isPending,
 		discoverSessionsMutation.variables,
@@ -657,6 +673,7 @@ function MainApp() {
 						branchLabel={activeSession?.worktreeBranch}
 						subdirectoryLabel={subdirectoryLabel}
 						statusMessage={statusMessage}
+						warningMessage={warningMessage}
 						streamError={streamError}
 						loadingMessage={loadingMessage}
 						plan={activeSession?.plan}

--- a/apps/webui/src/components/app/AppHeader.tsx
+++ b/apps/webui/src/components/app/AppHeader.tsx
@@ -45,6 +45,7 @@ export type AppHeaderProps = {
 	branchLabel?: string;
 	subdirectoryLabel?: string;
 	statusMessage?: string;
+	warningMessage?: string;
 	streamError?: ChatSession["streamError"];
 	loadingMessage?: string;
 	plan?: PlanEntry[];
@@ -90,6 +91,7 @@ export const AppHeader = memo(function AppHeader({
 	branchLabel,
 	subdirectoryLabel,
 	statusMessage,
+	warningMessage,
 	streamError,
 	loadingMessage,
 	plan,
@@ -324,12 +326,26 @@ export const AppHeader = memo(function AppHeader({
 			</div>
 
 			{loadingMessage ? (
-				<div className="text-muted-foreground mx-auto mt-2 w-full max-w-5xl text-xs">
+				<div
+					className="text-muted-foreground mx-auto mt-2 w-full max-w-5xl text-xs"
+					aria-live="polite"
+				>
 					{loadingMessage}
 				</div>
 			) : null}
+			{warningMessage ? (
+				<div
+					className="text-warning mx-auto mt-2 w-full max-w-5xl text-xs"
+					aria-live="polite"
+				>
+					{warningMessage}
+				</div>
+			) : null}
 			{statusMessage ? (
-				<div className="text-muted-foreground mx-auto mt-2 w-full max-w-5xl text-xs">
+				<div
+					className="text-destructive mx-auto mt-2 w-full max-w-5xl text-xs"
+					aria-live="polite"
+				>
 					{statusMessage}
 				</div>
 			) : null}

--- a/apps/webui/src/components/app/ChatMessageList.tsx
+++ b/apps/webui/src/components/app/ChatMessageList.tsx
@@ -16,6 +16,7 @@ import { MessageItem } from "@/components/chat/MessageItem";
 import { ThinkingIndicator } from "@/components/chat/ThinkingIndicator";
 import { ToolCallGroup } from "@/components/chat/tool-call-group";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { PermissionResultNotification } from "@/lib/acp";
 import type { ChatSession } from "@/lib/chat-store";
 import { buildMessageIndexMap, groupMessages } from "@/lib/group-tool-calls";
@@ -59,6 +60,7 @@ export const ChatMessageList = forwardRef<
 	const messages = activeSession?.messages ?? [];
 	const showIndicator = !!activeSession?.sending;
 	const isThinking = showIndicator && !activeSession?.streamingMessageId;
+	const isHistorySyncing = Boolean(activeSession?.historySyncing);
 
 	const displayItems = useMemo(() => groupMessages(messages), [messages]);
 	const totalItems = displayItems.length + (showIndicator ? 1 : 0);
@@ -193,16 +195,30 @@ export const ChatMessageList = forwardRef<
 							) : null}
 						</div>
 					) : null}
-					{activeSession?.isLoading ? (
-						<div
-							className="text-muted-foreground mt-8 text-center text-sm whitespace-pre font-mono"
-							aria-live="polite"
-						>
-							{loadingMessage ?? t("common.loading")}
+					{activeSession &&
+					isHistorySyncing &&
+					activeSession.messages.length === 0 ? (
+						<div className="flex flex-1 flex-col gap-4 pt-4" aria-live="polite">
+							<div className="text-muted-foreground text-sm font-mono whitespace-pre">
+								{loadingMessage ?? t("session.syncingHistory")}
+							</div>
+							<div className="flex flex-col gap-3">
+								<div className="ml-auto flex w-[72%] flex-col gap-2 rounded-none border border-primary/20 bg-primary/5 p-4">
+									<Skeleton className="h-3 w-20" />
+									<Skeleton className="h-4 w-full" />
+									<Skeleton className="h-4 w-4/5" />
+								</div>
+								<div className="flex w-[82%] flex-col gap-2 pl-4">
+									<Skeleton className="h-3 w-16" />
+									<Skeleton className="h-4 w-full" />
+									<Skeleton className="h-4 w-3/4" />
+								</div>
+							</div>
 						</div>
 					) : null}
 					{activeSession &&
 					!activeSession.isLoading &&
+					!isHistorySyncing &&
 					activeSession.messages.length === 0 ? (
 						<div
 							className="flex flex-1 items-center justify-center opacity-30"

--- a/apps/webui/src/components/app/__tests__/AppHeader.test.tsx
+++ b/apps/webui/src/components/app/__tests__/AppHeader.test.tsx
@@ -16,6 +16,9 @@ vi.mock("react-i18next", () => ({
 				"commandPalette.openCommandPalette": "Open Command Palette",
 				"common.toggleMenu": "Toggle menu",
 				"session.syncHistory": "Sync History",
+				"session.syncingHistory": "Synchronizing history…",
+				"session.historyMayBeStale":
+					"History may be out of date. Try syncing again.",
 				"session.forceReloadTitle": "Force Reload",
 				"session.forceReloadDescription": "This will force reload the session.",
 				"session.forceReloadConfirm": "Reload",
@@ -509,6 +512,15 @@ describe("AppHeader", () => {
 		it("displays loading message when provided", () => {
 			renderAppHeader({ loadingMessage: "Loading..." });
 			expect(screen.getByText("Loading...")).toBeInTheDocument();
+		});
+
+		it("displays warning message when provided", () => {
+			renderAppHeader({
+				warningMessage: "History may be out of date. Try syncing again.",
+			});
+			expect(
+				screen.getByText("History may be out of date. Try syncing again."),
+			).toBeInTheDocument();
 		});
 
 		it("displays status message when provided", () => {

--- a/apps/webui/src/components/app/__tests__/ChatMessageList.test.tsx
+++ b/apps/webui/src/components/app/__tests__/ChatMessageList.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ChatSession } from "@/lib/chat-store";
+import { ChatMessageList } from "../ChatMessageList";
+
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (key: string) => {
+			const translations: Record<string, string> = {
+				"session.syncingHistory": "Synchronizing history…",
+				"chat.welcomeCreateSession": "Create a session to start chatting.",
+				"chat.welcomeSelectMachine":
+					"Select a machine from the sidebar to get started.",
+				"chat.createSession": "Create Session",
+				"common.appName": "Mobvibe",
+			};
+			return translations[key] ?? key;
+		},
+	}),
+}));
+
+vi.mock("@tanstack/react-virtual", () => ({
+	useVirtualizer: () => ({
+		getVirtualItems: () => [],
+		getTotalSize: () => 0,
+		measureElement: vi.fn(),
+		scrollToIndex: vi.fn(),
+	}),
+}));
+
+vi.mock("@/lib/ui-store", () => ({
+	useUiStore: () => ({
+		setFileExplorerOpen: vi.fn(),
+		setFilePreviewPath: vi.fn(),
+	}),
+}));
+
+vi.mock("@/components/app/E2EEMissingBanner", () => ({
+	E2EEMissingBanner: () => <div data-testid="e2ee-banner" />,
+}));
+
+vi.mock("@/components/brand-logo", () => ({
+	BrandLogo: () => <div data-testid="brand-logo" />,
+}));
+
+vi.mock("@/components/chat/MessageItem", () => ({
+	MessageItem: () => <div data-testid="message-item" />,
+}));
+
+vi.mock("@/components/chat/ThinkingIndicator", () => ({
+	ThinkingIndicator: () => <div data-testid="thinking-indicator" />,
+}));
+
+vi.mock("@/components/chat/tool-call-group", () => ({
+	ToolCallGroup: () => <div data-testid="tool-call-group" />,
+}));
+
+const buildSession = (overrides: Partial<ChatSession> = {}): ChatSession =>
+	({
+		sessionId: "session-1",
+		title: "Session 1",
+		input: "",
+		inputContents: [],
+		messages: [],
+		terminalOutputs: {},
+		sending: false,
+		canceling: false,
+		isLoading: false,
+		historySyncing: false,
+		...overrides,
+	}) as ChatSession;
+
+describe("ChatMessageList", () => {
+	it("shows a visible sync placeholder while transcript history is being restored", () => {
+		render(
+			<ChatMessageList
+				activeSession={buildSession({ historySyncing: true })}
+				loadingMessage="Synchronizing history…"
+				hasMachineSelected
+				onCreateSession={vi.fn()}
+				onPermissionDecision={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("Synchronizing history…")).toBeInTheDocument();
+		expect(screen.queryByTestId("brand-logo")).not.toBeInTheDocument();
+	});
+
+	it("falls back to the empty session logo only when the session is idle", () => {
+		render(
+			<ChatMessageList
+				activeSession={buildSession()}
+				hasMachineSelected
+				onCreateSession={vi.fn()}
+				onPermissionDecision={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByTestId("brand-logo")).toBeInTheDocument();
+		expect(
+			screen.queryByText("Synchronizing history…"),
+		).not.toBeInTheDocument();
+	});
+});

--- a/apps/webui/src/components/chat/MessageItem.tsx
+++ b/apps/webui/src/components/chat/MessageItem.tsx
@@ -804,6 +804,13 @@ const MessageItemInner = ({
 	const getLabel = (key: string, options?: Record<string, unknown>) =>
 		t(key, { defaultValue: key, ...options });
 	const isUser = message.role === "user";
+	const isPendingUserMessage =
+		isUser &&
+		message.kind === "text" &&
+		message.provisional === true &&
+		message.failed !== true;
+	const isFailedUserMessage =
+		isUser && message.kind === "text" && message.failed === true;
 
 	// User message copy button state
 	const [copied, setCopied] = useState(false);
@@ -955,14 +962,31 @@ const MessageItemInner = ({
 		return <ThoughtItemContent message={message} />;
 	}
 	// User messages: bubble style with hover-reveal copy button
-	if (isUser) {
+	if (isUser && message.kind === "text") {
 		return (
 			<div className="flex flex-col gap-1 items-end">
+				{isPendingUserMessage || isFailedUserMessage ? (
+					<div
+						className="flex max-w-[85%] items-center gap-2 self-end text-[11px]"
+						aria-live="polite"
+					>
+						<Badge variant={isFailedUserMessage ? "destructive" : "secondary"}>
+							{isFailedUserMessage
+								? t("chat.messageFailed")
+								: t("chat.messagePending")}
+						</Badge>
+						{isFailedUserMessage ? (
+							<span className="text-destructive">
+								{t("chat.messageFailedHint")}
+							</span>
+						) : null}
+					</div>
+				) : null}
 				<div className="group/user-msg flex items-center gap-1.5 max-w-[85%]">
 					{!message.isStreaming && (
 						<button
 							type="button"
-							className="shrink-0 flex items-center justify-center size-6 rounded-full border border-border bg-background text-muted-foreground shadow-sm transition-all hover:text-foreground hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 md:opacity-0 group-hover/user-msg:opacity-100 focus-visible:opacity-100"
+							className="shrink-0 flex items-center justify-center size-6 rounded-full border border-border bg-background text-muted-foreground shadow-sm transition-[opacity,background-color,color] hover:text-foreground hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 md:opacity-0 group-hover/user-msg:opacity-100 focus-visible:opacity-100"
 							onClick={(e) => {
 								e.stopPropagation();
 								handleCopy();
@@ -979,7 +1003,12 @@ const MessageItemInner = ({
 					<Card
 						size="sm"
 						className={cn(
-							"border-primary/30 bg-primary/10 min-w-0",
+							"min-w-0",
+							isFailedUserMessage
+								? "border-destructive/40 bg-destructive/10"
+								: isPendingUserMessage
+									? "border-primary/30 border-dashed bg-primary/5"
+									: "border-primary/30 bg-primary/10",
 							message.isStreaming ? "opacity-90" : "opacity-100",
 						)}
 					>

--- a/apps/webui/src/components/chat/__tests__/MessageItem.test.tsx
+++ b/apps/webui/src/components/chat/__tests__/MessageItem.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { MessageItem } from "../MessageItem";
+
+vi.mock("react-i18next", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-i18next")>();
+	return {
+		...actual,
+		useTranslation: () => ({
+			t: (key: string) => {
+				const translations: Record<string, string> = {
+					"chat.copyMessage": "Copy",
+					"chat.messagePending": "Sending…",
+					"chat.messageFailed": "Send failed",
+					"chat.messageFailedHint": "Draft restored below.",
+				};
+				return translations[key] ?? key;
+			},
+		}),
+	};
+});
+
+vi.mock("@hugeicons/react", () => ({
+	HugeiconsIcon: () => <span data-testid="icon" />,
+}));
+
+vi.mock("@/components/chat/DiffView", () => ({
+	UnifiedDiffView: () => <div data-testid="diff-view" />,
+	buildUnifiedDiffString: () => "",
+}));
+
+vi.mock("@/components/chat/LazyStreamdown", () => ({
+	LazyStreamdown: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+vi.mock("@/lib/chat-store", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/chat-store")>();
+	return {
+		...actual,
+		useChatStore: vi.fn(() => undefined),
+		selectTerminalOutputSnapshot: vi.fn(() => undefined),
+	};
+});
+
+describe("MessageItem", () => {
+	it("shows a pending badge for provisional user messages", () => {
+		render(
+			<MessageItem
+				message={{
+					id: "msg-1",
+					role: "user",
+					kind: "text",
+					content: "Hello",
+					contentBlocks: [{ type: "text", text: "Hello" }],
+					createdAt: "2026-03-14T00:00:00.000Z",
+					isStreaming: false,
+					provisional: true,
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Sending…")).toBeInTheDocument();
+		expect(screen.queryByText("Draft restored below.")).not.toBeInTheDocument();
+		expect(screen.getByText("Hello")).toBeInTheDocument();
+	});
+
+	it("shows a failed badge and follow-up hint for failed provisional messages", () => {
+		render(
+			<MessageItem
+				message={{
+					id: "msg-2",
+					role: "user",
+					kind: "text",
+					content: "Hello again",
+					contentBlocks: [{ type: "text", text: "Hello again" }],
+					createdAt: "2026-03-14T00:00:00.000Z",
+					isStreaming: false,
+					provisional: true,
+					failed: true,
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Send failed")).toBeInTheDocument();
+		expect(screen.getByText("Draft restored below.")).toBeInTheDocument();
+		expect(screen.getByText("Hello again")).toBeInTheDocument();
+	});
+});

--- a/apps/webui/src/hooks/__tests__/useSessionActivation.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionActivation.test.tsx
@@ -82,6 +82,8 @@ const createStore = (): ChatStoreActions =>
 		setActiveSessionId: vi.fn(),
 		setLastCreatedCwd: vi.fn(),
 		setSessionLoading: vi.fn(),
+		setHistorySyncing: vi.fn(),
+		setHistorySyncWarning: vi.fn(),
 		markSessionAttached: vi.fn(),
 		markSessionDetached: vi.fn(),
 		createLocalSession: vi.fn(),
@@ -274,6 +276,11 @@ describe("useSessionActivation", () => {
 		});
 
 		expect(store.setSessionLoading).toHaveBeenCalledWith("session-1", true);
+		expect(store.setHistorySyncing).toHaveBeenCalledWith("session-1", true);
+		expect(store.setHistorySyncWarning).toHaveBeenCalledWith(
+			"session-1",
+			undefined,
+		);
 		expect(store.clearSessionMessages).toHaveBeenCalledWith("session-1");
 		expect(loadSessionMutation.mutateAsync).toHaveBeenCalledWith({
 			sessionId: "session-1",
@@ -435,6 +442,10 @@ describe("useSessionActivation", () => {
 		);
 		expect(mockGatewaySocket.unsubscribeFromSession).toHaveBeenCalledWith(
 			"session-1",
+		);
+		expect(store.setHistorySyncing).toHaveBeenLastCalledWith(
+			"session-1",
+			false,
 		);
 		expect(store.setSessionLoading).toHaveBeenCalledWith("session-1", false);
 	});

--- a/apps/webui/src/hooks/__tests__/useSessionBackfill.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionBackfill.test.tsx
@@ -165,6 +165,53 @@ describe("useSessionBackfill", () => {
 		expect(onComplete).not.toHaveBeenCalled();
 	});
 
+	it("times out a stalled backfill request and surfaces the error", async () => {
+		vi.useFakeTimers();
+		const onEvents = vi.fn();
+		const onComplete = vi.fn();
+		const onError = vi.fn();
+
+		mockFetch.mockImplementationOnce(
+			(_input: RequestInfo | URL, init?: RequestInit) =>
+				new Promise((_resolve, reject) => {
+					const signal = init?.signal as AbortSignal | undefined;
+					signal?.addEventListener("abort", () => {
+						const abortError = new Error("Aborted");
+						abortError.name = "AbortError";
+						reject(abortError);
+					});
+				}),
+		);
+
+		const { result } = renderHook(() =>
+			useSessionBackfill({
+				gatewayUrl: "http://localhost:3005",
+				onEvents,
+				onComplete,
+				onError,
+			}),
+		);
+
+		try {
+			await act(async () => {
+				const pending = result.current.startBackfill("session-1", 1, 0);
+				await vi.advanceTimersByTimeAsync(15_000);
+				await pending;
+			});
+
+			expect(onEvents).not.toHaveBeenCalled();
+			expect(onComplete).not.toHaveBeenCalled();
+			expect(onError).toHaveBeenCalledWith(
+				"session-1",
+				expect.objectContaining({
+					message: "Backfill request timed out after 15000ms",
+				}),
+			);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("fetches multiple pages until hasMore is false", async () => {
 		const onEvents = vi.fn();
 		const onComplete = vi.fn();

--- a/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionHandlers.test.tsx
@@ -584,6 +584,11 @@ describe("useSessionHandlers — handleSend", () => {
 		expect(mutations.sendMessageMutation.mutate).toHaveBeenCalledWith({
 			sessionId: "session-1",
 			prompt: promptContents,
+			messageId: expect.any(String),
+			draft: {
+				input: "Ship it",
+				inputContents: promptContents,
+			},
 		});
 	});
 
@@ -664,6 +669,11 @@ describe("useSessionHandlers — handleSend", () => {
 		expect(mutations.sendMessageMutation.mutate).toHaveBeenCalledWith({
 			sessionId: "session-1",
 			prompt: promptContents,
+			messageId: expect.any(String),
+			draft: {
+				input: "",
+				inputContents: promptContents,
+			},
 		});
 	});
 });

--- a/apps/webui/src/hooks/__tests__/useSessionMutations.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSessionMutations.test.tsx
@@ -26,9 +26,18 @@ vi.mock("@/lib/chat-store", async (importOriginal) => {
 });
 
 const mockBootstrapSessionE2EE = vi.hoisted(() => vi.fn(() => "ok"));
+const mockUiStoreState = vi.hoisted(() => ({
+	setChatDraft: vi.fn(),
+}));
 
 vi.mock("@/lib/e2ee", () => ({
 	bootstrapSessionE2EE: mockBootstrapSessionE2EE,
+}));
+
+vi.mock("@/lib/ui-store", () => ({
+	useUiStore: {
+		getState: () => mockUiStoreState,
+	},
 }));
 
 // Mock the API module
@@ -58,6 +67,8 @@ describe("useSessionMutations", () => {
 		setActiveSessionId: vi.fn(),
 		setLastCreatedCwd: vi.fn(),
 		setSessionLoading: vi.fn(),
+		setHistorySyncing: vi.fn(),
+		setHistorySyncWarning: vi.fn(),
 		markSessionAttached: vi.fn(),
 		markSessionDetached: vi.fn(),
 		createLocalSession: vi.fn(),
@@ -77,6 +88,7 @@ describe("useSessionMutations", () => {
 		appendAssistantChunk: vi.fn(),
 		appendThoughtChunk: vi.fn(),
 		confirmOrAppendUserMessage: vi.fn(),
+		markUserMessageFailed: vi.fn(),
 		finalizeAssistantMessage: vi.fn(),
 		addPermissionRequest: vi.fn(),
 		setPermissionDecisionState: vi.fn(),
@@ -107,6 +119,7 @@ describe("useSessionMutations", () => {
 		});
 		mockStore = createMockStore();
 		mockChatStoreState.sessions = {};
+		mockUiStoreState.setChatDraft.mockReset();
 		vi.clearAllMocks();
 	});
 
@@ -835,6 +848,36 @@ describe("useSessionMutations", () => {
 				"session-1",
 			);
 			expect(mockStore.setSending).toHaveBeenCalledWith("session-1", false);
+		});
+
+		it("marks the optimistic message failed and restores the draft on error", async () => {
+			vi.mocked(apiModule.sendMessage).mockRejectedValue(new Error("offline"));
+
+			const { result } = renderHook(() => useSessionMutations(mockStore), {
+				wrapper,
+			});
+
+			await expect(
+				result.current.sendMessageMutation.mutateAsync({
+					sessionId: "session-1",
+					prompt: [{ type: "text", text: "Hello" }],
+					messageId: "user-msg-1",
+					draft: {
+						input: "Hello",
+						inputContents: [{ type: "text", text: "Hello" }],
+					},
+				}),
+			).rejects.toThrow("offline");
+
+			expect(mockStore.markUserMessageFailed).toHaveBeenCalledWith(
+				"session-1",
+				"user-msg-1",
+			);
+			expect(mockUiStoreState.setChatDraft).toHaveBeenCalledWith("session-1", {
+				input: "Hello",
+				inputContents: [{ type: "text", text: "Hello" }],
+			});
+			expect(mockStore.setAppError).toHaveBeenCalled();
 		});
 
 		it("should handle undefined variables gracefully", async () => {

--- a/apps/webui/src/hooks/__tests__/useSocket.test.tsx
+++ b/apps/webui/src/hooks/__tests__/useSocket.test.tsx
@@ -14,9 +14,13 @@ const mockStoreState = vi.hoisted(
 		({
 			sessions: {} as Record<string, ChatSession>,
 			restoreSessionMessages: vi.fn(),
+			setHistorySyncing: vi.fn(),
+			setHistorySyncWarning: vi.fn(),
 		}) as {
 			sessions: Record<string, ChatSession>;
 			restoreSessionMessages: ChatStoreActions["restoreSessionMessages"];
+			setHistorySyncing: ChatStoreActions["setHistorySyncing"];
+			setHistorySyncWarning: ChatStoreActions["setHistorySyncWarning"];
 		},
 );
 
@@ -436,6 +440,8 @@ describe("useSocket (webui)", () => {
 		// Reset mock store state
 		setMockSessions({});
 		mockStoreState.restoreSessionMessages = vi.fn();
+		mockStoreState.setHistorySyncing = vi.fn();
+		mockStoreState.setHistorySyncWarning = vi.fn();
 		dekReadyListeners.clear();
 		decryptedPayloads.clear();
 
@@ -901,6 +907,17 @@ describe("useSocket (webui)", () => {
 			expect.objectContaining({
 				revision: 1,
 				lastAppliedSeq: 2,
+			}),
+		);
+		expect(mockStoreState.setHistorySyncing).toHaveBeenCalledWith(
+			"session-1",
+			false,
+		);
+		expect(mockStoreState.setHistorySyncWarning).toHaveBeenCalledWith(
+			"session-1",
+			expect.objectContaining({
+				code: "INTERNAL_ERROR",
+				message: "session.historyMayBeStale",
 			}),
 		);
 	});

--- a/apps/webui/src/hooks/use-session-backfill.ts
+++ b/apps/webui/src/hooks/use-session-backfill.ts
@@ -4,6 +4,8 @@ import { isInTauri } from "@/lib/auth";
 import { getAuthToken } from "@/lib/auth-token";
 import { platformFetch } from "@/lib/tauri-fetch";
 
+const BACKFILL_REQUEST_TIMEOUT_MS = 15_000;
+
 type BackfillState = {
 	sessionId: string;
 	revision: number;
@@ -92,12 +94,38 @@ export function useSessionBackfill({
 				headers.Authorization = `Bearer ${token}`;
 			}
 
-			const response = await platformFetch(url.toString(), {
-				method: "GET",
-				headers,
-				signal,
-				credentials: tauriEnv ? "omit" : "include",
-			});
+			const requestController = new AbortController();
+			let didTimeout = false;
+			const abortRequest = () => requestController.abort();
+			signal.addEventListener("abort", abortRequest, { once: true });
+			const timeoutId = setTimeout(() => {
+				didTimeout = true;
+				requestController.abort();
+			}, BACKFILL_REQUEST_TIMEOUT_MS);
+
+			let response: Response;
+			try {
+				response = await platformFetch(url.toString(), {
+					method: "GET",
+					headers,
+					signal: requestController.signal,
+					credentials: tauriEnv ? "omit" : "include",
+				});
+			} catch (error) {
+				if (
+					didTimeout &&
+					error instanceof Error &&
+					error.name === "AbortError"
+				) {
+					throw new Error(
+						`Backfill request timed out after ${BACKFILL_REQUEST_TIMEOUT_MS}ms`,
+					);
+				}
+				throw error;
+			} finally {
+				clearTimeout(timeoutId);
+				signal.removeEventListener("abort", abortRequest);
+			}
 
 			if (!response.ok) {
 				const errorText = await response.text();

--- a/apps/webui/src/hooks/useSessionActivation.ts
+++ b/apps/webui/src/hooks/useSessionActivation.ts
@@ -83,6 +83,8 @@ export function useSessionActivation(store: ChatStoreActions) {
 			};
 
 			store.setSessionLoading(fresh.sessionId, true);
+			store.setHistorySyncing(fresh.sessionId, true);
+			store.setHistorySyncWarning(fresh.sessionId, undefined);
 			const backupMessages: ChatMessage[] = [...fresh.messages];
 			const backupSnapshot = {
 				lastAppliedSeq: fresh.lastAppliedSeq,
@@ -105,6 +107,7 @@ export function useSessionActivation(store: ChatStoreActions) {
 					backupMessages,
 					backupSnapshot,
 				);
+				store.setHistorySyncing(fresh.sessionId, false);
 				gatewaySocket.unsubscribeFromSession(fresh.sessionId);
 			} finally {
 				store.setSessionLoading(fresh.sessionId, false);

--- a/apps/webui/src/hooks/useSessionHandlers.ts
+++ b/apps/webui/src/hooks/useSessionHandlers.ts
@@ -59,6 +59,11 @@ type Mutations = {
 		mutate: (params: {
 			sessionId: string;
 			prompt: ChatSession["inputContents"];
+			messageId?: string;
+			draft?: {
+				input: string;
+				inputContents: ChatSession["inputContents"];
+			};
 		}) => void;
 	};
 	permissionDecisionMutation: {
@@ -452,6 +457,11 @@ export function useSessionHandlers({
 		mutations.sendMessageMutation.mutate({
 			sessionId: activeSessionId,
 			prompt: promptContents,
+			messageId,
+			draft: {
+				input: promptText,
+				inputContents: promptContents,
+			},
 		});
 	};
 

--- a/apps/webui/src/hooks/useSessionMutations.ts
+++ b/apps/webui/src/hooks/useSessionMutations.ts
@@ -32,6 +32,7 @@ import type {
 import { useChatStore } from "@/lib/chat-store";
 import { bootstrapSessionE2EE } from "@/lib/e2ee";
 import { createFallbackError, normalizeError } from "@/lib/error-utils";
+import { useUiStore } from "@/lib/ui-store";
 
 type SessionMetadata = Partial<
 	Pick<
@@ -74,10 +75,27 @@ type PermissionRequestPayload = {
 	options: PermissionOption[];
 };
 
+type SendMessageDraft = {
+	input: string;
+	inputContents: ContentBlock[];
+};
+
+type SendMessageVariables = {
+	sessionId: string;
+	prompt: ContentBlock[];
+	messageId?: string;
+	draft?: SendMessageDraft;
+};
+
 export interface ChatStoreActions {
 	setActiveSessionId: (id: string | undefined) => void;
 	setLastCreatedCwd: (machineId: string, cwd: string) => void;
 	setSessionLoading: (sessionId: string, value: boolean) => void;
+	setHistorySyncing: (sessionId: string, value: boolean) => void;
+	setHistorySyncWarning: (
+		sessionId: string,
+		error?: ChatSession["historySyncWarning"],
+	) => void;
 	markSessionAttached: (payload: {
 		sessionId: string;
 		machineId?: string;
@@ -134,6 +152,7 @@ export interface ChatStoreActions {
 		},
 	) => void;
 	confirmOrAppendUserMessage: (sessionId: string, text: string) => void;
+	markUserMessageFailed: (sessionId: string, messageId: string) => void;
 	addStatusMessage: (sessionId: string, status: StatusPayload) => void;
 	appendAssistantChunk: (sessionId: string, text: string) => void;
 	appendThoughtChunk: (sessionId: string, text: string) => void;
@@ -409,8 +428,24 @@ export function useSessionMutations(store: ChatStoreActions) {
 	});
 
 	const sendMessageMutation = useMutation({
-		mutationFn: sendMessage,
-		onError: (mutationError: unknown) => {
+		mutationFn: (variables: SendMessageVariables) => {
+			if (!variables) {
+				return Promise.resolve({ stopReason: "end_turn" as const });
+			}
+			return sendMessage({
+				sessionId: variables.sessionId,
+				prompt: variables.prompt,
+			});
+		},
+		onError: (mutationError: unknown, variables) => {
+			if (variables?.messageId) {
+				store.markUserMessageFailed(variables.sessionId, variables.messageId);
+			}
+			if (variables?.draft) {
+				useUiStore
+					.getState()
+					.setChatDraft(variables.sessionId, variables.draft);
+			}
 			store.setAppError(
 				normalizeError(
 					mutationError,

--- a/apps/webui/src/hooks/useSocket.ts
+++ b/apps/webui/src/hooks/useSocket.ts
@@ -1,5 +1,6 @@
 import { isEncryptedPayload, type SessionSummary } from "@mobvibe/shared";
 import { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { useSessionBackfill } from "@/hooks/use-session-backfill";
 import type { ChatStoreActions } from "@/hooks/useSessionMutations";
 import {
@@ -27,7 +28,7 @@ import {
 	useChatStore,
 } from "@/lib/chat-store";
 import { bootstrapSessionE2EE, e2ee } from "@/lib/e2ee";
-import { isErrorDetail } from "@/lib/error-utils";
+import { createFallbackError, isErrorDetail } from "@/lib/error-utils";
 import { useMachinesStore } from "@/lib/machines-store";
 import {
 	notifyPermissionRequest,
@@ -127,6 +128,7 @@ export function useSocket({
 	resetSessionForRevision,
 	onReconnect,
 }: UseSocketOptions) {
+	const { t } = useTranslation();
 	const subscribedSessionsRef = useRef<Set<string>>(new Set());
 	const recoverableSessionsRef = useRef<Set<string>>(new Set());
 	const sessionsRef = useRef(useChatStore.getState().sessions);
@@ -417,9 +419,13 @@ export function useSocket({
 		},
 		onComplete: (_sessionId) => {
 			syncBackupsRef.current.delete(_sessionId);
+			const store = useChatStore.getState();
+			store.setHistorySyncing(_sessionId, false);
+			store.setHistorySyncWarning(_sessionId, undefined);
 		},
 		onError: (sessionId, error) => {
 			console.error(`[backfill] Error for session ${sessionId}:`, error);
+			const store = useChatStore.getState();
 			// Fall back to applying pending events best effort
 			const pending = pendingEventsRef.current.get(sessionId);
 			if (pending && pending.length > 0) {
@@ -444,27 +450,31 @@ export function useSocket({
 			}
 
 			const backup = syncBackupsRef.current.get(sessionId);
-			if (!backup) {
-				return;
+			if (backup) {
+				const failedSession = store.sessions[sessionId];
+				if (
+					failedSession &&
+					failedSession.messages.length === 0 &&
+					(failedSession.lastAppliedSeq ?? 0) === 0
+				) {
+					store.restoreSessionMessages(
+						sessionId,
+						backup.messages,
+						backup.snapshot,
+					);
+				}
+				syncBackupsRef.current.delete(sessionId);
 			}
-
-			const failedSession = useChatStore.getState().sessions[sessionId];
-			if (
-				failedSession &&
-				failedSession.messages.length === 0 &&
-				(failedSession.lastAppliedSeq ?? 0) === 0
-			) {
-				useChatStore
-					.getState()
-					.restoreSessionMessages(sessionId, backup.messages, backup.snapshot);
-			}
-			syncBackupsRef.current.delete(sessionId);
+			store.setHistorySyncing(sessionId, false);
+			store.setHistorySyncWarning(sessionId, {
+				...createFallbackError(t("session.historyMayBeStale"), "session"),
+				detail: error.message,
+			});
 		},
 		onRevisionMismatch: (sessionId, newRevision) => {
 			console.log(
 				`[backfill] Revision mismatch for ${sessionId}, resetting to revision ${newRevision}`,
 			);
-			syncBackupsRef.current.delete(sessionId);
 			resetSessionForRevision(sessionId, newRevision);
 			pendingEventsRef.current.delete(sessionId);
 			encryptedBufferRef.current.delete(sessionId);
@@ -537,8 +547,10 @@ export function useSocket({
 	const syncSessionHistory = useCallback(
 		(sessionId: string) => {
 			const session = useChatStore.getState().sessions[sessionId];
-			if (!session || session.sending) return;
+			if (!session || session.sending || session.historySyncing) return;
 
+			useChatStore.getState().setHistorySyncing(sessionId, true);
+			useChatStore.getState().setHistorySyncWarning(sessionId, undefined);
 			const revision = session.revision ?? 1;
 			syncBackupsRef.current.set(sessionId, {
 				messages: [...session.messages],

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -51,7 +51,10 @@
 		"commandModeLabel": "Mode: {{value}}",
 		"commandModelLabel": "Model: {{value}}",
 		"copyMessage": "Copy",
-		"copied": "Copied"
+		"copied": "Copied",
+		"messagePending": "Sending…",
+		"messageFailed": "Send failed",
+		"messageFailedHint": "Draft restored below."
 	},
 	"session": {
 		"title": "Sessions",
@@ -69,8 +72,10 @@
 		"forceReloadTitle": "Force stop and reload?",
 		"forceReloadDescription": "This stops the current generation and reloads history from the agent.",
 		"forceReloadConfirm": "Force reload",
-		"loadingHistory": "Loading history...",
-		"reloadingHistory": "Reloading history...",
+		"loadingHistory": "Loading history…",
+		"reloadingHistory": "Reloading history…",
+		"syncingHistory": "Synchronizing history…",
+		"historyMayBeStale": "History may be out of date. Try syncing again.",
 		"sessionClosed": "Session has ended or was closed",
 		"createTitle": "New conversation",
 		"createDescription": "Choose a backend and set the title and working directory.",
@@ -136,6 +141,7 @@
 		"sessionE2EEKeyMissing": "E2EE key missing. Pair this device before sending messages.",
 		"streamDisconnected": "SSE connection lost",
 		"createSessionFailed": "Failed to create session",
+		"loadSessionFailed": "Failed to load session",
 		"renameSessionFailed": "Failed to rename",
 		"archiveSessionFailed": "Failed to archive session",
 		"closeSessionFailed": "Failed to close session",

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -51,7 +51,10 @@
 		"commandModeLabel": "模式: {{value}}",
 		"commandModelLabel": "模型: {{value}}",
 		"copyMessage": "复制",
-		"copied": "已复制"
+		"copied": "已复制",
+		"messagePending": "发送中…",
+		"messageFailed": "发送失败",
+		"messageFailedHint": "草稿已恢复到下方输入框。"
 	},
 	"session": {
 		"title": "对话",
@@ -69,8 +72,10 @@
 		"forceReloadTitle": "强制停止并加载？",
 		"forceReloadDescription": "将先停止当前生成，再从代理重放历史。",
 		"forceReloadConfirm": "确认重载",
-		"loadingHistory": "正在加载历史...",
-		"reloadingHistory": "正在重放历史...",
+		"loadingHistory": "正在加载历史…",
+		"reloadingHistory": "正在重放历史…",
+		"syncingHistory": "正在同步历史…",
+		"historyMayBeStale": "历史可能不是最新的，请重新同步。",
 		"sessionClosed": "会话已结束或被关闭",
 		"createTitle": "新建对话",
 		"createDescription": "选择后端并设置对话标题与工作目录。",
@@ -136,6 +141,7 @@
 		"sessionE2EEKeyMissing": "E2EE 密钥缺失，请先配对此设备后再发送消息。",
 		"streamDisconnected": "SSE 连接异常",
 		"createSessionFailed": "创建会话失败",
+		"loadSessionFailed": "加载会话失败",
 		"renameSessionFailed": "重命名失败",
 		"archiveSessionFailed": "归档会话失败",
 		"closeSessionFailed": "关闭会话失败",

--- a/apps/webui/src/lib/__tests__/chat-store.test.ts
+++ b/apps/webui/src/lib/__tests__/chat-store.test.ts
@@ -161,11 +161,19 @@ describe("chat-store", () => {
 	// confirmOrAppendUserMessage
 	// ---------------------------------------------------------------------------
 	describe("confirmOrAppendUserMessage", () => {
-		it("confirms a provisional user message", () => {
-			const { createLocalSession, addUserMessage, confirmOrAppendUserMessage } =
-				useChatStore.getState();
+		it("confirms a provisional user message and clears failed state", () => {
+			const {
+				createLocalSession,
+				addUserMessage,
+				confirmOrAppendUserMessage,
+				markUserMessageFailed,
+			} = useChatStore.getState();
 			createLocalSession("s1");
 			addUserMessage("s1", "hello world", { provisional: true });
+			const messageId = useChatStore.getState().sessions.s1.messages[0]?.id;
+			if (messageId) {
+				markUserMessageFailed("s1", messageId);
+			}
 
 			expect(useChatStore.getState().sessions.s1.messages[0]).toHaveProperty(
 				"provisional",
@@ -176,6 +184,7 @@ describe("chat-store", () => {
 
 			const msg = useChatStore.getState().sessions.s1.messages[0];
 			expect(msg).toHaveProperty("provisional", false);
+			expect(msg).toHaveProperty("failed", false);
 			// Should NOT add a second message
 			expect(useChatStore.getState().sessions.s1.messages).toHaveLength(1);
 		});
@@ -246,18 +255,32 @@ describe("chat-store", () => {
 			}
 		});
 
-		it("provisional flag survives sanitizeMessageForPersist (not stripped)", () => {
+		it("defaults failed to false on optimistic messages", () => {
 			const { createLocalSession, addUserMessage } = useChatStore.getState();
 			createLocalSession("s1");
 			addUserMessage("s1", "prov msg", { provisional: true });
 
-			// Read persisted state — sanitizeMessageForPersist sets isStreaming=false
-			// but should not strip the provisional field
 			const msg = useChatStore.getState().sessions.s1.messages[0];
 			expect(msg.kind).toBe("text");
 			if (msg.kind === "text") {
 				expect(msg.provisional).toBe(true);
+				expect(msg.failed).toBe(false);
 				expect(msg.isStreaming).toBe(false);
+			}
+		});
+
+		it("marks a provisional user message as failed", () => {
+			const { createLocalSession, addUserMessage, markUserMessageFailed } =
+				useChatStore.getState();
+			createLocalSession("s1");
+			addUserMessage("s1", "hello", { provisional: true, messageId: "msg-1" });
+
+			markUserMessageFailed("s1", "msg-1");
+
+			const msg = useChatStore.getState().sessions.s1.messages[0];
+			if (msg.kind === "text") {
+				expect(msg.provisional).toBe(true);
+				expect(msg.failed).toBe(true);
 			}
 		});
 	});

--- a/apps/webui/src/lib/api.ts
+++ b/apps/webui/src/lib/api.ts
@@ -48,6 +48,7 @@ import { platformFetch } from "./tauri-fetch";
 
 let API_BASE_URL = getDefaultGatewayUrl();
 const SEND_MESSAGE_TIMEOUT_MS = 120_000;
+const SESSION_LOAD_TIMEOUT_MS = 30_000;
 
 /**
  * Update the API base URL. Used when Tauri app loads a stored gateway URL.
@@ -388,10 +389,14 @@ export const loadSession = async (payload: {
 	backendId: string;
 	machineId?: string;
 }): Promise<SessionSummary> =>
-	requestJson<SessionSummary>("/acp/session/load", {
-		method: "POST",
-		body: JSON.stringify(payload),
-	});
+	requestJsonWithTimeout<SessionSummary>(
+		"/acp/session/load",
+		SESSION_LOAD_TIMEOUT_MS,
+		{
+			method: "POST",
+			body: JSON.stringify(payload),
+		},
+	);
 
 export const reloadSession = async (payload: {
 	sessionId: string;
@@ -399,10 +404,14 @@ export const reloadSession = async (payload: {
 	backendId: string;
 	machineId?: string;
 }): Promise<SessionSummary> =>
-	requestJson<SessionSummary>("/acp/session/reload", {
-		method: "POST",
-		body: JSON.stringify(payload),
-	});
+	requestJsonWithTimeout<SessionSummary>(
+		"/acp/session/reload",
+		SESSION_LOAD_TIMEOUT_MS,
+		{
+			method: "POST",
+			body: JSON.stringify(payload),
+		},
+	);
 
 import type {
 	GitBlameParams,

--- a/apps/webui/src/lib/chat-store.ts
+++ b/apps/webui/src/lib/chat-store.ts
@@ -34,6 +34,8 @@ type TextMessage = {
 	isStreaming: boolean;
 	/** Optimistically added user message, awaiting server confirmation */
 	provisional?: boolean;
+	/** Message failed to send and needs user attention */
+	failed?: boolean;
 };
 
 type ThoughtMessage = {
@@ -155,6 +157,8 @@ export type ChatSession = {
 		| "gateway_disconnect"
 		| "unknown";
 	isLoading?: boolean;
+	historySyncing?: boolean;
+	historySyncWarning?: ErrorDetail;
 	/** Indicates this session is being created optimistically (before server confirmation) */
 	isCreating?: boolean;
 	/** Usage tracking from ACP agent */
@@ -232,6 +236,11 @@ type ChatState = {
 	setAppError: (value?: ErrorDetail) => void;
 	setLastCreatedCwd: (machineId: string, cwd: string) => void;
 	setSessionLoading: (sessionId: string, value: boolean) => void;
+	setHistorySyncing: (sessionId: string, value: boolean) => void;
+	setHistorySyncWarning: (
+		sessionId: string,
+		value?: ChatSession["historySyncWarning"],
+	) => void;
 	markSessionAttached: (payload: {
 		sessionId: string;
 		machineId?: string;
@@ -321,6 +330,7 @@ type ChatState = {
 	) => void;
 	/** Confirm a provisional user message or append a new one (backfill) */
 	confirmOrAppendUserMessage: (sessionId: string, text: string) => void;
+	markUserMessageFailed: (sessionId: string, messageId: string) => void;
 	addStatusMessage: (
 		sessionId: string,
 		payload: {
@@ -592,6 +602,8 @@ const createSessionState = (
 	detachedAt: undefined,
 	detachedReason: undefined,
 	isLoading: false,
+	historySyncing: false,
+	historySyncWarning: undefined,
 	worktreeSourceCwd: options?.worktreeSourceCwd,
 	worktreeBranch: options?.worktreeBranch,
 	workspaceRootCwd: options?.workspaceRootCwd,
@@ -695,6 +707,14 @@ const mergeSessionFromSummary = (
 const STORAGE_KEY = "mobvibe.chat-store";
 
 const sanitizeMessageForPersist = (message: ChatMessage): ChatMessage => {
+	if (isTextMessage(message)) {
+		return {
+			...message,
+			isStreaming: false,
+			provisional: false,
+			failed: false,
+		};
+	}
 	if (message.kind === "permission") {
 		return message;
 	}
@@ -722,6 +742,8 @@ const sanitizeSessionForPersist = (session: ChatSession): ChatSession => ({
 	detachedReason: undefined,
 	e2eeStatus: undefined,
 	plan: undefined,
+	historySyncing: false,
+	historySyncWarning: undefined,
 	// Preserve messages even when cursor is set so detached sessions keep history.
 	// Backfill applies only new events based on the cursor.
 	messages: session.messages.map(sanitizeMessageForPersist),
@@ -771,6 +793,32 @@ export const useChatStore = create<ChatState>()(
 						sessions: {
 							...state.sessions,
 							[sessionId]: { ...session, isLoading: value },
+						},
+					};
+				}),
+			setHistorySyncing: (sessionId, value) =>
+				set((state) => {
+					const session = state.sessions[sessionId];
+					if (!session) {
+						return state;
+					}
+					return {
+						sessions: {
+							...state.sessions,
+							[sessionId]: { ...session, historySyncing: value },
+						},
+					};
+				}),
+			setHistorySyncWarning: (sessionId, value) =>
+				set((state) => {
+					const session = state.sessions[sessionId];
+					if (!session) {
+						return state;
+					}
+					return {
+						sessions: {
+							...state.sessions,
+							[sessionId]: { ...session, historySyncWarning: value },
 						},
 					};
 				}),
@@ -1190,6 +1238,7 @@ export const useChatStore = create<ChatState>()(
 						contentBlocks:
 							options?.contentBlocks ?? createDefaultContentBlocks(content),
 						provisional: options?.provisional ?? false,
+						failed: false,
 					};
 					return {
 						sessions: {
@@ -1213,7 +1262,7 @@ export const useChatStore = create<ChatState>()(
 						if (msg.role === "user" && msg.kind === "text" && msg.provisional) {
 							// Confirm the optimistic message
 							const messages = [...session.messages];
-							messages[i] = { ...msg, provisional: false };
+							messages[i] = { ...msg, provisional: false, failed: false };
 							return {
 								sessions: {
 									...state.sessions,
@@ -1240,6 +1289,35 @@ export const useChatStore = create<ChatState>()(
 								...session,
 								messages: [...session.messages, newMsg],
 							},
+						},
+					};
+				}),
+			markUserMessageFailed: (sessionId, messageId) =>
+				set((state: ChatState) => {
+					const session = state.sessions[sessionId];
+					if (!session) {
+						return state;
+					}
+					let updated = false;
+					const messages = session.messages.map((message) => {
+						if (
+							message.id !== messageId ||
+							message.role !== "user" ||
+							message.kind !== "text" ||
+							message.provisional !== true
+						) {
+							return message;
+						}
+						updated = true;
+						return { ...message, failed: true };
+					});
+					if (!updated) {
+						return state;
+					}
+					return {
+						sessions: {
+							...state.sessions,
+							[sessionId]: { ...session, messages },
 						},
 					};
 				}),

--- a/apps/webui/tests/chat-message-list.test.tsx
+++ b/apps/webui/tests/chat-message-list.test.tsx
@@ -187,24 +187,26 @@ describe("ChatMessageList", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("shows loading message when session is loading", () => {
-		const session = buildSession({ isLoading: true });
+	it("shows loading message when session history is syncing", () => {
+		const session = buildSession({ historySyncing: true });
 		render(
 			<ChatMessageList activeSession={session} onPermissionDecision={noop} />,
 		);
-		expect(screen.getByText(i18n.t("common.loading"))).toBeInTheDocument();
+		expect(
+			screen.getByText(i18n.t("session.syncingHistory")),
+		).toBeInTheDocument();
 	});
 
-	it("shows custom loading message when provided", () => {
-		const session = buildSession({ isLoading: true });
+	it("shows custom loading message when provided during history sync", () => {
+		const session = buildSession({ historySyncing: true });
 		render(
 			<ChatMessageList
 				activeSession={session}
-				loadingMessage="Connecting..."
+				loadingMessage="Connecting…"
 				onPermissionDecision={noop}
 			/>,
 		);
-		expect(screen.getByText("Connecting...")).toBeInTheDocument();
+		expect(screen.getByText("Connecting…")).toBeInTheDocument();
 	});
 
 	it("shows logo when session has no messages", () => {


### PR DESCRIPTION
## Summary

This fixes three P1 UX gaps in the WebUI chat flow:

1. History load/sync no longer looks like a blank or frozen page.
2. Session recovery/backfill now has timeouts and visible stale-history warnings.
3. Optimistic user messages now clearly show pending vs failed state.

## What Changed

- Added `historySyncing` and `historySyncWarning` to session state and wired them through activation, manual sync, and backfill completion/error paths.
- Updated header and message list UI so an empty transcript during history sync shows an explicit loading/skeleton state instead of the idle logo-only empty state.
- Added timeout handling for:
  - `loadSession` / `reloadSession`: 30s
  - `/acp/session/events` backfill page fetch: 15s
- Surface backfill/load failures in the UI with a warning that the currently displayed history may be stale.
- Kept optimistic user messages as provisional while sending, and added a failed state when send fails.
- On send failure:
  - mark the provisional user bubble as failed
  - restore the original draft to the input
  - keep the top-level error message
- Added/updated locale strings for loading, stale-history warning, and pending/failed message states.

## UX Impact

- Weak network conditions now show a clear “syncing history” state instead of an apparently empty chat.
- Recovery paths no longer hang indefinitely without feedback.
- Users can distinguish:
  - message sent and awaiting confirmation
  - message failed to send

## Validation

- `pnpm -C apps/webui test:run -- src/hooks/__tests__/useSessionActivation.test.tsx src/hooks/__tests__/useSessionBackfill.test.tsx src/hooks/__tests__/useSocket.test.tsx src/hooks/__tests__/useSessionMutations.test.tsx src/hooks/__tests__/useSessionHandlers.test.tsx src/components/app/__tests__/AppHeader.test.tsx src/components/app/__tests__/ChatMessageList.test.tsx src/components/chat/__tests__/MessageItem.test.tsx src/lib/__tests__/chat-store.test.ts tests/chat-message-list.test.tsx`
- `pnpm -C apps/webui lint`
- `pnpm -C apps/webui build`

## Notes

`lint` still reports 3 pre-existing warnings unrelated to this change:
- `src/components/app/ChatFooter.tsx`
- `src/components/ui/ResizeHandle.tsx`
- `src/components/ui/input-group.tsx`
