### PR TITLE
fix(webui): close Android QR overlay on cancel

### DIFF
--- a/apps/webui/src/hooks/__tests__/use-qr-scanner.test.tsx
+++ b/apps/webui/src/hooks/__tests__/use-qr-scanner.test.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIsMobilePlatform = vi.hoisted(() => vi.fn());
+const mockScan = vi.hoisted(() => vi.fn());
+const mockCancel = vi.hoisted(() => vi.fn());
+const mockCheckPermissions = vi.hoisted(() => vi.fn());
+const mockRequestPermissions = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/platform", () => ({
+	isMobilePlatform: mockIsMobilePlatform,
+}));
+
+vi.mock("@tauri-apps/plugin-barcode-scanner", () => ({
+	scan: mockScan,
+	cancel: mockCancel,
+	checkPermissions: mockCheckPermissions,
+	requestPermissions: mockRequestPermissions,
+	Format: {
+		QRCode: "qr",
+	},
+}));
+
+import { useQrScanner } from "../use-qr-scanner";
+
+describe("useQrScanner", () => {
+	beforeEach(() => {
+		mockIsMobilePlatform.mockReset();
+		mockScan.mockReset();
+		mockCancel.mockReset();
+		mockCheckPermissions.mockReset();
+		mockRequestPermissions.mockReset();
+		document.documentElement.classList.remove("qr-scanning");
+	});
+
+	it("clears scanning state when native cancel returns before scan settles", async () => {
+		mockIsMobilePlatform.mockResolvedValue(true);
+		mockCheckPermissions.mockResolvedValue("granted");
+		mockScan.mockImplementation(() => new Promise<never>(() => undefined));
+		mockCancel.mockResolvedValue(undefined);
+
+		const { result } = renderHook(() => useQrScanner());
+
+		await waitFor(() => {
+			expect(result.current.canScan).toBe(true);
+		});
+
+		let scanPromise!: Promise<string | null>;
+
+		act(() => {
+			scanPromise = result.current.startScan();
+		});
+
+		await waitFor(() => {
+			expect(result.current.isScanning).toBe(true);
+			expect(document.documentElement.classList.contains("qr-scanning")).toBe(
+				true,
+			);
+		});
+
+		await act(async () => {
+			await result.current.cancelScan();
+		});
+
+		await waitFor(() => {
+			expect(result.current.isScanning).toBe(false);
+			expect(document.documentElement.classList.contains("qr-scanning")).toBe(
+				false,
+			);
+		});
+
+		await expect(scanPromise).resolves.toBeNull();
+		expect(mockCancel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/webui/src/hooks/use-qr-scanner.ts
+++ b/apps/webui/src/hooks/use-qr-scanner.ts
@@ -107,6 +107,11 @@ export function useQrScanner(): UseQrScannerReturn {
 	return { canScan, isScanning, startScan, cancelScan, videoRef };
 }
 
+function isCancelledScanError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.toLowerCase().includes("cancel");
+}
+
 /* ------------------------------------------------------------------ */
 /*  Tauri mobile strategy                                              */
 /* ------------------------------------------------------------------ */
@@ -132,22 +137,6 @@ async function startTauriScan(
 
 	let popstateCleanup: (() => void) | null = null;
 
-	const onPopstate = () => {
-		void cancel();
-	};
-	window.addEventListener("popstate", onPopstate);
-	popstateCleanup = () => {
-		window.removeEventListener("popstate", onPopstate);
-		// Clean up the fake history entry if scan completed normally
-		if (history.state?.qrScan) {
-			history.back();
-		}
-	};
-
-	cancelRef.current = async () => {
-		await cancel();
-	};
-
 	// Make the WebView transparent so the native camera preview behind it
 	// is visible. The plugin sets the Android WebView background to
 	// transparent when `windowed: true`, but the HTML/CSS backgrounds
@@ -155,21 +144,64 @@ async function startTauriScan(
 	document.documentElement.classList.add("qr-scanning");
 
 	try {
-		const result = await scan({
-			formats: [Format.QRCode],
-			windowed: true,
+		return await new Promise<string | null>((resolve, reject) => {
+			let settled = false;
+
+			const finish = (
+				handler: (
+					resolve: (value: string | null) => void,
+					reject: (reason?: unknown) => void,
+				) => void,
+			) => {
+				if (settled) return;
+				settled = true;
+				popstateCleanup?.();
+				popstateCleanup = null;
+				handler(resolve, reject);
+			};
+
+			const cancelCurrentScan = async () => {
+				finish((resolve) => resolve(null));
+				try {
+					await cancel();
+				} catch (error) {
+					if (!isCancelledScanError(error)) {
+						console.warn("Failed to cancel native QR scan:", error);
+					}
+				}
+			};
+
+			const onPopstate = () => {
+				void cancelCurrentScan();
+			};
+			window.addEventListener("popstate", onPopstate);
+			popstateCleanup = () => {
+				window.removeEventListener("popstate", onPopstate);
+				if (history.state?.qrScan) {
+					history.back();
+				}
+			};
+
+			cancelRef.current = cancelCurrentScan;
+
+			void Promise.resolve()
+				.then(() =>
+					scan({
+						formats: [Format.QRCode],
+						windowed: true,
+					}),
+				)
+				.then((result) => {
+					finish((resolve) => resolve(result?.content ?? null));
+				})
+				.catch((error) => {
+					if (isCancelledScanError(error)) {
+						finish((resolve) => resolve(null));
+						return;
+					}
+					finish((_, reject) => reject(error));
+				});
 		});
-		popstateCleanup();
-		popstateCleanup = null;
-		return result?.content ?? null;
-	} catch (err) {
-		popstateCleanup?.();
-		popstateCleanup = null;
-		const msg = err instanceof Error ? err.message : String(err);
-		if (msg.toLowerCase().includes("cancel")) {
-			return null;
-		}
-		throw err;
 	} finally {
 		document.documentElement.classList.remove("qr-scanning");
 	}


### PR DESCRIPTION
## Summary
- fix the Tauri mobile QR scan cancel path so the React scanning state closes immediately on cancel
- keep the browser qr-scanner flow unchanged and scope the behavior change to the Tauri branch
- add a hook regression test for the case where native cancel returns before the pending scan promise settles

## Testing
- not run locally: apps/webui dependencies are not installed in this worktree (vitest command not found)
