### PR TITLE
feat(cli): rewrite daemon transport for bun websocket runtime

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -33,7 +33,8 @@
 		"pino-pretty": "^13.1.1",
 		"resend": "^6.9.1",
 		"socket.io": "^4.8.1",
-		"web-push": "^3.6.7"
+		"web-push": "^3.6.7",
+		"ws": "^8.19.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.11",
@@ -42,6 +43,7 @@
 		"@types/node": "^24.10.1",
 		"@types/pg": "^8.11.0",
 		"@types/web-push": "^3.6.4",
+		"@types/ws": "^8.18.1",
 		"drizzle-kit": "^0.31.4",
 		"tsx": "^4.19.3",
 		"tweetnacl": "^1.0.3",

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -8,6 +8,7 @@ import { toNodeHandler } from "better-auth/node";
 import cors from "cors";
 import express, { type Express } from "express";
 import { Server } from "socket.io";
+import type { WebSocket } from "ws";
 import { getGatewayConfig, tauriOrigins } from "./config.js";
 import { closeDb } from "./db/index.js";
 import { auth } from "./lib/auth.js";
@@ -26,6 +27,7 @@ import { closeRedis, initRedis } from "./services/redis.js";
 import { SessionRouter } from "./services/session-router.js";
 import { UserAffinityManager } from "./services/user-affinity.js";
 import { setupCliHandlers } from "./socket/cli-handlers.js";
+import { createCliWsServer } from "./socket/cli-ws-server.js";
 import { setupWebuiHandlers } from "./socket/webui-handlers.js";
 
 const config = getGatewayConfig();
@@ -146,6 +148,18 @@ httpServer.removeAllListeners("upgrade");
 httpServer.on(
 	"upgrade",
 	async (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+		if (req.url?.startsWith("/cli-ws")) {
+			cliWsServer.handleUpgrade(
+				req,
+				socket,
+				head,
+				(webSocket: WebSocket, upgradedRequest: IncomingMessage) => {
+					cliWsServer.emit("connection", webSocket, upgradedRequest);
+				},
+			);
+			return;
+		}
+
 		if (!req.url?.startsWith("/socket.io")) {
 			socket.destroy();
 			return;
@@ -268,6 +282,56 @@ setupCliHandlers(
 	config,
 	notificationService,
 );
+
+const cliWsServer = createCliWsServer({
+	config,
+	cliRegistry,
+	emitToWebui: (event, payload, userId) => {
+		switch (event) {
+			case "session:attached":
+				if (userId) {
+					webuiEmitter.emitToUser(userId, "session:attached", payload);
+				}
+				return;
+			case "session:detached":
+				if (userId) {
+					webuiEmitter.emitToUser(userId, "session:detached", payload);
+				}
+				return;
+			case "sessions:changed":
+				if (userId) {
+					webuiEmitter.emitToUser(userId, "sessions:changed", payload);
+				}
+				return;
+			case "permission:request":
+				webuiEmitter.emitPermissionRequest(
+					payload as Parameters<typeof webuiEmitter.emitPermissionRequest>[0],
+				);
+				return;
+			case "permission:result":
+				webuiEmitter.emitPermissionResult(
+					payload as Parameters<typeof webuiEmitter.emitPermissionResult>[0],
+				);
+				return;
+			case "session:event":
+				webuiEmitter.emitSessionEvent(
+					payload as Parameters<typeof webuiEmitter.emitSessionEvent>[0],
+				);
+				return;
+			default:
+				logger.warn({ event }, "emitToWebui_unknown_event");
+		}
+	},
+	hasOtherUserConnections: (userId) =>
+		Array.from(io.of("/webui").sockets.values()).some(
+			(socket) =>
+				(socket as unknown as { data: { userId?: string } }).data.userId ===
+				userId,
+		),
+	notificationService,
+	sessionRouter,
+	userAffinity,
+});
 
 app.use((request, response, next) => {
 	const start = process.hrtime.bigint();

--- a/apps/gateway/src/services/cli-registry.ts
+++ b/apps/gateway/src/services/cli-registry.ts
@@ -7,13 +7,35 @@ import type {
 	SessionSummary,
 	SessionsChangedPayload,
 } from "@mobvibe/shared";
-import type { Socket } from "socket.io";
+import type { CliTransport } from "./cli-transport.js";
+
+type TransportLike =
+	| CliTransport
+	| {
+			id: string;
+			emit: (event: string, payload: unknown) => void;
+	  };
+
+const normalizeTransport = (transport: TransportLike): CliTransport => {
+	if ("send" in transport) {
+		return transport;
+	}
+	return {
+		id: transport.id,
+		close: () => {},
+		onDisconnect: () => () => {},
+		send: (type, payload) => {
+			transport.emit(type, payload);
+		},
+	};
+};
 
 export type CliRecord = {
 	machineId: string;
 	hostname: string;
 	version?: string;
-	socket: Socket;
+	socket: TransportLike;
+	transport: CliTransport;
 	connectedAt: Date;
 	sessions: SessionSummary[];
 	backends: AcpBackendSummary[];
@@ -27,25 +49,26 @@ export type CliRecord = {
 
 export class CliRegistry extends EventEmitter {
 	private cliByMachineId = new Map<string, CliRecord>();
-	private cliBySocketId = new Map<string, CliRecord>();
+	private cliByTransportId = new Map<string, CliRecord>();
 	/** Index of machines by user ID for efficient lookup */
 	private clisByUserId = new Map<string, Set<string>>();
 
 	/**
 	 * Register a CLI connection.
-	 * @param socket - The Socket.io socket
+	 * @param transport - The CLI transport
 	 * @param info - CLI registration info
 	 * @param authInfo - Auth info (userId, deviceId) from signed token verification
 	 */
 	register(
-		socket: Socket,
+		transport: TransportLike,
 		info: CliRegistrationInfo,
 		authInfo?: { userId: string; deviceId: string },
 	): CliRecord {
+		const normalizedTransport = normalizeTransport(transport);
 		// Remove any existing connection for this machine
 		const existing = this.cliByMachineId.get(info.machineId);
 		if (existing) {
-			this.cliBySocketId.delete(existing.socket.id);
+			this.cliByTransportId.delete(existing.transport.id);
 			// Remove from user index if it had a userId
 			if (existing.userId) {
 				const userMachines = this.clisByUserId.get(existing.userId);
@@ -62,7 +85,8 @@ export class CliRegistry extends EventEmitter {
 			machineId: info.machineId,
 			hostname: info.hostname,
 			version: info.version,
-			socket,
+			socket: transport,
+			transport: normalizedTransport,
 			connectedAt: new Date(),
 			sessions: [],
 			backends: info.backends ?? [],
@@ -71,7 +95,7 @@ export class CliRegistry extends EventEmitter {
 		};
 
 		this.cliByMachineId.set(info.machineId, record);
-		this.cliBySocketId.set(socket.id, record);
+		this.cliByTransportId.set(normalizedTransport.id, record);
 
 		// Add to user index if authenticated
 		if (authInfo?.userId) {
@@ -96,12 +120,12 @@ export class CliRegistry extends EventEmitter {
 	}
 
 	unregister(socketId: string): CliRecord | undefined {
-		const record = this.cliBySocketId.get(socketId);
+		const record = this.cliByTransportId.get(socketId);
 		if (!record) {
 			return undefined;
 		}
 
-		this.cliBySocketId.delete(socketId);
+		this.cliByTransportId.delete(socketId);
 		this.cliByMachineId.delete(record.machineId);
 
 		// Remove from user index
@@ -126,7 +150,7 @@ export class CliRegistry extends EventEmitter {
 	}
 
 	updateSessions(socketId: string, sessions: SessionSummary[]) {
-		const record = this.cliBySocketId.get(socketId);
+		const record = this.cliByTransportId.get(socketId);
 		if (!record) {
 			return;
 		}
@@ -145,7 +169,7 @@ export class CliRegistry extends EventEmitter {
 		socketId: string,
 		payload: SessionsChangedPayload,
 	): SessionsChangedPayload | undefined {
-		const record = this.cliBySocketId.get(socketId);
+		const record = this.cliByTransportId.get(socketId);
 		if (!record) {
 			return undefined;
 		}
@@ -180,9 +204,12 @@ export class CliRegistry extends EventEmitter {
 
 		// Emit the enhanced payload with machineId
 		const enhancedPayload: SessionsChangedPayload = {
-			added: payload.added.map((s) => ({ ...s, machineId: record.machineId })),
-			updated: payload.updated.map((s) => ({
-				...s,
+			added: payload.added.map((session) => ({
+				...session,
+				machineId: record.machineId,
+			})),
+			updated: payload.updated.map((session) => ({
+				...session,
 				machineId: record.machineId,
 			})),
 			removed: payload.removed,
@@ -222,7 +249,7 @@ export class CliRegistry extends EventEmitter {
 		socketId: string,
 		sessions: SessionSummary[],
 	): SessionSummary[] {
-		const record = this.cliBySocketId.get(socketId);
+		const record = this.cliByTransportId.get(socketId);
 		if (!record) {
 			return [];
 		}
@@ -292,7 +319,7 @@ export class CliRegistry extends EventEmitter {
 	}
 
 	getCliBySocketId(socketId: string): CliRecord | undefined {
-		return this.cliBySocketId.get(socketId);
+		return this.cliByTransportId.get(socketId);
 	}
 
 	/**
@@ -410,7 +437,7 @@ export class CliRegistry extends EventEmitter {
 		socketId: string,
 		capabilities: Record<string, AgentSessionCapabilities>,
 	): void {
-		const record = this.cliBySocketId.get(socketId);
+		const record = this.cliByTransportId.get(socketId);
 		if (!record) return;
 		record.backendCapabilities = {
 			...record.backendCapabilities,

--- a/apps/gateway/src/services/cli-transport.ts
+++ b/apps/gateway/src/services/cli-transport.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from "node:events";
+import type {
+	GatewayToCliWirePayloadMap,
+	GatewayToCliWireType,
+} from "@mobvibe/shared";
+
+export interface CliTransport {
+	readonly id: string;
+	close(code?: number, reason?: string): void;
+	onDisconnect(listener: (reason?: string) => void): () => void;
+	send<TType extends GatewayToCliWireType>(
+		type: TType,
+		payload: GatewayToCliWirePayloadMap[TType],
+	): void;
+}
+
+export class CliTransportDisconnectEmitter {
+	private readonly emitter = new EventEmitter();
+
+	emit(reason?: string) {
+		this.emitter.emit("disconnect", reason);
+	}
+
+	on(listener: (reason?: string) => void) {
+		this.emitter.on("disconnect", listener);
+		return () => {
+			this.emitter.off("disconnect", listener);
+		};
+	}
+}

--- a/apps/gateway/src/services/session-router.ts
+++ b/apps/gateway/src/services/session-router.ts
@@ -54,9 +54,9 @@ import type {
 	SetSessionModeParams,
 	StopReason,
 } from "@mobvibe/shared";
-import type { Socket } from "socket.io";
 import { logger } from "../lib/logger.js";
 import type { CliRecord, CliRegistry } from "./cli-registry.js";
+import type { CliTransport } from "./cli-transport.js";
 
 type PendingRpc<T> = {
 	requestId: string;
@@ -159,7 +159,7 @@ export class SessionRouter {
 			worktree: params.worktree,
 		};
 		const result = await this.sendRpc<CreateSessionParams, SessionSummary>(
-			cli.socket,
+			cli.transport,
 			"rpc:session:create",
 			rpcParams,
 		);
@@ -189,7 +189,7 @@ export class SessionRouter {
 
 		const cli = this.resolveCliForSession(params.sessionId, userId);
 		const result = await this.sendRpc<ArchiveSessionParams, { ok: boolean }>(
-			cli.socket,
+			cli.transport,
 			"rpc:session:archive",
 			{
 				sessionId: params.sessionId,
@@ -197,7 +197,7 @@ export class SessionRouter {
 		);
 
 		// Immediately remove from registry so the webui sees it gone
-		this.cliRegistry.updateSessionsIncremental(cli.socket.id, {
+		this.cliRegistry.updateSessionsIncremental(cli.transport.id, {
 			added: [],
 			updated: [],
 			removed: [params.sessionId],
@@ -258,10 +258,10 @@ export class SessionRouter {
 				const result = await this.sendRpc<
 					BulkArchiveSessionsParams,
 					{ archivedCount: number }
-				>(cli.socket, "rpc:session:archive-all", { sessionIds: ids });
+				>(cli.transport, "rpc:session:archive-all", { sessionIds: ids });
 
 				// Immediately remove from registry so the webui sees them gone
-				this.cliRegistry.updateSessionsIncremental(cli.socket.id, {
+				this.cliRegistry.updateSessionsIncremental(cli.transport.id, {
 					added: [],
 					updated: [],
 					removed: ids,
@@ -303,7 +303,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<RenameSessionParams, SessionSummary>(
-			cli.socket,
+			cli.transport,
 			"rpc:session:rename",
 			params,
 		);
@@ -333,7 +333,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<CancelSessionParams, { ok: boolean }>(
-			cli.socket,
+			cli.transport,
 			"rpc:session:cancel",
 			params,
 		);
@@ -363,7 +363,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<SetSessionModeParams, SessionSummary>(
-			cli.socket,
+			cli.transport,
 			"rpc:session:mode",
 			params,
 		);
@@ -393,7 +393,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<SetSessionModelParams, SessionSummary>(
-			cli.socket,
+			cli.transport,
 			"rpc:session:model",
 			params,
 		);
@@ -427,7 +427,7 @@ export class SessionRouter {
 		);
 
 		return this.sendRpc<SendMessageParams, { stopReason: StopReason }>(
-			cli.socket,
+			cli.transport,
 			"rpc:message:send",
 			params,
 		);
@@ -452,7 +452,7 @@ export class SessionRouter {
 		const result = await this.sendRpc<
 			PermissionDecisionPayload,
 			{ ok: boolean }
-		>(cli.socket, "rpc:permission:decision", params);
+		>(cli.transport, "rpc:permission:decision", params);
 
 		logger.info(
 			{ sessionId: params.sessionId, requestId: params.requestId, userId },
@@ -476,7 +476,7 @@ export class SessionRouter {
 		logger.debug({ sessionId, userId }, "fs_roots_rpc_start");
 
 		const result = await this.sendRpc<{ sessionId: string }, FsRootsResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:fs:roots",
 			{ sessionId },
 		);
@@ -502,7 +502,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<FsEntriesParams, FsEntriesResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:fs:entries",
 			params,
 		);
@@ -529,7 +529,7 @@ export class SessionRouter {
 		logger.debug({ sessionId: params.sessionId, userId }, "fs_file_rpc_start");
 
 		const result = await this.sendRpc<FsFileParams, SessionFsFilePreview>(
-			cli.socket,
+			cli.transport,
 			"rpc:fs:file",
 			params,
 		);
@@ -559,7 +559,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<FsResourcesParams, FsResourcesResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:fs:resources",
 			params,
 		);
@@ -587,7 +587,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<HostFsRootsParams, HostFsRootsResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:hostfs:roots",
 			params,
 		);
@@ -614,7 +614,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<HostFsEntriesParams, FsEntriesResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:hostfs:entries",
 			params,
 		);
@@ -661,7 +661,7 @@ export class SessionRouter {
 		const result = await this.sendRpc<
 			DiscoverSessionsRpcParams,
 			DiscoverSessionsRpcResult
-		>(cli.socket, "rpc:sessions:discover", params);
+		>(cli.transport, "rpc:sessions:discover", params);
 
 		logger.info(
 			{
@@ -716,7 +716,7 @@ export class SessionRouter {
 			backendId: params.backendId,
 		};
 		const result = await this.sendRpc<LoadSessionRpcParams, SessionSummary>(
-			cli.socket,
+			cli.transport,
 			"rpc:session:load",
 			rpcParams,
 		);
@@ -770,7 +770,7 @@ export class SessionRouter {
 			backendId: params.backendId,
 		};
 		const result = await this.sendRpc<ReloadSessionRpcParams, SessionSummary>(
-			cli.socket,
+			cli.transport,
 			"rpc:session:reload",
 			rpcParams,
 		);
@@ -797,7 +797,7 @@ export class SessionRouter {
 		logger.debug({ sessionId, userId }, "git_status_rpc_start");
 
 		const result = await this.sendRpc<GitStatusParams, GitStatusResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:status",
 			{ sessionId },
 		);
@@ -823,7 +823,7 @@ export class SessionRouter {
 		);
 
 		const result = await this.sendRpc<GitFileDiffParams, GitFileDiffResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:fileDiff",
 			params,
 		);
@@ -845,7 +845,7 @@ export class SessionRouter {
 		const cli = this.resolveCliForSession(params.sessionId, userId);
 		logger.debug({ sessionId: params.sessionId, userId }, "git_log_rpc_start");
 		const result = await this.sendRpc<GitLogParams, GitLogResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:log",
 			params,
 		);
@@ -869,7 +869,7 @@ export class SessionRouter {
 			"git_show_rpc_start",
 		);
 		const result = await this.sendRpc<GitShowParams, GitShowResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:show",
 			params,
 		);
@@ -893,7 +893,7 @@ export class SessionRouter {
 			"git_blame_rpc_start",
 		);
 		const result = await this.sendRpc<GitBlameParams, GitBlameResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:blame",
 			params,
 		);
@@ -917,7 +917,7 @@ export class SessionRouter {
 			"git_branches_rpc_start",
 		);
 		const result = await this.sendRpc<GitBranchesParams, GitBranchesResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:branches",
 			params,
 		);
@@ -943,7 +943,7 @@ export class SessionRouter {
 		const result = await this.sendRpc<
 			GitBranchesForCwdParams,
 			GitBranchesForCwdResponse
-		>(cli.socket, "rpc:git:branchesForCwd", { cwd: params.cwd });
+		>(cli.transport, "rpc:git:branchesForCwd", { cwd: params.cwd });
 		logger.debug(
 			{ cwd: params.cwd, userId },
 			"git_branches_for_cwd_rpc_complete",
@@ -964,7 +964,7 @@ export class SessionRouter {
 			"git_stash_list_rpc_start",
 		);
 		const result = await this.sendRpc<GitStashListParams, GitStashListResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:stashList",
 			params,
 		);
@@ -990,7 +990,7 @@ export class SessionRouter {
 		const result = await this.sendRpc<
 			GitStatusExtendedParams,
 			GitStatusExtendedResponse
-		>(cli.socket, "rpc:git:statusExtended", params);
+		>(cli.transport, "rpc:git:statusExtended", params);
 		logger.debug(
 			{ sessionId: params.sessionId, userId },
 			"git_status_extended_rpc_complete",
@@ -1011,7 +1011,7 @@ export class SessionRouter {
 			"git_search_log_rpc_start",
 		);
 		const result = await this.sendRpc<GitSearchLogParams, GitSearchLogResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:searchLog",
 			params,
 		);
@@ -1037,7 +1037,7 @@ export class SessionRouter {
 		const result = await this.sendRpc<
 			GitFileHistoryParams,
 			GitFileHistoryResponse
-		>(cli.socket, "rpc:git:fileHistory", params);
+		>(cli.transport, "rpc:git:fileHistory", params);
 		logger.debug(
 			{ sessionId: params.sessionId, path: params.path, userId },
 			"git_file_history_rpc_complete",
@@ -1058,7 +1058,7 @@ export class SessionRouter {
 			"git_grep_rpc_start",
 		);
 		const result = await this.sendRpc<GitGrepParams, GitGrepResponse>(
-			cli.socket,
+			cli.transport,
 			"rpc:git:grep",
 			params,
 		);
@@ -1093,7 +1093,7 @@ export class SessionRouter {
 		const result = await this.sendRpc<
 			SessionEventsParams,
 			SessionEventsResponse
-		>(cli.socket, "rpc:session:events", params);
+		>(cli.transport, "rpc:session:events", params);
 
 		logger.debug(
 			{
@@ -1109,7 +1109,7 @@ export class SessionRouter {
 	}
 
 	private sendRpc<TParams, TResult>(
-		socket: Socket,
+		transport: CliTransport,
 		event: string,
 		params: TParams,
 	): Promise<TResult> {
@@ -1151,7 +1151,7 @@ export class SessionRouter {
 
 			const request: RpcRequest<TParams> = { requestId, params };
 			logger.debug({ requestId, event }, "rpc_request_sent");
-			socket.emit(event, request);
+			transport.send(event as never, request as never);
 		});
 	}
 }

--- a/apps/gateway/src/socket/cli-connection.ts
+++ b/apps/gateway/src/socket/cli-connection.ts
@@ -1,0 +1,494 @@
+import type {
+	CliRegistrationInfo,
+	CliToGatewayWirePayloadMap,
+	CliToGatewayWireType,
+	PermissionDecisionPayload,
+	PermissionRequestPayload,
+	RpcResponse,
+	SessionAttachedPayload,
+	SessionDetachedPayload,
+	SessionEvent,
+	SessionSummary,
+	SessionsChangedPayload,
+	SessionsDiscoveredPayload,
+} from "@mobvibe/shared";
+import { logger } from "../lib/logger.js";
+import type { CliRegistry } from "../services/cli-registry.js";
+import type { CliTransport } from "../services/cli-transport.js";
+import {
+	findDeviceByPublicKey,
+	upsertMachine,
+} from "../services/db-service.js";
+import type { NotificationService } from "../services/notification-service.js";
+import type { SessionRouter } from "../services/session-router.js";
+import type { UserAffinityManager } from "../services/user-affinity.js";
+
+export type AuthenticatedCliContext = {
+	deviceId?: string;
+	transport: CliTransport;
+	userId?: string;
+};
+
+type CliConnectionDeps = {
+	cliRegistry: CliRegistry;
+	emitToWebui: (event: string, payload: unknown, userId?: string) => void;
+	hasOtherUserConnections: (userId: string) => boolean;
+	notificationService?: NotificationService;
+	sessionRouter: SessionRouter;
+	userAffinity: UserAffinityManager | null;
+};
+
+const isActiveCliSession = (
+	record: ReturnType<CliRegistry["getCliBySocketId"]>,
+	sessionId: string,
+): boolean => {
+	if (!record) {
+		return false;
+	}
+	const session = record.sessions.find(
+		(candidate) => candidate.sessionId === sessionId,
+	);
+	return session ? session.isAttached !== false : true;
+};
+
+const forwardRegistration = async (
+	context: AuthenticatedCliContext,
+	info: CliRegistrationInfo,
+	deps: CliConnectionDeps,
+) => {
+	const { cliRegistry, userAffinity } = deps;
+	const rawMachineId = info.machineId;
+	const userId = context.userId;
+	const deviceId = context.deviceId;
+
+	if (!userId || !deviceId) {
+		logger.warn(
+			{ transportId: context.transport.id },
+			"cli_rejected_missing_auth_data",
+		);
+		context.transport.send("cli:error", {
+			code: "AUTH_REQUIRED",
+			message: "Device not authenticated. Run 'mobvibe login' to register.",
+		});
+		context.transport.close(4001, "AUTH_REQUIRED");
+		return;
+	}
+
+	logger.info(
+		{ machineId: rawMachineId, hostname: info.hostname, userId },
+		"cli_register_start",
+	);
+	const machineResult = await upsertMachine({
+		rawMachineId,
+		userId,
+		name: info.hostname,
+		hostname: info.hostname,
+		platform: undefined,
+	});
+
+	if (!machineResult) {
+		logger.error({ machineId: info.machineId, userId }, "cli_register_failed");
+		context.transport.send("cli:error", {
+			code: "REGISTRATION_ERROR",
+			message: "Failed to register machine. Please try again.",
+		});
+		context.transport.close(1011, "REGISTRATION_ERROR");
+		return;
+	}
+
+	const resolvedMachineId = machineResult.machineId;
+	const record = cliRegistry.register(
+		context.transport,
+		{ ...info, machineId: resolvedMachineId },
+		{
+			userId,
+			deviceId,
+		},
+	);
+
+	if (userAffinity) {
+		await userAffinity.claimUser(userId);
+	}
+
+	context.transport.send("cli:registered", {
+		machineId: record.machineId,
+		userId,
+	});
+	logger.info(
+		{
+			machineId: record.machineId,
+			rawMachineId,
+			hostname: info.hostname,
+			userId,
+		},
+		"cli_registered",
+	);
+};
+
+const forwardDiscoveredSessions = (
+	context: AuthenticatedCliContext,
+	payload: SessionsDiscoveredPayload,
+	deps: CliConnectionDeps,
+) => {
+	const { cliRegistry, emitToWebui } = deps;
+	const cliRecord = cliRegistry.getCliBySocketId(context.transport.id);
+	if (!cliRecord) {
+		logger.warn(
+			{ transportId: context.transport.id },
+			"sessions_discovered_no_cli_record",
+		);
+		return;
+	}
+
+	const { sessions, capabilities } = payload;
+	if (capabilities && payload.backendId) {
+		cliRegistry.updateBackendCapabilities(context.transport.id, {
+			[payload.backendId]: capabilities,
+		});
+	}
+
+	const historicalSessions: SessionSummary[] = sessions.map((session) => ({
+		sessionId: session.sessionId,
+		title: session.title ?? `Session ${session.sessionId.slice(0, 8)}`,
+		cwd: session.cwd,
+		workspaceRootCwd: session.workspaceRootCwd,
+		updatedAt: session.updatedAt ?? new Date().toISOString(),
+		createdAt: session.updatedAt ?? new Date().toISOString(),
+		backendId: payload.backendId,
+		backendLabel: payload.backendLabel,
+		machineId: cliRecord.machineId,
+	}));
+
+	const added = cliRegistry.addDiscoveredSessions(
+		context.transport.id,
+		historicalSessions,
+	);
+
+	if (cliRecord.userId && (added.length > 0 || capabilities)) {
+		emitToWebui(
+			"sessions:changed",
+			{
+				added,
+				updated: [],
+				removed: [],
+				backendCapabilities: payload.backendId
+					? { [payload.backendId]: capabilities }
+					: undefined,
+			},
+			cliRecord.userId,
+		);
+	}
+
+	logger.info(
+		{
+			machineId: cliRecord.machineId,
+			count: sessions.length,
+			capabilities,
+		},
+		"historical_sessions_synced",
+	);
+};
+
+const forwardAttached = (
+	context: AuthenticatedCliContext,
+	payload: SessionAttachedPayload,
+	deps: CliConnectionDeps,
+) => {
+	const record = deps.cliRegistry.getCliBySocketId(context.transport.id);
+	if (!record) {
+		logger.warn(
+			{ transportId: context.transport.id },
+			"session_attached_unregistered_cli",
+		);
+		return;
+	}
+
+	logger.info(
+		{ sessionId: payload.sessionId, machineId: record.machineId },
+		"session_attached_received",
+	);
+	deps.emitToWebui(
+		"session:attached",
+		{ ...payload, machineId: record.machineId },
+		record.userId,
+	);
+};
+
+const forwardDetached = (
+	context: AuthenticatedCliContext,
+	payload: SessionDetachedPayload,
+	deps: CliConnectionDeps,
+) => {
+	const record = deps.cliRegistry.getCliBySocketId(context.transport.id);
+	if (!record) {
+		logger.warn(
+			{ transportId: context.transport.id },
+			"session_detached_unregistered_cli",
+		);
+		return;
+	}
+
+	logger.info(
+		{
+			sessionId: payload.sessionId,
+			machineId: record.machineId,
+			reason: payload.reason,
+		},
+		"session_detached_received",
+	);
+	deps.emitToWebui(
+		"session:detached",
+		{ ...payload, machineId: record.machineId },
+		record.userId,
+	);
+};
+
+const forwardPermissionRequest = (
+	context: AuthenticatedCliContext,
+	payload: PermissionRequestPayload,
+	deps: CliConnectionDeps,
+) => {
+	const record = deps.cliRegistry.getCliBySocketId(context.transport.id);
+	if (!record) {
+		logger.warn(
+			{ transportId: context.transport.id },
+			"permission_request_unregistered_cli",
+		);
+		return;
+	}
+
+	logger.info(
+		{ sessionId: payload.sessionId, requestId: payload.requestId },
+		"permission_request_received",
+	);
+	deps.emitToWebui("permission:request", payload, record.userId);
+	if (
+		record.userId &&
+		deps.notificationService &&
+		isActiveCliSession(record, payload.sessionId)
+	) {
+		void deps.notificationService.notifyPermissionRequest(
+			record.userId,
+			payload,
+		);
+	}
+};
+
+const forwardPermissionResult = (
+	context: AuthenticatedCliContext,
+	payload: PermissionDecisionPayload,
+	deps: CliConnectionDeps,
+) => {
+	const record = deps.cliRegistry.getCliBySocketId(context.transport.id);
+	if (!record) {
+		logger.warn(
+			{ transportId: context.transport.id },
+			"permission_result_unregistered_cli",
+		);
+		return;
+	}
+
+	logger.info(
+		{ sessionId: payload.sessionId, requestId: payload.requestId },
+		"permission_result_received",
+	);
+	deps.emitToWebui("permission:result", payload, record.userId);
+};
+
+const forwardSessionEvent = (
+	context: AuthenticatedCliContext,
+	event: SessionEvent,
+	deps: CliConnectionDeps,
+) => {
+	const record = deps.cliRegistry.getCliBySocketId(context.transport.id);
+	if (!record) {
+		logger.warn(
+			{ transportId: context.transport.id },
+			"session_event_unregistered_cli",
+		);
+		return;
+	}
+
+	logger.debug(
+		{
+			sessionId: event.sessionId,
+			revision: event.revision,
+			seq: event.seq,
+			kind: event.kind,
+			transportId: context.transport.id,
+		},
+		"session_event_received",
+	);
+	deps.emitToWebui("session:event", event, record.userId);
+	if (
+		record.userId &&
+		deps.notificationService &&
+		isActiveCliSession(record, event.sessionId)
+	) {
+		void deps.notificationService.notifySessionEvent(record.userId, event);
+	}
+
+	context.transport.send("events:ack", {
+		sessionId: event.sessionId,
+		revision: event.revision,
+		upToSeq: event.seq,
+	});
+};
+
+export const createCliConnectionHandlers = (deps: CliConnectionDeps) => ({
+	async handleMessage<TType extends CliToGatewayWireType>(
+		context: AuthenticatedCliContext,
+		type: TType,
+		payload: CliToGatewayWirePayloadMap[TType],
+	) {
+		switch (type) {
+			case "cli:register":
+				await forwardRegistration(
+					context,
+					payload as CliRegistrationInfo,
+					deps,
+				);
+				return;
+			case "cli:heartbeat":
+				return;
+			case "sessions:list":
+				deps.cliRegistry.updateSessions(
+					context.transport.id,
+					payload as SessionSummary[],
+				);
+				logger.debug(
+					{
+						transportId: context.transport.id,
+						sessionCount: (payload as SessionSummary[]).length,
+					},
+					"cli_sessions_list",
+				);
+				return;
+			case "sessions:changed":
+				logger.info(
+					{
+						transportId: context.transport.id,
+						added: (payload as SessionsChangedPayload).added.length,
+						updated: (payload as SessionsChangedPayload).updated.length,
+						removed: (payload as SessionsChangedPayload).removed.length,
+					},
+					"cli_sessions_changed",
+				);
+				deps.cliRegistry.updateSessionsIncremental(
+					context.transport.id,
+					payload as SessionsChangedPayload,
+				);
+				return;
+			case "sessions:discovered":
+				forwardDiscoveredSessions(
+					context,
+					payload as SessionsDiscoveredPayload,
+					deps,
+				);
+				return;
+			case "session:attached":
+				forwardAttached(context, payload as SessionAttachedPayload, deps);
+				return;
+			case "session:detached":
+				forwardDetached(context, payload as SessionDetachedPayload, deps);
+				return;
+			case "permission:request":
+				forwardPermissionRequest(
+					context,
+					payload as PermissionRequestPayload,
+					deps,
+				);
+				return;
+			case "permission:result":
+				forwardPermissionResult(
+					context,
+					payload as PermissionDecisionPayload,
+					deps,
+				);
+				return;
+			case "session:event":
+				forwardSessionEvent(context, payload as SessionEvent, deps);
+				return;
+			case "rpc:response":
+				logger.debug(
+					{
+						requestId: (payload as RpcResponse<unknown>).requestId,
+						isError: Boolean((payload as RpcResponse<unknown>).error),
+						code: (payload as RpcResponse<unknown>).error?.code,
+					},
+					"rpc_response_received",
+				);
+				deps.sessionRouter.handleRpcResponse(payload as RpcResponse<unknown>);
+				return;
+		}
+	},
+	async handleDisconnect(context: AuthenticatedCliContext, reason?: string) {
+		const { cliRegistry, emitToWebui, userAffinity } = deps;
+		const preRecord = cliRegistry.getCliBySocketId(context.transport.id);
+		const cachedUserId = preRecord?.userId;
+		const record = cliRegistry.unregister(context.transport.id);
+		if (!record) {
+			return;
+		}
+
+		logger.info(
+			{
+				machineId: record.machineId,
+				reason,
+				transportId: context.transport.id,
+			},
+			"cli_disconnected",
+		);
+		for (const session of record.sessions) {
+			if (!session.isAttached) {
+				continue;
+			}
+			emitToWebui(
+				"session:detached",
+				{
+					sessionId: session.sessionId,
+					machineId: record.machineId,
+					detachedAt: new Date().toISOString(),
+					reason: "cli_disconnect",
+				},
+				cachedUserId,
+			);
+		}
+
+		if (userAffinity && cachedUserId) {
+			const hasCliConnections =
+				cliRegistry.getClisForUser(cachedUserId).length > 0;
+			const hasOtherConnections = deps.hasOtherUserConnections(cachedUserId);
+			if (!hasCliConnections && !hasOtherConnections) {
+				await userAffinity.releaseUser(cachedUserId);
+			}
+		}
+	},
+});
+
+export const cliMessageTypes: CliToGatewayWireType[] = [
+	"cli:heartbeat",
+	"cli:register",
+	"permission:request",
+	"permission:result",
+	"rpc:response",
+	"session:attached",
+	"session:detached",
+	"session:event",
+	"sessions:changed",
+	"sessions:discovered",
+	"sessions:list",
+];
+
+export const authenticateCliToken = async (
+	publicKey: string,
+): Promise<{ deviceId: string; userId: string } | null> => {
+	const device = await findDeviceByPublicKey(publicKey);
+	if (!device) {
+		return null;
+	}
+	return {
+		userId: device.userId,
+		deviceId: device.id,
+	};
+};

--- a/apps/gateway/src/socket/cli-handlers.ts
+++ b/apps/gateway/src/socket/cli-handlers.ts
@@ -1,46 +1,51 @@
-import type {
-	CliRegistrationInfo,
-	PermissionDecisionPayload,
-	PermissionRequestPayload,
-	RpcResponse,
-	SessionAttachedPayload,
-	SessionDetachedPayload,
-	SessionEvent,
-	SessionSummary,
-	SessionsChangedPayload,
-	SessionsDiscoveredPayload,
-	SignedAuthToken,
-} from "@mobvibe/shared";
+import type { SignedAuthToken } from "@mobvibe/shared";
 import { initCrypto, verifySignedToken } from "@mobvibe/shared";
 import type { Server, Socket } from "socket.io";
 import type { GatewayConfig } from "../config.js";
 import { logger } from "../lib/logger.js";
 import type { CliRegistry } from "../services/cli-registry.js";
 import {
-	findDeviceByPublicKey,
-	upsertMachine,
-} from "../services/db-service.js";
+	type CliTransport,
+	CliTransportDisconnectEmitter,
+} from "../services/cli-transport.js";
 import type { NotificationService } from "../services/notification-service.js";
 import type { SessionRouter } from "../services/session-router.js";
 import type { UserAffinityManager } from "../services/user-affinity.js";
+import {
+	cliMessageTypes,
+	createCliConnectionHandlers,
+} from "./cli-connection.js";
 
-/**
- * Extended socket data with auth info.
- */
 interface SocketData {
-	userId?: string;
 	deviceId?: string;
+	userId?: string;
 }
 
-export type CliHandlersDeps = {
-	io: Server;
-	cliRegistry: CliRegistry;
-	sessionRouter: SessionRouter;
-	emitToWebui: (event: string, payload: unknown, userId?: string) => void;
-	userAffinity: UserAffinityManager | null;
-	config: GatewayConfig;
-	notificationService?: NotificationService;
-};
+class SocketIoCliTransport implements CliTransport {
+	private readonly disconnects = new CliTransportDisconnectEmitter();
+
+	constructor(private readonly socket: Socket) {}
+
+	get id() {
+		return this.socket.id;
+	}
+
+	close(): void {
+		this.socket.disconnect(true);
+	}
+
+	onDisconnect(listener: (reason?: string) => void): () => void {
+		return this.disconnects.on(listener);
+	}
+
+	send(type: string, payload: unknown): void {
+		this.socket.emit(type, payload);
+	}
+
+	emitDisconnect(reason?: string) {
+		this.disconnects.emit(reason);
+	}
+}
 
 export function setupCliHandlers(
 	io: Server,
@@ -52,28 +57,25 @@ export function setupCliHandlers(
 	notificationService?: NotificationService,
 ) {
 	const cliNamespace = io.of("/cli");
-
-	const isActiveCliSession = (
-		record: ReturnType<CliRegistry["getCliBySocketId"]>,
-		sessionId: string,
-	): boolean => {
-		if (!record) {
-			return false;
-		}
-		const session = record.sessions.find(
-			(candidate) => candidate.sessionId === sessionId,
-		);
-		return session ? session.isAttached !== false : true;
-	};
-
-	// Ensure crypto is ready for signature verification
 	const cryptoReady = initCrypto();
+	const connectionHandlers = createCliConnectionHandlers({
+		cliRegistry,
+		emitToWebui,
+		hasOtherUserConnections: (userId: string) =>
+			Array.from(io.of("/webui").sockets.values()).some(
+				(socket) =>
+					(socket as Socket & { data: { userId?: string } }).data.userId ===
+					userId,
+			),
+		notificationService,
+		sessionRouter,
+		userAffinity,
+	});
 
 	cliNamespace.use(async (socket: Socket, next) => {
 		await cryptoReady;
 
 		const authToken = socket.handshake.auth as SignedAuthToken | undefined;
-
 		if (
 			!authToken?.payload?.publicKey ||
 			!authToken?.payload?.timestamp ||
@@ -90,8 +92,9 @@ export function setupCliHandlers(
 				return next(new Error("INVALID_TOKEN"));
 			}
 
-			const device = await findDeviceByPublicKey(verified.publicKey);
-			if (!device) {
+			const { authenticateCliToken } = await import("./cli-connection.js");
+			const authInfo = await authenticateCliToken(verified.publicKey);
+			if (!authInfo) {
 				logger.warn(
 					{ publicKey: verified.publicKey },
 					"cli_rejected_unregistered_device",
@@ -99,23 +102,18 @@ export function setupCliHandlers(
 				return next(new Error("DEVICE_NOT_REGISTERED"));
 			}
 
-			const socketData: SocketData = {
-				userId: device.userId,
-				deviceId: device.id,
-			};
-			(socket as Socket & { data: SocketData }).data = socketData;
+			(socket as Socket & { data: SocketData }).data = authInfo;
 			logger.info(
-				{ userId: device.userId, deviceId: device.id },
+				{ userId: authInfo.userId, deviceId: authInfo.deviceId },
 				"cli_authenticated",
 			);
 
-			// Check user affinity — redirect to correct instance if needed
 			if (userAffinity && config) {
-				const target = await userAffinity.getUserInstance(device.userId);
+				const target = await userAffinity.getUserInstance(authInfo.userId);
 				if (target && target.instanceId !== config.instanceId) {
 					logger.info(
 						{
-							userId: device.userId,
+							userId: authInfo.userId,
 							targetInstance: target.instanceId,
 							thisInstance: config.instanceId,
 						},
@@ -134,361 +132,23 @@ export function setupCliHandlers(
 
 	cliNamespace.on("connection", (socket: Socket) => {
 		logger.info({ socketId: socket.id }, "cli_connected");
-
+		const transport = new SocketIoCliTransport(socket);
 		const socketData = (socket as Socket & { data: SocketData }).data;
-		const userId = socketData?.userId;
-		const deviceId = socketData?.deviceId;
+		const context = {
+			deviceId: socketData?.deviceId,
+			transport,
+			userId: socketData?.userId,
+		};
 
-		if (!userId || !deviceId) {
-			logger.warn({ socketId: socket.id }, "cli_rejected_missing_auth_data");
-			socket.emit("cli:error", {
-				code: "AUTH_REQUIRED",
-				message: "Device not authenticated. Run 'mobvibe login' to register.",
+		for (const type of cliMessageTypes) {
+			socket.on(type, (payload) => {
+				void connectionHandlers.handleMessage(context, type, payload as never);
 			});
-			socket.disconnect(true);
-			return;
 		}
 
-		// CLI registration (after auth)
-		socket.on("cli:register", async (info: CliRegistrationInfo) => {
-			const rawMachineId = info.machineId;
-			// Create or update machine record in database
-			logger.info(
-				{ machineId: rawMachineId, hostname: info.hostname, userId },
-				"cli_register_start",
-			);
-			const machineResult = await upsertMachine({
-				rawMachineId,
-				userId,
-				name: info.hostname,
-				hostname: info.hostname,
-				platform: undefined,
-			});
-
-			if (!machineResult) {
-				logger.error(
-					{ machineId: info.machineId, userId },
-					"cli_register_failed",
-				);
-				socket.emit("cli:error", {
-					code: "REGISTRATION_ERROR",
-					message: "Failed to register machine. Please try again.",
-				});
-				socket.disconnect(true);
-				return;
-			}
-
-			const resolvedMachineId = machineResult.machineId;
-
-			// Register with in-memory registry
-			const record = cliRegistry.register(
-				socket,
-				{ ...info, machineId: resolvedMachineId },
-				{
-					userId,
-					deviceId,
-				},
-			);
-
-			// Claim user affinity for this instance
-			if (userAffinity) {
-				await userAffinity.claimUser(userId);
-			}
-
-			socket.emit("cli:registered", {
-				machineId: record.machineId,
-				userId,
-			});
-			logger.info(
-				{
-					machineId: record.machineId,
-					rawMachineId,
-					hostname: info.hostname,
-					userId,
-				},
-				"cli_registered",
-			);
-		});
-
-		// Heartbeat
-		socket.on("cli:heartbeat", () => {
-			// Just acknowledge
-		});
-
-		// Sessions list update (initial sync and heartbeat)
-		socket.on("sessions:list", (sessions: SessionSummary[]) => {
-			cliRegistry.updateSessions(socket.id, sessions);
-			logger.debug(
-				{ socketId: socket.id, sessionCount: sessions.length },
-				"cli_sessions_list",
-			);
-		});
-
-		// Incremental sessions update
-		socket.on("sessions:changed", (payload: SessionsChangedPayload) => {
-			logger.info(
-				{
-					socketId: socket.id,
-					added: payload.added.length,
-					updated: payload.updated.length,
-					removed: payload.removed.length,
-				},
-				"cli_sessions_changed",
-			);
-			cliRegistry.updateSessionsIncremental(socket.id, payload);
-		});
-
-		// Historical sessions discovered from ACP agent
-		socket.on("sessions:discovered", (payload: SessionsDiscoveredPayload) => {
-			const cliRecord = cliRegistry.getCliBySocketId(socket.id);
-			if (!cliRecord) {
-				logger.warn(
-					{ socketId: socket.id },
-					"sessions_discovered_no_cli_record",
-				);
-				return;
-			}
-
-			const { sessions, capabilities } = payload;
-
-			// Update per-backend capabilities from discovery result
-			if (capabilities && payload.backendId) {
-				cliRegistry.updateBackendCapabilities(socket.id, {
-					[payload.backendId]: capabilities,
-				});
-			}
-
-			// Transform AcpSessionInfo to SessionSummary with historical markers
-			const historicalSessions: SessionSummary[] = sessions.map((s) => ({
-				sessionId: s.sessionId,
-				title: s.title ?? `Session ${s.sessionId.slice(0, 8)}`,
-				cwd: s.cwd,
-				workspaceRootCwd: s.workspaceRootCwd,
-				updatedAt: s.updatedAt ?? new Date().toISOString(),
-				createdAt: s.updatedAt ?? new Date().toISOString(),
-				backendId: payload.backendId,
-				backendLabel: payload.backendLabel,
-				machineId: cliRecord.machineId,
-			}));
-
-			// Add to CLI registry (returns only actually new sessions)
-			const added = cliRegistry.addDiscoveredSessions(
-				socket.id,
-				historicalSessions,
-			);
-
-			// Emit sessions:changed to webui (with capabilities even if no new sessions)
-			if (cliRecord.userId && (added.length > 0 || capabilities)) {
-				emitToWebui(
-					"sessions:changed",
-					{
-						added,
-						updated: [],
-						removed: [],
-						backendCapabilities: payload.backendId
-							? { [payload.backendId]: capabilities }
-							: undefined,
-					},
-					cliRecord.userId,
-				);
-			}
-
-			logger.info(
-				{
-					machineId: cliRecord.machineId,
-					count: sessions.length,
-					capabilities,
-				},
-				"historical_sessions_synced",
-			);
-		});
-
-		// Note: session:update and session:error are deprecated - all content updates
-		// now go through session:event (WAL-persisted events with seq/revision)
-
-		// Session attached
-		socket.on("session:attached", (payload: SessionAttachedPayload) => {
-			const record = cliRegistry.getCliBySocketId(socket.id);
-			if (!record) {
-				logger.warn(
-					{ socketId: socket.id },
-					"session_attached_unregistered_cli",
-				);
-				return;
-			}
-			logger.info(
-				{ sessionId: payload.sessionId, machineId: record.machineId },
-				"session_attached_received",
-			);
-			emitToWebui(
-				"session:attached",
-				{ ...payload, machineId: record.machineId },
-				record.userId,
-			);
-		});
-
-		// Session detached
-		socket.on("session:detached", (payload: SessionDetachedPayload) => {
-			const record = cliRegistry.getCliBySocketId(socket.id);
-			if (!record) {
-				logger.warn(
-					{ socketId: socket.id },
-					"session_detached_unregistered_cli",
-				);
-				return;
-			}
-			logger.info(
-				{
-					sessionId: payload.sessionId,
-					machineId: record.machineId,
-					reason: payload.reason,
-				},
-				"session_detached_received",
-			);
-			emitToWebui(
-				"session:detached",
-				{ ...payload, machineId: record.machineId },
-				record.userId,
-			);
-		});
-
-		// Permission request from CLI
-		socket.on("permission:request", (payload: PermissionRequestPayload) => {
-			const record = cliRegistry.getCliBySocketId(socket.id);
-			if (!record) {
-				logger.warn(
-					{ socketId: socket.id },
-					"permission_request_unregistered_cli",
-				);
-				return;
-			}
-			logger.info(
-				{ sessionId: payload.sessionId, requestId: payload.requestId },
-				"permission_request_received",
-			);
-			emitToWebui("permission:request", payload, record.userId);
-			if (
-				record.userId &&
-				notificationService &&
-				isActiveCliSession(record, payload.sessionId)
-			) {
-				void notificationService.notifyPermissionRequest(
-					record.userId,
-					payload,
-				);
-			}
-		});
-
-		// Permission result from CLI
-		socket.on("permission:result", (payload: PermissionDecisionPayload) => {
-			const record = cliRegistry.getCliBySocketId(socket.id);
-			if (!record) {
-				logger.warn(
-					{ socketId: socket.id },
-					"permission_result_unregistered_cli",
-				);
-				return;
-			}
-			logger.info(
-				{ sessionId: payload.sessionId, requestId: payload.requestId },
-				"permission_result_received",
-			);
-			emitToWebui("permission:result", payload, record.userId);
-		});
-
-		// Session event (WAL-persisted events with seq/revision)
-		// Note: terminal:output is deprecated - terminal output now goes through
-		// session:event with kind="terminal_output"
-		socket.on("session:event", (event: SessionEvent) => {
-			const record = cliRegistry.getCliBySocketId(socket.id);
-			if (!record) {
-				logger.warn({ socketId: socket.id }, "session_event_unregistered_cli");
-				return;
-			}
-			logger.debug(
-				{
-					sessionId: event.sessionId,
-					revision: event.revision,
-					seq: event.seq,
-					kind: event.kind,
-					socketId: socket.id,
-				},
-				"session_event_received",
-			);
-			emitToWebui("session:event", event, record.userId);
-			if (
-				record.userId &&
-				notificationService &&
-				isActiveCliSession(record, event.sessionId)
-			) {
-				void notificationService.notifySessionEvent(record.userId, event);
-			}
-
-			// Send acknowledgment back to CLI
-			socket.emit("events:ack", {
-				sessionId: event.sessionId,
-				revision: event.revision,
-				upToSeq: event.seq,
-			});
-		});
-
-		// RPC response
-		socket.on("rpc:response", (response: RpcResponse<unknown>) => {
-			logger.debug(
-				{
-					requestId: response.requestId,
-					isError: Boolean(response.error),
-					code: response.error?.code,
-				},
-				"rpc_response_received",
-			);
-			sessionRouter.handleRpcResponse(response);
-		});
-
-		// Disconnect
-		socket.on("disconnect", async (reason) => {
-			// Cache userId before unregister (unregister deletes the userId mapping)
-			const preRecord = cliRegistry.getCliBySocketId(socket.id);
-			const cachedUserId = preRecord?.userId;
-
-			const record = cliRegistry.unregister(socket.id);
-			if (record) {
-				logger.info(
-					{ machineId: record.machineId, reason, socketId: socket.id },
-					"cli_disconnected",
-				);
-				for (const session of record.sessions) {
-					// Only emit detached for sessions that were actually attached
-					// (skip discovered sessions that were never attached)
-					if (!session.isAttached) continue;
-					emitToWebui(
-						"session:detached",
-						{
-							sessionId: session.sessionId,
-							machineId: record.machineId,
-							detachedAt: new Date().toISOString(),
-							reason: "cli_disconnect",
-						},
-						cachedUserId,
-					);
-				}
-
-				// Release user affinity if no more connections for this user
-				if (userAffinity && cachedUserId) {
-					const hasCliConnections =
-						cliRegistry.getClisForUser(cachedUserId).length > 0;
-					const hasWebuiConnections =
-						io.of("/webui").sockets.size > 0 &&
-						Array.from(io.of("/webui").sockets.values()).some(
-							(s) =>
-								(s as Socket & { data: { userId?: string } }).data.userId ===
-								cachedUserId,
-						);
-					if (!hasCliConnections && !hasWebuiConnections) {
-						await userAffinity.releaseUser(cachedUserId);
-					}
-				}
-			}
+		socket.on("disconnect", (reason) => {
+			transport.emitDisconnect(reason);
+			void connectionHandlers.handleDisconnect(context, reason);
 		});
 	});
 

--- a/apps/gateway/src/socket/cli-ws-server.ts
+++ b/apps/gateway/src/socket/cli-ws-server.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+import {
+	type CliControlWireMessage,
+	type CliToGatewayWireMessage,
+	initCrypto,
+	type SignedAuthToken,
+	verifySignedToken,
+} from "@mobvibe/shared";
+import { type RawData, type WebSocket, WebSocketServer } from "ws";
+import type { GatewayConfig } from "../config.js";
+import { logger } from "../lib/logger.js";
+import type { CliRegistry } from "../services/cli-registry.js";
+import {
+	type CliTransport,
+	CliTransportDisconnectEmitter,
+} from "../services/cli-transport.js";
+import type { NotificationService } from "../services/notification-service.js";
+import type { SessionRouter } from "../services/session-router.js";
+import type { UserAffinityManager } from "../services/user-affinity.js";
+import {
+	cliMessageTypes,
+	createCliConnectionHandlers,
+} from "./cli-connection.js";
+
+class WebSocketCliTransport implements CliTransport {
+	private readonly disconnects = new CliTransportDisconnectEmitter();
+	readonly id = randomUUID();
+
+	constructor(private readonly socket: WebSocket) {}
+
+	close(code?: number, reason?: string): void {
+		this.socket.close(code, reason);
+	}
+
+	onDisconnect(listener: (reason?: string) => void): () => void {
+		return this.disconnects.on(listener);
+	}
+
+	send(type: string, payload: unknown): void {
+		const message = {
+			type,
+			payload,
+		};
+		this.socket.send(JSON.stringify(message));
+	}
+
+	emitDisconnect(reason?: string) {
+		this.disconnects.emit(reason);
+	}
+}
+
+const parseMessage = (
+	data: RawData,
+): CliControlWireMessage | CliToGatewayWireMessage | null => {
+	try {
+		const text =
+			typeof data === "string"
+				? data
+				: data instanceof ArrayBuffer
+					? Buffer.from(data).toString("utf8")
+					: Array.isArray(data)
+						? Buffer.concat(data).toString("utf8")
+						: Buffer.from(data).toString("utf8");
+		return JSON.parse(text) as CliControlWireMessage | CliToGatewayWireMessage;
+	} catch {
+		return null;
+	}
+};
+
+export const createCliWsServer = ({
+	config,
+	cliRegistry,
+	emitToWebui,
+	notificationService,
+	sessionRouter,
+	userAffinity,
+	hasOtherUserConnections,
+}: {
+	config: GatewayConfig;
+	cliRegistry: CliRegistry;
+	emitToWebui: (event: string, payload: unknown, userId?: string) => void;
+	hasOtherUserConnections: (userId: string) => boolean;
+	notificationService?: NotificationService;
+	sessionRouter: SessionRouter;
+	userAffinity: UserAffinityManager | null;
+}) => {
+	const wsServer = new WebSocketServer({
+		noServer: true,
+		path: "/cli-ws",
+	});
+	const cryptoReady = initCrypto();
+	const connectionHandlers = createCliConnectionHandlers({
+		cliRegistry,
+		emitToWebui,
+		hasOtherUserConnections,
+		notificationService,
+		sessionRouter,
+		userAffinity,
+	});
+
+	wsServer.on("connection", (socket: WebSocket, req: IncomingMessage) => {
+		const transport = new WebSocketCliTransport(socket);
+		const context: {
+			deviceId?: string;
+			transport: CliTransport;
+			userId?: string;
+		} = { transport };
+		let authenticated = false;
+
+		logger.info(
+			{
+				transportId: transport.id,
+				remoteAddress: req.socket.remoteAddress,
+			},
+			"cli_ws_connected",
+		);
+
+		socket.on("message", async (data: RawData) => {
+			const message = parseMessage(data);
+			if (!message) {
+				logger.warn({ transportId: transport.id }, "cli_ws_invalid_message");
+				transport.send("auth-error", {
+					code: "INVALID_MESSAGE",
+					message: "Invalid JSON message.",
+				});
+				transport.close(1008, "INVALID_MESSAGE");
+				return;
+			}
+
+			if (!authenticated) {
+				if (message.type !== "auth") {
+					transport.send("auth-error", {
+						code: "AUTH_REQUIRED",
+						message: "Authenticate before sending CLI messages.",
+					});
+					transport.close(1008, "AUTH_REQUIRED");
+					return;
+				}
+
+				await cryptoReady;
+				const authToken = message.payload as SignedAuthToken | undefined;
+				if (
+					!authToken?.payload?.publicKey ||
+					!authToken?.payload?.timestamp ||
+					!authToken?.signature
+				) {
+					transport.send("auth-error", {
+						code: "AUTH_REQUIRED",
+						message: "Missing signed auth token.",
+					});
+					transport.close(1008, "AUTH_REQUIRED");
+					return;
+				}
+
+				try {
+					const verified = verifySignedToken(authToken, 5 * 60 * 1000);
+					if (!verified) {
+						transport.send("auth-error", {
+							code: "INVALID_TOKEN",
+							message: "Invalid device signature.",
+						});
+						transport.close(1008, "INVALID_TOKEN");
+						return;
+					}
+
+					const { authenticateCliToken } = await import("./cli-connection.js");
+					const authInfo = await authenticateCliToken(verified.publicKey);
+					if (!authInfo) {
+						transport.send("auth-error", {
+							code: "DEVICE_NOT_REGISTERED",
+							message:
+								"Device not authenticated. Run 'mobvibe login' to register.",
+						});
+						transport.close(1008, "DEVICE_NOT_REGISTERED");
+						return;
+					}
+
+					if (userAffinity) {
+						const target = await userAffinity.getUserInstance(authInfo.userId);
+						if (target && target.instanceId !== config.instanceId) {
+							logger.info(
+								{
+									userId: authInfo.userId,
+									targetInstance: target.instanceId,
+									thisInstance: config.instanceId,
+								},
+								"cli_ws_affinity_redirect",
+							);
+							transport.send("redirect", {
+								instanceId: target.instanceId,
+							});
+							transport.close(4003, "WRONG_INSTANCE");
+							return;
+						}
+					}
+
+					authenticated = true;
+					context.userId = authInfo.userId;
+					context.deviceId = authInfo.deviceId;
+					transport.send("auth-ok", authInfo);
+					logger.info(
+						{
+							userId: authInfo.userId,
+							deviceId: authInfo.deviceId,
+							transportId: transport.id,
+						},
+						"cli_ws_authenticated",
+					);
+				} catch (error) {
+					logger.error({ err: error }, "cli_ws_auth_error");
+					transport.send("auth-error", {
+						code: "AUTH_ERROR",
+						message: "Failed to verify signed auth token.",
+					});
+					transport.close(1011, "AUTH_ERROR");
+				}
+				return;
+			}
+
+			if (!cliMessageTypes.includes(message.type as never)) {
+				logger.warn(
+					{ transportId: transport.id, type: message.type },
+					"cli_ws_unknown_message",
+				);
+				return;
+			}
+
+			await connectionHandlers.handleMessage(
+				context,
+				message.type as never,
+				message.payload as never,
+			);
+		});
+
+		socket.on("close", (_code: number, reasonBuffer: Buffer) => {
+			const reason =
+				typeof reasonBuffer === "string"
+					? reasonBuffer
+					: Buffer.from(reasonBuffer).toString("utf8");
+			transport.emitDisconnect(reason);
+			if (authenticated) {
+				void connectionHandlers.handleDisconnect(context, reason);
+			}
+		});
+
+		socket.on("error", (error: Error) => {
+			logger.warn({ err: error, transportId: transport.id }, "cli_ws_error");
+		});
+	});
+
+	return wsServer;
+};

--- a/apps/mobvibe-cli/package.json
+++ b/apps/mobvibe-cli/package.json
@@ -50,14 +50,11 @@
 	},
 	"dependencies": {
 		"@agentclientprotocol/sdk": "^0.16.1",
-		"@clack/prompts": "^1.0.1",
-		"commander": "^13.1.0",
 		"ignore": "^7.0.4",
 		"open": "^10.1.0",
 		"pino": "^9.6.0",
 		"pino-pretty": "^13.1.1",
-		"qrcode": "^1.5.4",
-		"socket.io-client": "^4.8.1"
+		"qrcode": "^1.5.4"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.11",

--- a/apps/mobvibe-cli/src/acp/acp-connection.ts
+++ b/apps/mobvibe-cli/src/acp/acp-connection.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { Readable, Writable } from "node:stream";
 import {
 	type AgentCapabilities,
 	type Client,
@@ -38,10 +37,6 @@ import {
 	type TerminalOutputEvent,
 } from "@mobvibe/shared";
 import type { AcpBackendConfig } from "../config.js";
-import {
-	type ChildProcessWithoutNullStreams,
-	spawn,
-} from "../lib/child-process.js";
 import { logger } from "../lib/logger.js";
 import { buildShellCommand, resolveShell } from "../lib/shell.js";
 
@@ -83,7 +78,7 @@ type TerminalRecord = {
 	args: string[];
 	outputByteLimit: number;
 	output: TerminalOutputSnapshot;
-	process?: ChildProcessWithoutNullStreams;
+	process?: Bun.Subprocess<"pipe", "pipe", "pipe">;
 	onExit?: Promise<WaitForTerminalExitResponse>;
 	resolveExit?: (response: WaitForTerminalExitResponse) => void;
 };
@@ -221,9 +216,44 @@ const sliceOutputToLimit = (value: string, limit: number) => {
 	return sliced.subarray(start).toString("utf8");
 };
 
+const createProcessInputStream = (
+	process: Bun.Subprocess<"pipe", "pipe", "pipe">,
+) =>
+	new WritableStream<Uint8Array>({
+		write(chunk) {
+			process.stdin.write(chunk);
+		},
+		close() {
+			process.stdin.end();
+		},
+		abort() {
+			process.kill();
+		},
+	});
+
+const pumpProcessStream = (
+	stream: ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined,
+	onChunk: (chunk: Buffer) => void,
+) => {
+	if (!stream || typeof stream === "number") {
+		return;
+	}
+
+	const reader = stream.getReader();
+	void (async () => {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				break;
+			}
+			onChunk(Buffer.from(value));
+		}
+	})();
+};
+
 export class AcpConnection {
 	private connection?: ClientSideConnection;
-	private process?: ChildProcessWithoutNullStreams;
+	private process?: Bun.Subprocess<"pipe", "pipe", "pipe">;
 	private closedPromise?: Promise<void>;
 	private state: AcpConnectionState = "idle";
 	private connectedAt?: Date;
@@ -381,17 +411,16 @@ export class AcpConnection {
 			const env = this.options.backend.envOverrides
 				? { ...process.env, ...this.options.backend.envOverrides }
 				: process.env;
-			const child = spawn(
-				this.options.backend.command,
-				this.options.backend.args,
+			const child = Bun.spawn(
+				[this.options.backend.command, ...this.options.backend.args],
 				{
-					stdio: ["pipe", "pipe", "pipe"],
 					env,
+					stdio: ["pipe", "pipe", "pipe"],
 				},
 			);
 			this.process = child;
 			this.sessionId = undefined;
-			child.stderr.on("data", (chunk: Buffer) => {
+			pumpProcessStream(child.stderr, (chunk) => {
 				const text = chunk.toString("utf8").trimEnd();
 				if (text) {
 					logger.debug(
@@ -401,11 +430,10 @@ export class AcpConnection {
 				}
 			});
 
-			const input = Writable.toWeb(child.stdin) as WritableStream<Uint8Array>;
-			const output = Readable.toWeb(
+			const stream = ndJsonStream(
+				createProcessInputStream(child),
 				child.stdout,
-			) as unknown as ReadableStream<Uint8Array>;
-			const stream = ndJsonStream(input, output);
+			);
 			const connection = new ClientSideConnection(
 				() =>
 					buildClient({
@@ -422,21 +450,13 @@ export class AcpConnection {
 				stream,
 			);
 			this.connection = connection;
-
-			child.once("error", (error) => {
-				if (this.state === "stopped") {
-					return;
-				}
-				this.updateStatus("error", buildConnectError(error));
-			});
-
-			child.once("exit", (code, signal) => {
+			void child.exited.then((code) => {
 				if (this.state === "stopped") {
 					return;
 				}
 				this.updateStatus(
 					"error",
-					buildProcessExitError(formatExitMessage(code, signal)),
+					buildProcessExitError(formatExitMessage(code, child.signalCode)),
 				);
 			});
 
@@ -529,24 +549,10 @@ export class AcpConnection {
 
 		const shell = resolveShell();
 		const fullCommand = buildShellCommand(params.command, params.args ?? []);
-		const child = spawn(shell, ["-c", fullCommand], {
+		const child = Bun.spawn([shell, "-c", fullCommand], {
 			cwd: params.cwd ?? undefined,
 			env: resolvedEnv ? { ...process.env, ...resolvedEnv } : process.env,
-		});
-		child.once("error", (error) => {
-			record.output.exitStatus = {
-				exitCode: null,
-				signal: null,
-			};
-			record.resolveExit?.({ exitCode: null, signal: null });
-			this.terminalOutputEmitter.emit("output", {
-				sessionId: record.sessionId,
-				terminalId,
-				delta: `\n[terminal error] ${String(error)}`,
-				truncated: record.output.truncated,
-				output: record.output.output,
-				exitStatus: record.output.exitStatus,
-			} satisfies TerminalOutputEvent);
+			stdio: ["pipe", "pipe", "pipe"],
 		});
 		record.process = child;
 		let resolveExit: (response: WaitForTerminalExitResponse) => void = () => {};
@@ -580,16 +586,16 @@ export class AcpConnection {
 			} satisfies TerminalOutputEvent);
 		};
 
-		child.stdout?.on("data", handleChunk);
-		child.stderr?.on("data", handleChunk);
-		child.on("exit", (code, signal) => {
+		pumpProcessStream(child.stdout, handleChunk);
+		pumpProcessStream(child.stderr, handleChunk);
+		void child.exited.then((code) => {
 			record.output.exitStatus = {
 				exitCode: code ?? null,
-				signal: signal ?? null,
+				signal: child.signalCode ?? null,
 			};
 			record.resolveExit?.({
 				exitCode: code ?? null,
-				signal: signal ?? null,
+				signal: child.signalCode ?? null,
 			});
 			this.terminalOutputEmitter.emit("output", {
 				sessionId: record.sessionId,

--- a/apps/mobvibe-cli/src/daemon/__tests__/socket-client.test.ts
+++ b/apps/mobvibe-cli/src/daemon/__tests__/socket-client.test.ts
@@ -2,26 +2,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SessionEvent } from "@mobvibe/shared";
 import type { CliConfig } from "../../config.js";
 
-const socketHandlers = new Map<string, (...args: Array<unknown>) => void>();
-
-const socketMock = {
-	on: mock((event: string, handler: (...args: Array<unknown>) => void) => {
-		socketHandlers.set(event, handler);
-	}),
-	emit: mock(() => {}),
-	connect: mock(() => {}),
-	disconnect: mock(() => {}),
-	io: {
-		opts: {
-			extraHeaders: {},
-		},
-	},
-};
-
-mock.module("socket.io-client", () => ({
-	io: mock((_url: string, _options: unknown) => socketMock),
-}));
-
 mock.module("../../lib/logger.js", () => ({
 	logger: {
 		info: mock(() => {}),
@@ -86,8 +66,19 @@ const createSessionEvent = (
 	...overrides,
 });
 
+type GatewayConnectionHarness = {
+	emit: (event: string, payload?: unknown) => boolean;
+	socket?: {
+		close: ReturnType<typeof mock>;
+		readyState: number;
+		send: ReturnType<typeof mock>;
+	};
+};
+
 describe("SocketClient restore semantics", () => {
 	let client: InstanceType<typeof SocketClient>;
+	let gatewayConnection: GatewayConnectionHarness;
+	let sentMessages: Array<{ payload: unknown; type: string }>;
 	let sessionEventListener: ((event: SessionEvent) => void) | undefined;
 	let promptConnection: {
 		prompt: ReturnType<typeof mock>;
@@ -117,12 +108,7 @@ describe("SocketClient restore semantics", () => {
 	};
 
 	beforeEach(() => {
-		socketHandlers.clear();
-		socketMock.on.mockClear();
-		socketMock.emit.mockClear();
-		socketMock.connect.mockClear();
-		socketMock.disconnect.mockClear();
-		socketMock.io.opts.extraHeaders = {};
+		sentMessages = [];
 		sessionEventListener = undefined;
 		promptConnection = {
 			prompt: mock(() => Promise.resolve({ stopReason: "end_turn" })),
@@ -172,6 +158,20 @@ describe("SocketClient restore semantics", () => {
 			sessionManager: sessionManager as never,
 			cryptoService: cryptoService as never,
 		});
+
+		const clientHarness = client as unknown as {
+			socket: GatewayConnectionHarness;
+		};
+		gatewayConnection = clientHarness.socket;
+		gatewayConnection.socket = {
+			close: mock(() => {}),
+			readyState: WebSocket.OPEN,
+			send: mock((raw: string) => {
+				sentMessages.push(
+					JSON.parse(raw) as { payload: unknown; type: string },
+				);
+			}),
+		};
 	});
 
 	afterEach(() => {
@@ -181,9 +181,7 @@ describe("SocketClient restore semantics", () => {
 	test("replays unacked events after reconnect using the active revision", async () => {
 		(client as unknown as { reconnectAttempts: number }).reconnectAttempts = 1;
 
-		await (
-			socketHandlers.get("connect") as (() => Promise<void>) | undefined
-		)?.();
+		await gatewayConnection.emit("connect", undefined);
 
 		expect(sessionManager.getSessionRevision).toHaveBeenCalledWith("session-1");
 		expect(sessionManager.getUnackedEvents).toHaveBeenCalledWith(
@@ -197,12 +195,14 @@ describe("SocketClient restore semantics", () => {
 				seq: 4,
 			}),
 		);
-		expect(socketMock.emit).toHaveBeenCalledWith(
-			"session:event",
+		expect(sentMessages).toContainEqual(
 			expect.objectContaining({
-				sessionId: "session-1",
-				revision: 2,
-				payload: { encrypted: true, originalSeq: 4 },
+				type: "session:event",
+				payload: expect.objectContaining({
+					sessionId: "session-1",
+					revision: 2,
+					payload: { encrypted: true, originalSeq: 4 },
+				}),
 			}),
 		);
 	});
@@ -210,24 +210,16 @@ describe("SocketClient restore semantics", () => {
 	test("does not replay events on the first successful connect", async () => {
 		(client as unknown as { reconnectAttempts: number }).reconnectAttempts = 0;
 
-		await (
-			socketHandlers.get("connect") as (() => Promise<void>) | undefined
-		)?.();
+		await gatewayConnection.emit("connect", undefined);
 
 		expect(sessionManager.getUnackedEvents).not.toHaveBeenCalled();
-		expect(socketMock.emit).not.toHaveBeenCalledWith(
-			"session:event",
-			expect.anything(),
-		);
+		expect(
+			sentMessages.find((message) => message.type === "session:event"),
+		).toBe(undefined);
 	});
 
 	test("acks replayed events through the session manager", () => {
-		const ackHandler = socketHandlers.get("events:ack");
-		if (!ackHandler) {
-			throw new Error("events:ack handler not registered");
-		}
-
-		ackHandler({
+		gatewayConnection.emit("events:ack", {
 			sessionId: "session-1",
 			revision: 2,
 			upToSeq: 4,
@@ -246,9 +238,7 @@ describe("SocketClient restore semantics", () => {
 		);
 
 		(client as unknown as { reconnectAttempts: number }).reconnectAttempts = 1;
-		await (
-			socketHandlers.get("connect") as (() => Promise<void>) | undefined
-		)?.();
+		await gatewayConnection.emit("connect", undefined);
 
 		expect(sessionManager.getUnackedEvents).toHaveBeenCalledTimes(1);
 		expect(sessionManager.getUnackedEvents).toHaveBeenCalledWith(
@@ -259,12 +249,8 @@ describe("SocketClient restore semantics", () => {
 
 	test("forwards plaintext prompts through rpc:message:send", async () => {
 		const prompt = [{ type: "text", text: "plain prompt" }] as const;
-		const handler = socketHandlers.get("rpc:message:send");
-		if (!handler) {
-			throw new Error("rpc:message:send handler not registered");
-		}
 
-		await handler({
+		await gatewayConnection.emit("rpc:message:send", {
 			requestId: "req-1",
 			params: {
 				sessionId: "session-1",
@@ -282,13 +268,16 @@ describe("SocketClient restore semantics", () => {
 			"session-1",
 			"end_turn",
 		);
-		expect(socketMock.emit).toHaveBeenCalledWith("rpc:response", {
-			requestId: "req-1",
-			result: { stopReason: "end_turn" },
+		expect(sentMessages).toContainEqual({
+			type: "rpc:response",
+			payload: {
+				requestId: "req-1",
+				result: { stopReason: "end_turn" },
+			},
 		});
 	});
 
-	test("emits plaintext session events when crypto service is pass-through", async () => {
+	test("emits plaintext session events when crypto service is pass-through", () => {
 		const event = createSessionEvent({
 			payload: { text: "plain event" },
 		});
@@ -303,6 +292,9 @@ describe("SocketClient restore semantics", () => {
 		sessionEventListener(event);
 
 		expect(cryptoService.encryptEvent).toHaveBeenCalledWith(event);
-		expect(socketMock.emit).toHaveBeenCalledWith("session:event", event);
+		expect(sentMessages).toContainEqual({
+			type: "session:event",
+			payload: event,
+		});
 	});
 });

--- a/apps/mobvibe-cli/src/daemon/daemon.ts
+++ b/apps/mobvibe-cli/src/daemon/daemon.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { base64ToUint8, initCrypto } from "@mobvibe/shared";
@@ -12,11 +12,53 @@ import { WalCompactor, WalStore } from "../wal/index.js";
 import { SocketClient } from "./socket-client.js";
 import { buildBackgroundSpawnArgs } from "./spawn-utils.js";
 
+type DaemonControlState = {
+	logFile: string;
+	pid: number;
+	port: number;
+	startedAt: string;
+	token: string;
+};
+
 type DaemonStatus = {
 	running: boolean;
 	pid?: number;
 	connected?: boolean;
 	sessionCount?: number;
+	startedAt?: string;
+	logFile?: string;
+};
+
+const CONTROL_HOST = "127.0.0.1";
+const CONTROL_STATE_FILE = "daemon-state.json";
+const CONTROL_WAIT_TIMEOUT_MS = 5000;
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const toBearerToken = (token: string) => `Bearer ${token}`;
+
+const readLogSnapshot = async (logFile: string) => {
+	try {
+		const text = await fs.readFile(logFile, "utf8");
+		return {
+			cursor: text.length,
+			text,
+		};
+	} catch {
+		return {
+			cursor: 0,
+			text: "",
+		};
+	}
+};
+
+const tailLogLines = async (logFile: string, lines: number) => {
+	const snapshot = await readLogSnapshot(logFile);
+	const contentLines = snapshot.text.split("\n");
+	return {
+		cursor: snapshot.cursor,
+		text: contentLines.slice(-lines).join("\n"),
+	};
 };
 
 export class DaemonManager {
@@ -27,6 +69,35 @@ export class DaemonManager {
 		await fs.mkdir(this.config.logPath, { recursive: true });
 	}
 
+	private getStateFilePath() {
+		return path.join(this.config.homePath, CONTROL_STATE_FILE);
+	}
+
+	private async readStateFile(): Promise<DaemonControlState | null> {
+		try {
+			const content = await fs.readFile(this.getStateFilePath(), "utf8");
+			return JSON.parse(content) as DaemonControlState;
+		} catch {
+			return null;
+		}
+	}
+
+	private async writeStateFile(state: DaemonControlState) {
+		await fs.writeFile(
+			this.getStateFilePath(),
+			JSON.stringify(state, null, 2),
+			"utf8",
+		);
+	}
+
+	private async removeStateFile() {
+		try {
+			await fs.unlink(this.getStateFilePath());
+		} catch {
+			// ignore cleanup errors
+		}
+	}
+
 	async getPid(): Promise<number | null> {
 		try {
 			const content = await fs.readFile(this.config.pidFile, "utf8");
@@ -34,15 +105,8 @@ export class DaemonManager {
 			if (Number.isNaN(pid)) {
 				return null;
 			}
-			// Check if process is running
-			try {
-				process.kill(pid, 0);
-				return pid;
-			} catch {
-				// Process not running, clean up stale PID file
-				await this.removePidFile();
-				return null;
-			}
+			process.kill(pid, 0);
+			return pid;
 		} catch {
 			return null;
 		}
@@ -56,25 +120,100 @@ export class DaemonManager {
 		try {
 			await fs.unlink(this.config.pidFile);
 		} catch {
-			// Ignore errors
+			// ignore cleanup errors
 		}
 	}
 
-	async status(): Promise<DaemonStatus> {
-		const pid = await this.getPid();
-		if (!pid) {
-			return { running: false };
+	private async cleanupStaleState() {
+		await this.removeStateFile();
+		await this.removePidFile();
+	}
+
+	private async getRunningState(): Promise<DaemonControlState | null> {
+		const state = await this.readStateFile();
+		if (!state) {
+			return null;
 		}
-		return { running: true, pid };
+
+		try {
+			process.kill(state.pid, 0);
+			return state;
+		} catch {
+			logger.warn({ pid: state.pid }, "daemon_state_stale_cleanup");
+			await this.cleanupStaleState();
+			return null;
+		}
+	}
+
+	private async requestControl(
+		pathname: string,
+		init?: RequestInit,
+	): Promise<{
+		response: Response;
+		state: DaemonControlState;
+	} | null> {
+		const state = await this.getRunningState();
+		if (!state) {
+			return null;
+		}
+
+		try {
+			const response = await fetch(
+				`http://${CONTROL_HOST}:${state.port}${pathname}`,
+				{
+					...init,
+					headers: {
+						...(init?.headers ?? {}),
+						authorization: toBearerToken(state.token),
+					},
+				},
+			);
+
+			if (!response.ok) {
+				throw new Error(`Control request failed with ${response.status}`);
+			}
+
+			return { response, state };
+		} catch (error) {
+			logger.warn({ err: error, pathname }, "daemon_control_request_failed");
+			try {
+				process.kill(state.pid, 0);
+			} catch {
+				await this.cleanupStaleState();
+			}
+			return null;
+		}
+	}
+
+	private async waitForStateFile(expectedPid: number) {
+		const start = Date.now();
+		while (Date.now() - start < CONTROL_WAIT_TIMEOUT_MS) {
+			const state = await this.readStateFile();
+			if (state?.pid === expectedPid) {
+				return state;
+			}
+			await wait(100);
+		}
+		return null;
+	}
+
+	async status(): Promise<DaemonStatus> {
+		const control = await this.requestControl("/status");
+		if (!control) {
+			const pid = await this.getPid();
+			return pid ? { running: true, pid } : { running: false };
+		}
+
+		return (await control.response.json()) as DaemonStatus;
 	}
 
 	async start(options?: {
 		foreground?: boolean;
 		noE2ee?: boolean;
 	}): Promise<void> {
-		const existingPid = await this.getPid();
-		if (existingPid) {
-			logger.info({ pid: existingPid }, "daemon_already_running");
+		const status = await this.status();
+		if (status.running && status.pid) {
+			logger.info({ pid: status.pid }, "daemon_already_running");
 			return;
 		}
 
@@ -82,63 +221,47 @@ export class DaemonManager {
 
 		if (options?.foreground) {
 			await this.runForeground({ noE2ee: options.noE2ee });
-		} else {
-			await this.spawnBackground({ noE2ee: options?.noE2ee });
+			return;
 		}
+
+		await this.spawnBackground({ noE2ee: options?.noE2ee });
 	}
 
 	async stop(): Promise<void> {
-		const pid = await this.getPid();
-		if (!pid) {
-			logger.info("daemon_not_running");
-			return;
-		}
+		const control = await this.requestControl("/shutdown", {
+			method: "POST",
+		});
 
-		// Check if process actually exists
-		try {
-			process.kill(pid, 0);
-		} catch {
-			logger.warn("daemon_pid_missing_cleanup");
-			await this.removePidFile();
-			return;
-		}
-
-		try {
-			logger.info({ pid }, "daemon_stop_sigterm");
-			process.kill(pid, "SIGTERM");
-
-			// Wait for process to exit (up to 5 seconds)
-			const startTime = Date.now();
-			const timeout = 5000;
-
-			while (Date.now() - startTime < timeout) {
-				await new Promise((resolve) => setTimeout(resolve, 100));
+		if (control) {
+			logger.info({ pid: control.state.pid }, "daemon_shutdown_requested");
+			const start = Date.now();
+			while (Date.now() - start < CONTROL_WAIT_TIMEOUT_MS) {
 				try {
-					process.kill(pid, 0);
-					// Process still running
+					process.kill(control.state.pid, 0);
+					await wait(100);
 				} catch {
-					// Process exited
-					logger.info({ pid }, "daemon_stopped_gracefully");
-					await this.removePidFile();
+					await this.cleanupStaleState();
+					logger.info({ pid: control.state.pid }, "daemon_stopped_gracefully");
 					return;
 				}
 			}
+		}
 
-			// Process didn't exit gracefully, force kill
-			logger.warn({ pid }, "daemon_force_kill_start");
-			try {
-				process.kill(pid, "SIGKILL");
-				// Wait a bit for SIGKILL to take effect
-				await new Promise((resolve) => setTimeout(resolve, 500));
-				logger.warn({ pid }, "daemon_force_kill_complete");
-			} catch {
-				// Already dead
-				logger.info({ pid }, "daemon_already_stopped");
-			}
-			await this.removePidFile();
+		const pid = await this.getPid();
+		if (!pid) {
+			logger.info("daemon_not_running");
+			await this.cleanupStaleState();
+			return;
+		}
+
+		try {
+			logger.warn({ pid }, "daemon_stop_fallback_sigterm");
+			process.kill(pid, "SIGTERM");
+			await wait(500);
+			await this.cleanupStaleState();
 		} catch (error) {
-			logger.error({ err: error }, "daemon_stop_error");
-			await this.removePidFile();
+			logger.error({ err: error, pid }, "daemon_stop_error");
+			await this.cleanupStaleState();
 		}
 	}
 
@@ -149,19 +272,18 @@ export class DaemonManager {
 			this.config.logPath,
 			`${new Date().toISOString().replace(/[:.]/g, "-")}-daemon.log`,
 		);
-
-		const args = buildBackgroundSpawnArgs(process.argv, options);
-
-		// Open log file for direct stdio redirection (no pipe, parent can exit immediately)
-		const logFd = await fs.open(logFile, "a");
-
-		const child = spawn(process.execPath, args, {
+		const args = buildBackgroundSpawnArgs(
+			Bun.argv.length > 0 ? Bun.argv : process.argv,
+			options,
+		);
+		const child = Bun.spawn([process.execPath, ...args], {
 			detached: true,
-			stdio: ["ignore", logFd.fd, logFd.fd],
 			env: {
 				...process.env,
+				MOBVIBE_DAEMON_LOG_FILE: logFile,
 				MOBVIBE_GATEWAY_URL: this.config.gatewayUrl,
 			},
+			stdio: ["ignore", Bun.file(logFile), Bun.file(logFile)],
 		});
 
 		if (!child.pid) {
@@ -169,20 +291,23 @@ export class DaemonManager {
 			throw new Error("Failed to spawn daemon process");
 		}
 
-		// Close parent's fd reference (child has duplicated it)
-		await logFd.close();
-
-		// Detach from parent - no event listeners needed since stdio is directly redirected
-		// Note: The child process writes its own PID file in runForeground()
 		child.unref();
 
+		const state = await this.waitForStateFile(child.pid);
 		logger.info({ pid: child.pid }, "daemon_started");
-		console.log(`Logs: ${logFile}`);
-		logger.info({ logFile }, "daemon_log_path");
+		console.log(`Logs: ${state?.logFile ?? logFile}`);
 	}
 
 	async runForeground(options?: { noE2ee?: boolean }): Promise<void> {
 		const pid = process.pid;
+		const startedAt = new Date().toISOString();
+		const logFile =
+			process.env.MOBVIBE_DAEMON_LOG_FILE ??
+			path.join(
+				this.config.logPath,
+				`${startedAt.replace(/[:.]/g, "-")}-daemon.log`,
+			);
+
 		await this.writePidFile(pid);
 
 		logger.info({ pid }, "daemon_starting");
@@ -195,11 +320,10 @@ export class DaemonManager {
 
 		const sessionManager = this.createSessionManager(cryptoService);
 		const socketClient = this.createSocketClient(sessionManager, cryptoService);
+		const controlToken = randomUUID();
 
-		// Initialize compactor if enabled
 		let compactor: WalCompactor | undefined;
 		let compactionInterval: NodeJS.Timeout | undefined;
-		// P1-2: Track compactor resources for cleanup on shutdown
 		let compactorWalStore: WalStore | undefined;
 		let compactorDb: Database | undefined;
 
@@ -212,31 +336,23 @@ export class DaemonManager {
 				compactorDb,
 			);
 
-			// Run compaction on startup
 			if (this.config.compaction.runOnStartup) {
-				logger.info("compaction_startup_start");
-				compactor.compactAll().catch((error) => {
+				void compactor.compactAll().catch((error) => {
 					logger.error({ err: error }, "compaction_startup_error");
 				});
 			}
 
-			// Schedule periodic compaction
 			const intervalMs =
 				this.config.compaction.runIntervalHours * 60 * 60 * 1000;
 			compactionInterval = setInterval(() => {
-				logger.info("compaction_scheduled_start");
-				compactor?.compactAll().catch((error) => {
+				void compactor?.compactAll().catch((error) => {
 					logger.error({ err: error }, "compaction_scheduled_error");
 				});
 			}, intervalMs);
-
-			logger.info(
-				{ intervalHours: this.config.compaction.runIntervalHours },
-				"compaction_scheduled",
-			);
 		}
 
 		let shuttingDown = false;
+		let controlServer: Bun.Server<undefined> | undefined;
 
 		const shutdown = async (signal: string) => {
 			if (shuttingDown) {
@@ -244,46 +360,145 @@ export class DaemonManager {
 				return;
 			}
 			shuttingDown = true;
-
 			logger.info({ signal }, "daemon_shutdown_start");
 
-			try {
-				// Stop compaction interval
-				if (compactionInterval) {
-					clearInterval(compactionInterval);
-				}
-
-				// P1-2: Close compactor resources to prevent connection leak
-				if (compactorWalStore) {
-					compactorWalStore.close();
-				}
-				if (compactorDb) {
-					compactorDb.close();
-				}
-
-				socketClient.disconnect();
-				await sessionManager.shutdown();
-				await this.removePidFile();
-				logger.info({ signal }, "daemon_shutdown_complete");
-			} catch (error) {
-				logger.error({ err: error, signal }, "daemon_shutdown_error");
+			if (compactionInterval) {
+				clearInterval(compactionInterval);
 			}
+
+			compactorWalStore?.close();
+			compactorDb?.close();
+			socketClient.disconnect();
+			await sessionManager.shutdown();
+			await controlServer?.stop(true);
+			await this.cleanupStaleState();
+			logger.info({ signal }, "daemon_shutdown_complete");
+			process.exit(0);
 		};
 
-		process.on("SIGINT", () => {
-			shutdown("SIGINT").catch((error) => {
-				logger.error({ err: error }, "daemon_shutdown_sigint_error");
+		const createLogStream = (startCursor: number) => {
+			const encoder = new TextEncoder();
+			let interval: NodeJS.Timeout | undefined;
+			return new ReadableStream<Uint8Array>({
+				start: (controller) => {
+					let cursor = startCursor;
+					interval = setInterval(() => {
+						void (async () => {
+							const snapshot = await readLogSnapshot(logFile);
+							if (snapshot.cursor < cursor) {
+								cursor = 0;
+							}
+							if (snapshot.cursor > cursor) {
+								controller.enqueue(encoder.encode(snapshot.text.slice(cursor)));
+								cursor = snapshot.cursor;
+							}
+						})().catch((error) => {
+							controller.error(error);
+						});
+					}, 500);
+
+					void (async () => {
+						const snapshot = await readLogSnapshot(logFile);
+						if (startCursor === 0 && snapshot.text.length > 0) {
+							controller.enqueue(encoder.encode(snapshot.text));
+							cursor = snapshot.cursor;
+						}
+					})();
+				},
+				cancel: () => {
+					if (interval) {
+						clearInterval(interval);
+					}
+				},
 			});
+		};
+
+		controlServer = Bun.serve({
+			hostname: CONTROL_HOST,
+			port: 0,
+			fetch: async (request) => {
+				const url = new URL(request.url);
+				if (
+					request.headers.get("authorization") !== toBearerToken(controlToken)
+				) {
+					return new Response("Unauthorized", { status: 401 });
+				}
+
+				if (request.method === "GET" && url.pathname === "/status") {
+					return Response.json({
+						running: true,
+						pid,
+						connected: socketClient.isConnected(),
+						sessionCount: sessionManager.listAllSessions().length,
+						startedAt,
+						logFile,
+					} satisfies DaemonStatus);
+				}
+
+				if (request.method === "POST" && url.pathname === "/shutdown") {
+					queueMicrotask(() => {
+						void shutdown("control-plane");
+					});
+					return Response.json({ ok: true });
+				}
+
+				if (request.method === "GET" && url.pathname === "/logs") {
+					const lineCount = Number.parseInt(
+						url.searchParams.get("lines") ?? "50",
+						10,
+					);
+					const snapshot = await tailLogLines(
+						logFile,
+						Number.isNaN(lineCount) ? 50 : lineCount,
+					);
+					return new Response(snapshot.text, {
+						headers: {
+							"content-type": "text/plain; charset=utf-8",
+							"x-mobvibe-log-cursor": String(snapshot.cursor),
+						},
+					});
+				}
+
+				if (request.method === "GET" && url.pathname === "/logs/stream") {
+					const startCursor = Number.parseInt(
+						url.searchParams.get("cursor") ?? "0",
+						10,
+					);
+					return new Response(
+						createLogStream(Number.isNaN(startCursor) ? 0 : startCursor),
+						{
+							headers: {
+								"cache-control": "no-cache",
+								"content-type": "text/plain; charset=utf-8",
+							},
+						},
+					);
+				}
+
+				return new Response("Not found", { status: 404 });
+			},
+		});
+		const controlPort = controlServer.port;
+		if (typeof controlPort !== "number") {
+			throw new Error("Control server did not bind a local port");
+		}
+
+		await this.writeStateFile({
+			logFile,
+			pid,
+			port: controlPort,
+			startedAt,
+			token: controlToken,
+		});
+
+		process.on("SIGINT", () => {
+			void shutdown("SIGINT");
 		});
 		process.on("SIGTERM", () => {
-			shutdown("SIGTERM").catch((error) => {
-				logger.error({ err: error }, "daemon_shutdown_sigterm_error");
-			});
+			void shutdown("SIGTERM");
 		});
 
 		socketClient.connect();
-
-		// Keep process alive
 		await new Promise(() => {});
 	}
 
@@ -297,11 +512,9 @@ export class DaemonManager {
 			console.error(
 				`[mobvibe-cli] No credentials found. Run 'mobvibe login' to authenticate.`,
 			);
-			logger.warn("daemon_exit_missing_master_secret");
 			process.exit(1);
 		}
-		const masterSecret = base64ToUint8(masterSecretBase64);
-		return new CliCryptoService(masterSecret, {
+		return new CliCryptoService(base64ToUint8(masterSecretBase64), {
 			contentEncryptionEnabled: !options?.noE2ee,
 		});
 	}
@@ -323,36 +536,62 @@ export class DaemonManager {
 		});
 	}
 
-	async logs(options?: { follow?: boolean; lines?: number }): Promise<void> {
-		const files = await fs.readdir(this.config.logPath);
-		const logFiles = files
-			.filter((f) => f.endsWith("-daemon.log"))
+	private async readLatestLocalLogFile() {
+		const files = await fs.readdir(this.config.logPath).catch(() => []);
+		const latestLog = files
+			.filter((file) => file.endsWith("-daemon.log"))
 			.sort()
-			.reverse();
+			.reverse()[0];
+		return latestLog ? path.join(this.config.logPath, latestLog) : null;
+	}
 
-		if (logFiles.length === 0) {
+	async logs(options?: { follow?: boolean; lines?: number }): Promise<void> {
+		const requestedLines = options?.lines ?? 50;
+		const control = await this.requestControl(`/logs?lines=${requestedLines}`);
+		if (control) {
+			const cursor = Number.parseInt(
+				control.response.headers.get("x-mobvibe-log-cursor") ?? "0",
+				10,
+			);
+			const content = await control.response.text();
+			if (content) {
+				process.stdout.write(`${content}${content.endsWith("\n") ? "" : "\n"}`);
+			}
+
+			if (!options?.follow) {
+				return;
+			}
+
+			const streamResponse = await this.requestControl(
+				`/logs/stream?cursor=${Number.isNaN(cursor) ? 0 : cursor}`,
+			);
+			if (!streamResponse?.response.body) {
+				return;
+			}
+
+			const reader = streamResponse.response.body.getReader();
+			const decoder = new TextDecoder();
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) {
+					break;
+				}
+				process.stdout.write(decoder.decode(value, { stream: true }));
+			}
+			return;
+		}
+
+		const latestLog = await this.readLatestLocalLogFile();
+		if (!latestLog) {
 			logger.warn("daemon_logs_empty");
 			console.log("No log files found");
 			return;
 		}
 
-		const latestLog = path.join(this.config.logPath, logFiles[0]);
-		logger.info({ logFile: latestLog }, "daemon_logs_latest");
-		console.log(`Log file: ${latestLog}\n`);
-
+		const { text } = await tailLogLines(latestLog, requestedLines);
+		console.log(text);
 		if (options?.follow) {
-			// Use tail -f
-			const tail = spawn("tail", ["-f", latestLog], {
-				stdio: "inherit",
-			});
-			await new Promise<void>((resolve) => {
-				tail.on("close", () => resolve());
-			});
-		} else {
-			const content = await fs.readFile(latestLog, "utf8");
-			const lines = content.split("\n");
-			const count = options?.lines ?? 50;
-			console.log(lines.slice(-count).join("\n"));
+			console.log("Daemon is not running; live log streaming is unavailable.");
 		}
 	}
 }

--- a/apps/mobvibe-cli/src/daemon/socket-client.ts
+++ b/apps/mobvibe-cli/src/daemon/socket-client.ts
@@ -3,22 +3,23 @@ import fs from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import type {
-	CliToGatewayEvents,
+	CliErrorPayload,
+	CliRedirectPayload,
 	EventsAckPayload,
 	FsEntry,
 	FsRoot,
-	GatewayToCliEvents,
+	GatewayToCliWirePayloadMap,
 	GitBranchesForCwdResponse,
 	HostFsRootsResponse,
 	RpcResponse,
 	SessionEventsResponse,
 	SessionFsFilePreview,
 	SessionFsResourceEntry,
+	SignedAuthToken,
 	StopReason,
 } from "@mobvibe/shared";
 import { createSignedToken } from "@mobvibe/shared";
 import ignore, { type Ignore } from "ignore";
-import { io, type Socket } from "socket.io-client";
 import type { SessionManager } from "../acp/session-manager.js";
 import type { CliConfig } from "../config.js";
 import type { CliCryptoService } from "../e2ee/crypto-service.js";
@@ -147,8 +148,197 @@ const buildHostFsRoots = async (): Promise<HostFsRootsResponse> => {
 /** Minimum interval between automatic discover calls (ms) */
 const DISCOVER_THROTTLE_MS = 60_000;
 
+type GatewayConnectionEvents = {
+	"cli:error": CliErrorPayload;
+	"cli:registered": { machineId: string; userId?: string };
+	connect: undefined;
+	connect_error: Error;
+	disconnect: string;
+	"events:ack": EventsAckPayload;
+	redirect: CliRedirectPayload;
+};
+
+type GatewayConnectionEventMap = GatewayConnectionEvents &
+	GatewayToCliWirePayloadMap;
+
+type GatewayConnectionListener<T> = [T] extends [null]
+	? () => void
+	: (payload: T) => void;
+
+class GatewayConnection extends EventEmitter {
+	private reconnectAttemptCount = 0;
+	private reconnectTimer?: NodeJS.Timeout;
+	private shouldReconnect = false;
+	private socket?: WebSocket;
+	private socketAuthenticated = false;
+	readonly io = {
+		opts: {
+			extraHeaders: {} as Record<string, string>,
+		},
+	};
+
+	constructor(
+		private readonly gatewayUrl: string,
+		private readonly createAuthToken: () => SignedAuthToken,
+	) {
+		super();
+	}
+
+	on<TEvent extends keyof GatewayConnectionEventMap>(
+		event: TEvent,
+		listener: GatewayConnectionListener<GatewayConnectionEventMap[TEvent]>,
+	): this;
+	override on(
+		event: string,
+		listener: (...args: Array<unknown>) => void,
+	): this {
+		return super.on(event, listener);
+	}
+
+	private emitEvent<TEvent extends keyof GatewayConnectionEventMap>(
+		event: TEvent,
+		payload: GatewayConnectionEventMap[TEvent],
+	) {
+		super.emit(event, payload);
+	}
+
+	emitMessage(type: string, payload: unknown) {
+		if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+			return;
+		}
+		this.socket.send(JSON.stringify({ type, payload }));
+	}
+
+	connect() {
+		this.shouldReconnect = true;
+		this.clearReconnectTimer();
+		if (
+			this.socket &&
+			(this.socket.readyState === WebSocket.OPEN ||
+				this.socket.readyState === WebSocket.CONNECTING)
+		) {
+			return;
+		}
+		this.open();
+	}
+
+	disconnect() {
+		this.shouldReconnect = false;
+		this.clearReconnectTimer();
+		this.socketAuthenticated = false;
+		this.socket?.close();
+		this.socket = undefined;
+	}
+
+	private clearReconnectTimer() {
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = undefined;
+		}
+	}
+
+	private open() {
+		const url = new URL("/cli-ws", this.gatewayUrl);
+		const ws = new WebSocket(url.toString(), {
+			headers:
+				Object.keys(this.io.opts.extraHeaders).length > 0
+					? this.io.opts.extraHeaders
+					: undefined,
+		});
+		this.socket = ws;
+		this.socketAuthenticated = false;
+
+		ws.addEventListener("open", () => {
+			this.emitMessage("auth", this.createAuthToken());
+		});
+
+		ws.addEventListener("message", (event) => {
+			this.handleMessage(event.data);
+		});
+
+		ws.addEventListener("close", (event) => {
+			const wasAuthenticated = this.socketAuthenticated;
+			this.socketAuthenticated = false;
+			this.socket = undefined;
+
+			const reason = event.reason || `close_${event.code}`;
+			if (wasAuthenticated) {
+				this.emitEvent("disconnect", reason);
+			} else {
+				this.emitEvent("connect_error", new Error(reason));
+			}
+
+			if (!this.shouldReconnect) {
+				return;
+			}
+
+			const delay = Math.min(
+				1000 * 2 ** Math.max(0, this.reconnectAttemptCount - 1),
+				30000,
+			);
+			this.reconnectAttemptCount += 1;
+			this.reconnectTimer = setTimeout(() => {
+				this.open();
+			}, delay);
+		});
+
+		ws.addEventListener("error", () => {
+			// close event drives reconnect and error emission
+		});
+	}
+
+	private handleMessage(raw: string | ArrayBuffer | Blob) {
+		if (raw instanceof Blob) {
+			raw
+				.text()
+				.then((text) => this.handleTextMessage(text))
+				.catch(() => {});
+			return;
+		}
+		if (raw instanceof ArrayBuffer) {
+			this.handleTextMessage(Buffer.from(raw).toString("utf8"));
+			return;
+		}
+		this.handleTextMessage(raw);
+	}
+
+	private handleTextMessage(text: string) {
+		try {
+			const message = JSON.parse(text) as { type: string; payload: unknown };
+			switch (message.type) {
+				case "auth-ok":
+					this.socketAuthenticated = true;
+					this.reconnectAttemptCount = 0;
+					this.emitEvent("connect", undefined);
+					return;
+				case "auth-error":
+					this.emitEvent("cli:error", message.payload as CliErrorPayload);
+					this.socket?.close();
+					return;
+				case "redirect": {
+					const payload = message.payload as CliRedirectPayload;
+					this.io.opts.extraHeaders = {
+						...this.io.opts.extraHeaders,
+						"fly-force-instance-id": payload.instanceId,
+					};
+					this.emitEvent("redirect", payload);
+					this.socket?.close();
+					return;
+				}
+				default:
+					super.emit(message.type, message.payload);
+			}
+		} catch (error) {
+			this.emitEvent(
+				"connect_error",
+				error instanceof Error ? error : new Error(String(error)),
+			);
+		}
+	}
+}
+
 export class SocketClient extends EventEmitter {
-	private socket: Socket<GatewayToCliEvents, CliToGatewayEvents>;
+	private socket: GatewayConnection;
 	private connected = false;
 	private reconnectAttempts = 0;
 	private heartbeatInterval?: NodeJS.Timeout;
@@ -157,16 +347,9 @@ export class SocketClient extends EventEmitter {
 	constructor(private readonly options: SocketClientOptions) {
 		super();
 		const { cryptoService } = options;
-		this.socket = io(`${options.config.gatewayUrl}/cli`, {
-			path: "/socket.io",
-			reconnection: true,
-			reconnectionAttempts: Number.POSITIVE_INFINITY,
-			reconnectionDelay: 1000,
-			reconnectionDelayMax: 30000,
-			transports: ["websocket"],
-			autoConnect: false,
-			auth: (cb) => cb(createSignedToken(cryptoService.authKeyPair)),
-		});
+		this.socket = new GatewayConnection(options.config.gatewayUrl, () =>
+			createSignedToken(cryptoService.authKeyPair),
+		);
 		this.setupEventHandlers();
 		this.setupRpcHandlers();
 		this.setupSessionManagerListeners();
@@ -187,24 +370,19 @@ export class SocketClient extends EventEmitter {
 		this.socket.on("connect_error", (error) => {
 			this.reconnectAttempts++;
 
-			// Handle affinity redirect — Fly.io routes to the correct instance
-			if (error.message.startsWith("WRONG_INSTANCE:")) {
-				const targetId = error.message.split(":")[1];
-				logger.info({ targetInstance: targetId }, "gateway_affinity_redirect");
-				this.socket.io.opts.extraHeaders = {
-					...this.socket.io.opts.extraHeaders,
-					"fly-force-instance-id": targetId,
-				};
-				// Socket.io auto-reconnect will carry the new header
-				return;
-			}
-
 			if (this.reconnectAttempts <= 3 || this.reconnectAttempts % 10 === 0) {
 				logger.error(
 					{ attempt: this.reconnectAttempts, err: error },
 					"gateway_connect_error",
 				);
 			}
+		});
+
+		this.socket.on("redirect", (payload) => {
+			logger.info(
+				{ targetInstance: payload.instanceId },
+				"gateway_affinity_redirect",
+			);
 		});
 
 		this.socket.on("cli:registered", async (info) => {
@@ -231,7 +409,7 @@ export class SocketClient extends EventEmitter {
 							});
 						cursor = nextCursor;
 						if (sessions.length > 0) {
-							this.socket.emit("sessions:discovered", {
+							this.socket.emitMessage("sessions:discovered", {
 								sessions,
 								capabilities,
 								nextCursor,
@@ -1288,13 +1466,13 @@ export class SocketClient extends EventEmitter {
 
 		sessionManager.onPermissionRequest((payload) => {
 			if (this.connected) {
-				this.socket.emit("permission:request", payload);
+				this.socket.emitMessage("permission:request", payload);
 			}
 		});
 
 		sessionManager.onPermissionResult((payload) => {
 			if (this.connected) {
-				this.socket.emit("permission:result", payload);
+				this.socket.emitMessage("permission:result", payload);
 			}
 		});
 
@@ -1308,19 +1486,19 @@ export class SocketClient extends EventEmitter {
 					},
 					"sessions_changed_emit",
 				);
-				this.socket.emit("sessions:changed", payload);
+				this.socket.emitMessage("sessions:changed", payload);
 			}
 		});
 
 		sessionManager.onSessionAttached((payload) => {
 			if (this.connected) {
-				this.socket.emit("session:attached", payload);
+				this.socket.emitMessage("session:attached", payload);
 			}
 		});
 
 		sessionManager.onSessionDetached((payload) => {
 			if (this.connected) {
-				this.socket.emit("session:detached", payload);
+				this.socket.emitMessage("session:detached", payload);
 			}
 		});
 
@@ -1349,7 +1527,7 @@ export class SocketClient extends EventEmitter {
 					},
 					"session_event_emitting_to_gateway",
 				);
-				this.socket.emit("session:event", encrypted);
+				this.socket.emitMessage("session:event", encrypted);
 				logger.debug(
 					{
 						sessionId: event.sessionId,
@@ -1416,7 +1594,7 @@ export class SocketClient extends EventEmitter {
 
 	private sendRpcResponse<T>(requestId: string, result: T) {
 		const response: RpcResponse<T> = { requestId, result };
-		this.socket.emit("rpc:response", response);
+		this.socket.emitMessage("rpc:response", response);
 		logger.debug({ requestId }, "rpc_response_sent");
 	}
 
@@ -1447,13 +1625,13 @@ export class SocketClient extends EventEmitter {
 				detail,
 			},
 		};
-		this.socket.emit("rpc:response", response);
+		this.socket.emitMessage("rpc:response", response);
 	}
 
 	private register() {
 		const { config } = this.options;
 		logger.info({ machineId: config.machineId }, "cli_register_emit");
-		this.socket.emit("cli:register", {
+		this.socket.emitMessage("cli:register", {
 			machineId: config.machineId,
 			hostname: config.hostname,
 			version: config.clientVersion,
@@ -1486,7 +1664,7 @@ export class SocketClient extends EventEmitter {
 			logger.error({ err: error }, "cli_register_backfill_failed");
 		}
 		logger.info({ machineId: config.machineId }, "cli_register_sessions_list");
-		this.socket.emit("sessions:list", sessionManager.listAllSessions());
+		this.socket.emitMessage("sessions:list", sessionManager.listAllSessions());
 		this.startHeartbeat();
 
 		if (wasReconnect) {
@@ -1500,8 +1678,8 @@ export class SocketClient extends EventEmitter {
 		this.stopHeartbeat();
 		this.heartbeatInterval = setInterval(() => {
 			if (this.connected) {
-				this.socket.emit("cli:heartbeat");
-				this.socket.emit(
+				this.socket.emitMessage("cli:heartbeat", null);
+				this.socket.emitMessage(
 					"sessions:list",
 					this.options.sessionManager.listAllSessions(),
 				);
@@ -1544,7 +1722,7 @@ export class SocketClient extends EventEmitter {
 
 				for (const event of unackedEvents) {
 					const encrypted = this.options.cryptoService.encryptEvent(event);
-					this.socket.emit("session:event", encrypted);
+					this.socket.emitMessage("session:event", encrypted);
 				}
 			}
 		}

--- a/apps/mobvibe-cli/src/index.ts
+++ b/apps/mobvibe-cli/src/index.ts
@@ -1,13 +1,4 @@
 import { Database } from "bun:sqlite";
-import {
-	cancel,
-	intro,
-	isCancel,
-	log,
-	multiselect,
-	outro,
-} from "@clack/prompts";
-import { Command } from "commander";
 import { loadCredentials } from "./auth/credentials.js";
 import { login, loginStatus, logout } from "./auth/login.js";
 import { getCliConfig } from "./config.js";
@@ -17,297 +8,453 @@ import { logger } from "./lib/logger.js";
 import { resolveSelectedAgents } from "./registry/agent-detector.js";
 import { WalCompactor, WalStore } from "./wal/index.js";
 
-const program = new Command();
+const VERSION = "0.0.0";
 
-program
-	.name("mobvibe")
-	.description("Mobvibe CLI - Connect local ACP backends to the gateway")
-	.version("0.0.0");
+const ROOT_HELP = `Mobvibe CLI - Connect local ACP backends to the gateway
 
-program
-	.command("start")
-	.description("Start the mobvibe daemon")
-	.option("--gateway <url>", "Gateway URL", process.env.MOBVIBE_GATEWAY_URL)
-	.option("--foreground", "Run in foreground instead of detaching")
-	.option("--no-e2ee", "Disable end-to-end encryption for this daemon run")
-	.action(async (options) => {
-		if (options.gateway) {
-			process.env.MOBVIBE_GATEWAY_URL = options.gateway;
+Usage:
+  mobvibe <command> [options]
+
+Commands:
+  start [--gateway <url>] [--foreground] [--no-e2ee]
+  stop
+  status
+  logs [-f|--follow] [-n|--lines <number>]
+  login
+  logout
+  auth-status
+  e2ee <show|status>
+  compact [--session <id>] [--dry-run] [-v|--verbose]
+
+Global options:
+  --help
+  --version`;
+
+const START_HELP = `Usage:
+  mobvibe start [--gateway <url>] [--foreground] [--no-e2ee]`;
+
+const LOGS_HELP = `Usage:
+  mobvibe logs [-f|--follow] [-n|--lines <number>]`;
+
+const E2EE_HELP = `Usage:
+  mobvibe e2ee <show|status>`;
+
+const COMPACT_HELP = `Usage:
+  mobvibe compact [--session <id>] [--dry-run] [-v|--verbose]`;
+
+const fail = (message: string): never => {
+	console.error(message);
+	process.exit(1);
+};
+
+const showAndExit = (text: string) => {
+	console.log(text);
+	process.exit(0);
+};
+
+const parseFlagValue = (args: string[], index: number, flag: string) => {
+	const value = args[index + 1];
+	if (!value || value.startsWith("-")) {
+		fail(`Missing value for ${flag}`);
+	}
+	return value;
+};
+
+const parseStartArgs = (args: string[]) => {
+	let foreground = false;
+	let gateway: string | undefined;
+	let noE2ee = false;
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		switch (arg) {
+			case "--foreground":
+				foreground = true;
+				break;
+			case "--gateway":
+				gateway = parseFlagValue(args, index, "--gateway");
+				index += 1;
+				break;
+			case "--no-e2ee":
+				noE2ee = true;
+				break;
+			case "--help":
+				showAndExit(START_HELP);
+				break;
+			default:
+				fail(`Unknown option for start: ${arg}`);
 		}
-		const config = await getCliConfig();
+	}
 
-		// First run with interactive terminal → prompt user to select agents
-		if (config.enabledAgents === undefined && process.stdout.isTTY) {
-			if (config.registryAgents.length > 0) {
-				intro("Welcome to Mobvibe!");
-				const selected = await multiselect({
-					message: "Which agents do you want to enable?",
-					options: config.registryAgents.map((a) => ({
-						value: a.id,
-						label: a.name,
-						hint: a.description,
-					})),
-					required: false,
-				});
-				if (isCancel(selected)) {
-					cancel("Setup cancelled.");
-					process.exit(0);
+	return {
+		foreground,
+		gateway,
+		noE2ee,
+	};
+};
+
+const parseLogsArgs = (args: string[]) => {
+	let follow = false;
+	let lines = 50;
+
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		switch (arg) {
+			case "-f":
+			case "--follow":
+				follow = true;
+				break;
+			case "-n":
+			case "--lines": {
+				const raw = parseFlagValue(args, index, arg);
+				const parsed = Number.parseInt(raw, 10);
+				if (Number.isNaN(parsed) || parsed <= 0) {
+					fail(`Invalid line count: ${raw}`);
 				}
-
-				// Resolve selected agents — check PATH/npx/uvx availability
-				const { resolved, failed } = resolveSelectedAgents(
-					config.registryAgents,
-					selected as string[],
-				);
-
-				if (failed.length > 0) {
-					for (const agent of failed) {
-						log.warn(
-							`Agent "${agent.name}" cannot be resolved — binary not in PATH, or npx/uvx unavailable. Skipping.`,
-						);
-					}
-				}
-
-				// Only save successfully resolved agent IDs
-				const enabledIds = resolved.map((b) => b.id);
-				await saveUserConfig(config.homePath, {
-					enabledAgents: enabledIds,
-				});
-				config.acpBackends = resolved;
-				config.enabledAgents = enabledIds;
-				outro(
-					`Enabled ${resolved.length} agent(s). Config saved to ${config.homePath}/.config.json`,
-				);
+				lines = parsed;
+				index += 1;
+				break;
 			}
+			case "--help":
+				showAndExit(LOGS_HELP);
+				break;
+			default:
+				fail(`Unknown option for logs: ${arg}`);
 		}
-		// Non-TTY + not configured → use all backends (backwards-compatible for CI/scripts)
+	}
 
-		const daemon = new DaemonManager(config);
-		await daemon.start({
-			foreground: options.foreground,
-			noE2ee: options.noE2ee,
-		});
-	});
+	return {
+		follow,
+		lines,
+	};
+};
 
-program
-	.command("stop")
-	.description("Stop the mobvibe daemon")
-	.action(async () => {
-		const config = await getCliConfig();
-		const daemon = new DaemonManager(config);
-		await daemon.stop();
-	});
+const parseCompactArgs = (args: string[]) => {
+	let dryRun = false;
+	let session: string | undefined;
+	let verbose = false;
 
-program
-	.command("status")
-	.description("Show daemon status")
-	.action(async () => {
-		const config = await getCliConfig();
-		const daemon = new DaemonManager(config);
-		const status = await daemon.status();
-		if (status.running) {
-			logger.info({ pid: status.pid }, "daemon_status_running");
-			console.log(`Daemon is running (PID ${status.pid})`);
-			if (status.connected !== undefined) {
-				console.log(`Connected to gateway: ${status.connected ? "yes" : "no"}`);
-			}
-			if (status.sessionCount !== undefined) {
-				console.log(`Active sessions: ${status.sessionCount}`);
-			}
-		} else {
-			logger.info("daemon_status_not_running");
-			console.log("Daemon is not running");
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		switch (arg) {
+			case "--session":
+				session = parseFlagValue(args, index, "--session");
+				index += 1;
+				break;
+			case "--dry-run":
+				dryRun = true;
+				break;
+			case "-v":
+			case "--verbose":
+				verbose = true;
+				break;
+			case "--help":
+				showAndExit(COMPACT_HELP);
+				break;
+			default:
+				fail(`Unknown option for compact: ${arg}`);
 		}
-	});
+	}
 
-program
-	.command("logs")
-	.description("Show daemon logs")
-	.option("-f, --follow", "Follow log output")
-	.option("-n, --lines <number>", "Number of lines to show", "50")
-	.action(async (options) => {
-		const config = await getCliConfig();
-		const daemon = new DaemonManager(config);
-		await daemon.logs({
-			follow: options.follow,
-			lines: Number.parseInt(options.lines, 10),
-		});
-	});
+	return {
+		dryRun,
+		session,
+		verbose,
+	};
+};
 
-program
-	.command("login")
-	.description("Authenticate with an API key from the WebUI")
-	.action(async () => {
-		const result = await login();
-		if (!result.success) {
-			logger.error({ err: result.error }, "login_failed");
-			console.error(`Login failed: ${result.error}`);
-			process.exit(1);
-		}
-	});
+const promptAgentSelection = async (
+	config: Awaited<ReturnType<typeof getCliConfig>>,
+) => {
+	if (config.enabledAgents !== undefined || !process.stdout.isTTY) {
+		return config;
+	}
 
-program
-	.command("logout")
-	.description("Remove stored credentials")
-	.action(async () => {
-		await logout();
-	});
+	if (config.registryAgents.length === 0) {
+		return config;
+	}
 
-program
-	.command("auth-status")
-	.description("Show authentication status")
-	.action(async () => {
-		await loginStatus();
-	});
-
-const e2eeCmd = program.command("e2ee").description("E2EE key management");
-
-e2eeCmd
-	.command("show")
-	.description("Display the master secret for pairing other devices")
-	.action(async () => {
-		const credentials = await loadCredentials();
-		if (!credentials) {
-			console.error("Not logged in. Run 'mobvibe login' first.");
-			process.exit(1);
-		}
-
-		// Convert standard base64 to base64url for URL safety
-		const base64url = credentials.masterSecret
-			.replace(/\+/g, "-")
-			.replace(/\//g, "_")
-			.replace(/=+$/, "");
-		const pairingUrl = `mobvibe://pair?secret=${base64url}`;
-
-		// Display QR code for mobile scanning
-		const QRCode = await import("qrcode");
-		const qrText = await QRCode.toString(pairingUrl, {
-			type: "terminal",
-			small: true,
-		});
-		console.log(qrText);
-
-		console.log("Master secret (for pairing WebUI/Tauri devices):");
-		console.log(`  ${credentials.masterSecret}`);
+	console.log("Welcome to Mobvibe!");
+	console.log("Select agents to enable on first run:");
+	for (const [index, agent] of config.registryAgents.entries()) {
 		console.log(
-			"\nScan the QR code with your phone, or paste the secret into WebUI Settings > E2EE > Pair.",
+			`  ${index + 1}. ${agent.name} (${agent.id})${agent.description ? ` - ${agent.description}` : ""}`,
 		);
-	});
+	}
 
-e2eeCmd
-	.command("status")
-	.description("Show E2EE key status")
-	.action(async () => {
-		const {
-			initCrypto,
-			deriveAuthKeyPair,
-			deriveContentKeyPair,
-			base64ToUint8,
-			uint8ToBase64,
-		} = await import("@mobvibe/shared");
-		const credentials = await loadCredentials();
-		if (!credentials) {
-			console.log("Status: Not logged in");
-			console.log("Run 'mobvibe login' to authenticate.");
-			return;
-		}
-		await initCrypto();
-		const masterSecret = base64ToUint8(credentials.masterSecret);
-		const authKp = deriveAuthKeyPair(masterSecret);
-		const contentKp = deriveContentKeyPair(masterSecret);
-		const authPub = uint8ToBase64(authKp.publicKey);
-		const contentPub = uint8ToBase64(contentKp.publicKey);
-		console.log("Status: E2EE enabled");
-		console.log(`Auth public key:    ${authPub.slice(0, 16)}...`);
-		console.log(`Content public key: ${contentPub.slice(0, 16)}...`);
-		console.log(`Saved: ${new Date(credentials.createdAt).toLocaleString()}`);
-	});
+	const answer = prompt(
+		"Enter agent numbers or ids separated by commas. Leave blank for none.",
+	);
+	if (answer === null) {
+		console.log("Setup cancelled.");
+		process.exit(0);
+	}
 
-program
-	.command("compact")
-	.description("Compact the WAL database to reclaim space")
-	.option("--session <id>", "Compact a specific session only")
-	.option("--dry-run", "Show what would be deleted without actually deleting")
-	.option("-v, --verbose", "Show detailed output")
-	.action(async (options) => {
-		const config = await getCliConfig();
-
-		if (!config.compaction.enabled && !options.dryRun) {
-			console.log("Compaction is disabled in configuration.");
-			console.log("Set MOBVIBE_COMPACTION_ENABLED=true to enable.");
-			return;
-		}
-
-		const walStore = new WalStore(config.walDbPath);
-		const db = new Database(config.walDbPath);
-		const compactor = new WalCompactor(walStore, config.compaction, db);
-
-		console.log(
-			options.dryRun
-				? "Dry run - no changes will be made"
-				: "Starting compaction...",
-		);
-
-		try {
-			if (options.session) {
-				const stats = await compactor.compactSession(options.session, {
-					dryRun: options.dryRun,
-				});
-				console.log(`Session ${options.session}:`);
-				console.log(`  Acked events deleted: ${stats.ackedEventsDeleted}`);
-				console.log(`  Old revisions deleted: ${stats.oldRevisionsDeleted}`);
-				console.log(`  Duration: ${stats.durationMs.toFixed(2)}ms`);
-			} else {
-				const result = await compactor.compactAll({
-					dryRun: options.dryRun,
-				});
-
-				if (options.verbose) {
-					for (const stats of result.stats) {
-						if (stats.ackedEventsDeleted > 0 || stats.oldRevisionsDeleted > 0) {
-							console.log(`\nSession ${stats.sessionId}:`);
-							console.log(
-								`  Acked events deleted: ${stats.ackedEventsDeleted}`,
-							);
-							console.log(
-								`  Old revisions deleted: ${stats.oldRevisionsDeleted}`,
-							);
-						}
-					}
-					if (result.skipped.length > 0) {
-						console.log(
-							`\nSkipped (active sessions): ${result.skipped.join(", ")}`,
-						);
-					}
-				}
-
-				const totalDeleted = result.stats.reduce(
-					(sum, s) => sum + s.ackedEventsDeleted + s.oldRevisionsDeleted,
-					0,
-				);
-
-				console.log(`\nSummary:`);
-				console.log(`  Sessions processed: ${result.stats.length}`);
-				console.log(`  Sessions skipped: ${result.skipped.length}`);
-				console.log(
-					`  Total events ${options.dryRun ? "to delete" : "deleted"}: ${totalDeleted}`,
-				);
-				console.log(`  Duration: ${result.totalDurationMs.toFixed(2)}ms`);
+	const tokens = answer
+		.split(",")
+		.map((token) => token.trim())
+		.filter(Boolean);
+	const selectedIds = tokens
+		.map((token) => {
+			const asIndex = Number.parseInt(token, 10);
+			if (!Number.isNaN(asIndex) && asIndex >= 1) {
+				return config.registryAgents[asIndex - 1]?.id;
 			}
-		} finally {
-			walStore.close();
-			db.close();
-		}
+			return config.registryAgents.find((agent) => agent.id === token)?.id;
+		})
+		.filter((value): value is string => Boolean(value));
+
+	const { resolved, failed } = resolveSelectedAgents(
+		config.registryAgents,
+		selectedIds,
+	);
+
+	for (const agent of failed) {
+		logger.warn(
+			`Agent "${agent.name}" cannot be resolved — binary not in PATH, or npx/uvx unavailable. Skipping.`,
+		);
+	}
+
+	const enabledIds = resolved.map((backend) => backend.id);
+	await saveUserConfig(config.homePath, {
+		enabledAgents: enabledIds,
 	});
 
-export async function run() {
-	await program.parseAsync(process.argv);
-}
+	return {
+		...config,
+		acpBackends: resolved,
+		enabledAgents: enabledIds,
+	};
+};
 
-if (import.meta.main) {
-	run().catch((error) => {
-		logger.error({ err: error }, "cli_run_error");
-		console.error("Error:", error.message);
+const runStart = async (args: string[]) => {
+	const options = parseStartArgs(args);
+	if (options.gateway) {
+		process.env.MOBVIBE_GATEWAY_URL = options.gateway;
+	}
+
+	let config = await getCliConfig();
+	config = await promptAgentSelection(config);
+
+	const daemon = new DaemonManager(config);
+	await daemon.start({
+		foreground: options.foreground,
+		noE2ee: options.noE2ee,
+	});
+};
+
+const runStatus = async () => {
+	const config = await getCliConfig();
+	const daemon = new DaemonManager(config);
+	const status = await daemon.status();
+	if (!status.running) {
+		console.log("Daemon is not running");
+		return;
+	}
+
+	console.log(`Daemon is running (PID ${status.pid})`);
+	if (status.connected !== undefined) {
+		console.log(`Connected to gateway: ${status.connected ? "yes" : "no"}`);
+	}
+	if (status.sessionCount !== undefined) {
+		console.log(`Active sessions: ${status.sessionCount}`);
+	}
+	if (status.startedAt) {
+		console.log(`Started at: ${new Date(status.startedAt).toLocaleString()}`);
+	}
+	if (status.logFile) {
+		console.log(`Log file: ${status.logFile}`);
+	}
+};
+
+const runLogs = async (args: string[]) => {
+	const options = parseLogsArgs(args);
+	const config = await getCliConfig();
+	const daemon = new DaemonManager(config);
+	await daemon.logs(options);
+};
+
+const runLogin = async () => {
+	const result = await login();
+	if (!result.success) {
+		logger.error({ err: result.error }, "login_failed");
+		console.error(`Login failed: ${result.error}`);
 		process.exit(1);
-	});
-}
+	}
+};
+
+const runE2ee = async (args: string[]) => {
+	const subcommand = args[0];
+	if (!subcommand || subcommand === "--help") {
+		showAndExit(E2EE_HELP);
+	}
+
+	switch (subcommand) {
+		case "show": {
+			const credentials = await loadCredentials();
+			const maybeMasterSecret = credentials?.masterSecret;
+			const masterSecret =
+				maybeMasterSecret ?? fail("Not logged in. Run 'mobvibe login' first.");
+
+			const base64url = masterSecret
+				.replace(/\+/g, "-")
+				.replace(/\//g, "_")
+				.replace(/=+$/, "");
+			const pairingUrl = `mobvibe://pair?secret=${base64url}`;
+			const QRCode = await import("qrcode");
+			const qrText = await QRCode.toString(pairingUrl, {
+				type: "terminal",
+				small: true,
+			});
+			console.log(qrText);
+			console.log("Master secret (for pairing WebUI/Tauri devices):");
+			console.log(`  ${masterSecret}`);
+			console.log(
+				"\nScan the QR code with your phone, or paste the secret into WebUI Settings > E2EE > Pair.",
+			);
+			return;
+		}
+		case "status": {
+			const {
+				base64ToUint8,
+				deriveAuthKeyPair,
+				deriveContentKeyPair,
+				initCrypto,
+				uint8ToBase64,
+			} = await import("@mobvibe/shared");
+			const credentials = await loadCredentials();
+			if (!credentials) {
+				console.log("Status: Not logged in");
+				console.log("Run 'mobvibe login' to authenticate.");
+				return;
+			}
+			await initCrypto();
+			const masterSecret = base64ToUint8(credentials.masterSecret);
+			const authKp = deriveAuthKeyPair(masterSecret);
+			const contentKp = deriveContentKeyPair(masterSecret);
+			console.log("Status: E2EE enabled");
+			console.log(
+				`Auth public key:    ${uint8ToBase64(authKp.publicKey).slice(0, 16)}...`,
+			);
+			console.log(
+				`Content public key: ${uint8ToBase64(contentKp.publicKey).slice(0, 16)}...`,
+			);
+			console.log(`Saved: ${new Date(credentials.createdAt).toLocaleString()}`);
+			return;
+		}
+		default:
+			fail(`Unknown e2ee command: ${subcommand}`);
+	}
+};
+
+const runCompact = async (args: string[]) => {
+	const options = parseCompactArgs(args);
+	const config = await getCliConfig();
+
+	if (!config.compaction.enabled && !options.dryRun) {
+		console.log("Compaction is disabled in configuration.");
+		console.log("Set MOBVIBE_COMPACTION_ENABLED=true to enable.");
+		return;
+	}
+
+	const walStore = new WalStore(config.walDbPath);
+	const db = new Database(config.walDbPath);
+	const compactor = new WalCompactor(walStore, config.compaction, db);
+
+	console.log(
+		options.dryRun
+			? "Dry run - no changes will be made"
+			: "Starting compaction...",
+	);
+
+	try {
+		if (options.session) {
+			const stats = await compactor.compactSession(options.session, {
+				dryRun: options.dryRun,
+			});
+			console.log(`Session ${options.session}:`);
+			console.log(`  Acked events deleted: ${stats.ackedEventsDeleted}`);
+			console.log(`  Old revisions deleted: ${stats.oldRevisionsDeleted}`);
+			console.log(`  Duration: ${stats.durationMs.toFixed(2)}ms`);
+		} else {
+			const result = await compactor.compactAll({ dryRun: options.dryRun });
+			const totalAcked = result.stats.reduce(
+				(sum, stat) => sum + stat.ackedEventsDeleted,
+				0,
+			);
+			const totalRevisions = result.stats.reduce(
+				(sum, stat) => sum + stat.oldRevisionsDeleted,
+				0,
+			);
+			console.log(`Sessions processed: ${result.stats.length}`);
+			console.log(`Acked events deleted: ${totalAcked}`);
+			console.log(`Old revisions deleted: ${totalRevisions}`);
+			console.log(`Duration: ${result.totalDurationMs.toFixed(2)}ms`);
+			if (options.verbose) {
+				for (const session of result.stats) {
+					console.log(
+						`  ${session.sessionId}: ${session.ackedEventsDeleted} acked, ${session.oldRevisionsDeleted} revisions`,
+					);
+				}
+			}
+		}
+	} finally {
+		walStore.close();
+		db.close();
+	}
+};
+
+const main = async () => {
+	const args = Bun.argv.slice(2);
+	if (args.length === 0) {
+		showAndExit(ROOT_HELP);
+	}
+
+	const [command, ...rest] = args;
+	if (command === "--help") {
+		showAndExit(ROOT_HELP);
+	}
+	if (command === "--version") {
+		showAndExit(VERSION);
+	}
+
+	switch (command) {
+		case "start":
+			await runStart(rest);
+			return;
+		case "stop": {
+			const config = await getCliConfig();
+			await new DaemonManager(config).stop();
+			return;
+		}
+		case "status":
+			await runStatus();
+			return;
+		case "logs":
+			await runLogs(rest);
+			return;
+		case "login":
+			await runLogin();
+			return;
+		case "logout":
+			await logout();
+			return;
+		case "auth-status":
+			await loginStatus();
+			return;
+		case "e2ee":
+			await runE2ee(rest);
+			return;
+		case "compact":
+			await runCompact(rest);
+			return;
+		default:
+			fail(`Unknown command: ${command}\n\n${ROOT_HELP}`);
+	}
+};
+
+main().catch((error) => {
+	logger.error({ err: error }, "cli_command_failed");
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -92,6 +92,21 @@ export type {
 	MobvibeUserConfig,
 	UserAgentConfig,
 } from "./types/agent-config.js";
+// Socket event types
+export type {
+	CliAuthOkPayload,
+	CliControlWireMessage,
+	CliControlWirePayloadMap,
+	CliControlWireType,
+	CliRedirectPayload,
+	CliToGatewayWireMessage,
+	CliToGatewayWirePayloadMap,
+	CliToGatewayWireType,
+	GatewayRpcResultMap,
+	GatewayToCliWireMessage,
+	GatewayToCliWirePayloadMap,
+	GatewayToCliWireType,
+} from "./types/cli-wire.js";
 // Error types
 export type {
 	ErrorCode,
@@ -134,7 +149,6 @@ export type {
 	SessionSummary,
 	SessionsChangedPayload,
 } from "./types/session.js";
-// Socket event types
 export type {
 	// HTTP API response types
 	AcpBackendsResponse,

--- a/packages/shared/src/types/cli-wire.ts
+++ b/packages/shared/src/types/cli-wire.ts
@@ -1,0 +1,192 @@
+import type { SignedAuthToken } from "../crypto/types.js";
+import type { StopReason } from "./acp.js";
+import type {
+	SessionFsFilePreview,
+	SessionSummary,
+	SessionsChangedPayload,
+} from "./session.js";
+import type {
+	ArchiveSessionParams,
+	BulkArchiveSessionsParams,
+	CancelSessionParams,
+	CliErrorPayload,
+	CliRegistrationInfo,
+	CreateSessionParams,
+	DiscoverSessionsRpcParams,
+	DiscoverSessionsRpcResult,
+	EventsAckPayload,
+	FsEntriesParams,
+	FsEntriesResponse,
+	FsFileParams,
+	FsResourcesParams,
+	FsResourcesResponse,
+	FsRootsResponse,
+	GitBlameParams,
+	GitBlameResponse,
+	GitBranchesForCwdParams,
+	GitBranchesForCwdResponse,
+	GitBranchesParams,
+	GitBranchesResponse,
+	GitFileDiffParams,
+	GitFileDiffResponse,
+	GitFileHistoryParams,
+	GitFileHistoryResponse,
+	GitGrepParams,
+	GitGrepResponse,
+	GitLogParams,
+	GitLogResponse,
+	GitSearchLogParams,
+	GitSearchLogResponse,
+	GitShowParams,
+	GitShowResponse,
+	GitStashListParams,
+	GitStashListResponse,
+	GitStatusExtendedParams,
+	GitStatusExtendedResponse,
+	GitStatusParams,
+	GitStatusResponse,
+	HostFsEntriesParams,
+	HostFsRootsParams,
+	HostFsRootsResponse,
+	LoadSessionRpcParams,
+	PermissionDecisionPayload,
+	PermissionRequestPayload,
+	ReloadSessionRpcParams,
+	RenameSessionParams,
+	RpcRequest,
+	RpcResponse,
+	SendMessageParams,
+	SessionAttachedPayload,
+	SessionDetachedPayload,
+	SessionEvent,
+	SessionEventsParams,
+	SessionEventsResponse,
+	SessionsDiscoveredPayload,
+	SetSessionModelParams,
+	SetSessionModeParams,
+} from "./socket-events.js";
+
+export type CliAuthOkPayload = {
+	userId: string;
+	deviceId: string;
+};
+
+export type CliRedirectPayload = {
+	instanceId: string;
+};
+
+export type CliToGatewayWirePayloadMap = {
+	"cli:heartbeat": null;
+	"cli:register": CliRegistrationInfo;
+	"permission:request": PermissionRequestPayload;
+	"permission:result": PermissionDecisionPayload;
+	"rpc:response": RpcResponse<unknown>;
+	"session:attached": SessionAttachedPayload;
+	"session:detached": SessionDetachedPayload;
+	"session:event": SessionEvent;
+	"sessions:changed": SessionsChangedPayload;
+	"sessions:discovered": SessionsDiscoveredPayload;
+	"sessions:list": SessionSummary[];
+};
+
+export type GatewayToCliWirePayloadMap = {
+	"auth-error": CliErrorPayload;
+	"auth-ok": CliAuthOkPayload;
+	"cli:error": CliErrorPayload;
+	"cli:registered": {
+		machineId: string;
+		userId?: string;
+	};
+	"events:ack": EventsAckPayload;
+	redirect: CliRedirectPayload;
+	"rpc:fs:entries": RpcRequest<FsEntriesParams>;
+	"rpc:fs:file": RpcRequest<FsFileParams>;
+	"rpc:fs:resources": RpcRequest<FsResourcesParams>;
+	"rpc:fs:roots": RpcRequest<{ sessionId: string }>;
+	"rpc:git:blame": RpcRequest<GitBlameParams>;
+	"rpc:git:branches": RpcRequest<GitBranchesParams>;
+	"rpc:git:branchesForCwd": RpcRequest<GitBranchesForCwdParams>;
+	"rpc:git:fileDiff": RpcRequest<GitFileDiffParams>;
+	"rpc:git:fileHistory": RpcRequest<GitFileHistoryParams>;
+	"rpc:git:grep": RpcRequest<GitGrepParams>;
+	"rpc:git:log": RpcRequest<GitLogParams>;
+	"rpc:git:searchLog": RpcRequest<GitSearchLogParams>;
+	"rpc:git:show": RpcRequest<GitShowParams>;
+	"rpc:git:stashList": RpcRequest<GitStashListParams>;
+	"rpc:git:status": RpcRequest<GitStatusParams>;
+	"rpc:git:statusExtended": RpcRequest<GitStatusExtendedParams>;
+	"rpc:hostfs:entries": RpcRequest<HostFsEntriesParams>;
+	"rpc:hostfs:roots": RpcRequest<HostFsRootsParams>;
+	"rpc:message:send": RpcRequest<SendMessageParams>;
+	"rpc:permission:decision": RpcRequest<PermissionDecisionPayload>;
+	"rpc:session:archive": RpcRequest<ArchiveSessionParams>;
+	"rpc:session:archive-all": RpcRequest<BulkArchiveSessionsParams>;
+	"rpc:session:cancel": RpcRequest<CancelSessionParams>;
+	"rpc:session:create": RpcRequest<CreateSessionParams>;
+	"rpc:session:events": RpcRequest<SessionEventsParams>;
+	"rpc:session:load": RpcRequest<LoadSessionRpcParams>;
+	"rpc:session:model": RpcRequest<SetSessionModelParams>;
+	"rpc:session:mode": RpcRequest<SetSessionModeParams>;
+	"rpc:session:reload": RpcRequest<ReloadSessionRpcParams>;
+	"rpc:session:rename": RpcRequest<RenameSessionParams>;
+	"rpc:sessions:discover": RpcRequest<DiscoverSessionsRpcParams>;
+};
+
+export type CliControlWirePayloadMap = {
+	auth: SignedAuthToken;
+};
+
+type MessageFromMap<
+	TPayloadMap extends Record<string, unknown>,
+	TType extends keyof TPayloadMap = keyof TPayloadMap,
+> = TType extends string
+	? {
+			type: TType;
+			payload: TPayloadMap[TType];
+		}
+	: never;
+
+export type CliControlWireMessage = MessageFromMap<CliControlWirePayloadMap>;
+export type CliToGatewayWireMessage =
+	| CliControlWireMessage
+	| MessageFromMap<CliToGatewayWirePayloadMap>;
+export type GatewayToCliWireMessage =
+	MessageFromMap<GatewayToCliWirePayloadMap>;
+
+export type CliToGatewayWireType = keyof CliToGatewayWirePayloadMap;
+export type GatewayToCliWireType = keyof GatewayToCliWirePayloadMap;
+export type CliControlWireType = keyof CliControlWirePayloadMap;
+
+export type GatewayRpcResultMap = {
+	"rpc:fs:entries": FsEntriesResponse;
+	"rpc:fs:file": SessionFsFilePreview;
+	"rpc:fs:resources": FsResourcesResponse;
+	"rpc:fs:roots": FsRootsResponse;
+	"rpc:git:blame": GitBlameResponse;
+	"rpc:git:branches": GitBranchesResponse;
+	"rpc:git:branchesForCwd": GitBranchesForCwdResponse;
+	"rpc:git:fileDiff": GitFileDiffResponse;
+	"rpc:git:fileHistory": GitFileHistoryResponse;
+	"rpc:git:grep": GitGrepResponse;
+	"rpc:git:log": GitLogResponse;
+	"rpc:git:searchLog": GitSearchLogResponse;
+	"rpc:git:show": GitShowResponse;
+	"rpc:git:stashList": GitStashListResponse;
+	"rpc:git:status": GitStatusResponse;
+	"rpc:git:statusExtended": GitStatusExtendedResponse;
+	"rpc:hostfs:entries": FsEntriesResponse;
+	"rpc:hostfs:roots": HostFsRootsResponse;
+	"rpc:message:send": { stopReason: StopReason };
+	"rpc:permission:decision": { ok: boolean };
+	"rpc:session:archive": { ok: boolean };
+	"rpc:session:archive-all": { archivedCount: number };
+	"rpc:session:cancel": { ok: boolean };
+	"rpc:session:create": SessionSummary;
+	"rpc:session:events": SessionEventsResponse;
+	"rpc:session:load": SessionSummary;
+	"rpc:session:model": SessionSummary;
+	"rpc:session:mode": SessionSummary;
+	"rpc:session:reload": SessionSummary;
+	"rpc:session:rename": SessionSummary;
+	"rpc:sessions:discover": DiscoverSessionsRpcResult;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       web-push:
         specifier: ^3.6.7
         version: 3.6.7
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.11
@@ -78,6 +81,9 @@ importers:
       '@types/web-push':
         specifier: ^3.6.4
         version: 3.6.4
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       drizzle-kit:
         specifier: ^0.31.4
         version: 0.31.8
@@ -99,12 +105,6 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: ^0.16.1
         version: 0.16.1(zod@4.3.5)
-      '@clack/prompts':
-        specifier: ^1.0.1
-        version: 1.0.1
-      commander:
-        specifier: ^13.1.0
-        version: 13.1.0
       ignore:
         specifier: ^7.0.4
         version: 7.0.5
@@ -120,9 +120,6 @@ importers:
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
-      socket.io-client:
-        specifier: ^4.8.1
-        version: 4.8.3
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.11
@@ -703,12 +700,6 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
-
-  '@clack/core@1.0.1':
-    resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==, tarball: https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz}
-
-  '@clack/prompts@1.0.1':
-    resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==, tarball: https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.1.tgz}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==, tarball: https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz}
@@ -2746,6 +2737,9 @@ packages:
   '@types/web-push@3.6.4':
     resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==, tarball: https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==, tarball: https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz}
 
@@ -3091,10 +3085,6 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==, tarball: https://registry.npmjs.org/commander/-/commander-11.1.0.tgz}
     engines: {node: '>=16'}
-
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==, tarball: https://registry.npmjs.org/commander/-/commander-13.1.0.tgz}
-    engines: {node: '>=18'}
 
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==, tarball: https://registry.npmjs.org/commander/-/commander-14.0.2.tgz}
@@ -6238,17 +6228,6 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.11':
     optional: true
 
-  '@clack/core@1.0.1':
-    dependencies:
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
-  '@clack/prompts@1.0.1':
-    dependencies:
-      '@clack/core': 1.0.1
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -7983,6 +7962,10 @@ snapshots:
     dependencies:
       '@types/node': 24.10.7
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.10.7
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@24.10.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))':
@@ -8294,8 +8277,6 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
-
-  commander@13.1.0: {}
 
   commander@14.0.2: {}
 


### PR DESCRIPTION
## Summary
- rewrite `apps/mobvibe-cli` around Bun-native command dispatch, daemon management, and process spawning
- replace CLI↔gateway Socket.io transport with shared plain JSON WebSocket wire types and a new `/cli-ws` gateway endpoint
- add a local daemon control plane for `status`, `stop`, and `logs --follow` using Bun HTTP instead of PID-only checks and `tail -f`

## Implementation
- add shared discriminated wire message types in `packages/shared`
- add gateway `CliTransport` abstraction and route new WebSocket CLI connections through the same registry/session router flow
- keep legacy `/cli` Socket.io path in place during rollout while new CLI uses `/cli-ws`
- remove `commander`, `@clack/prompts`, and `socket.io-client` from the CLI runtime
- switch daemon and ACP subprocess management to `Bun.spawn`

## Verification
- `pnpm build`
- `pnpm -C apps/gateway test:run -- src/services/__tests__/cli-registry.test.ts src/services/__tests__/session-router.test.ts src/socket/__tests__/cli-handlers.test.ts`
- `pnpm -C apps/mobvibe-cli test -- src/acp/__tests__/acp-connection.test.ts src/daemon/__tests__/socket-client.test.ts src/daemon/__tests__/zz-daemon-no-e2ee.test.ts`

## Notes
- root `pnpm lint` still reports existing `webui` accessibility warnings outside this change set
- `apps/mobvibe-cli/src/registry/agent-detector.ts` still has a pre-existing non-null assertion warning
