### PR TITLE
Fix Windows cwd picker host root handling

### DIFF
--- a/apps/mobvibe-cli/src/daemon/__tests__/host-fs.test.ts
+++ b/apps/mobvibe-cli/src/daemon/__tests__/host-fs.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import type { FsEntry } from "@mobvibe/shared";
+import {
+	buildHostFsEntries,
+	buildHostFsRoots,
+	buildWindowsPathSegments,
+	WINDOWS_HOST_ROOT_NAME,
+	WINDOWS_HOST_ROOT_PATH,
+} from "../host-fs.js";
+
+const createDirectoryEntry = (name: string, entryPath: string): FsEntry => ({
+	name,
+	path: entryPath,
+	type: "directory",
+	hidden: false,
+});
+
+describe("host-fs", () => {
+	test("returns a single fake root on Windows", async () => {
+		const result = await buildHostFsRoots("win32", "C:\\Users\\tester");
+
+		expect(result).toEqual({
+			homePath: "C:\\Users\\tester",
+			roots: [{ name: WINDOWS_HOST_ROOT_NAME, path: WINDOWS_HOST_ROOT_PATH }],
+		});
+	});
+
+	test("builds Windows path segments from a real path", () => {
+		expect(buildWindowsPathSegments("D:\\repo\\src")).toEqual([
+			{
+				name: WINDOWS_HOST_ROOT_NAME,
+				path: WINDOWS_HOST_ROOT_PATH,
+				selectable: false,
+			},
+			{ name: "D:", path: "D:\\" },
+			{ name: "repo", path: "D:\\repo" },
+			{ name: "src", path: "D:\\repo\\src" },
+		]);
+	});
+
+	test("returns drive entries when requesting the Windows fake root", async () => {
+		const result = await buildHostFsEntries(
+			WINDOWS_HOST_ROOT_PATH,
+			async () => [],
+			"win32",
+			async () => [
+				createDirectoryEntry("C:", "C:\\"),
+				createDirectoryEntry("D:", "D:\\"),
+			],
+		);
+
+		expect(result).toEqual({
+			path: WINDOWS_HOST_ROOT_PATH,
+			entries: [
+				createDirectoryEntry("C:", "C:\\"),
+				createDirectoryEntry("D:", "D:\\"),
+			],
+		});
+	});
+
+	test("returns real entries and segments for Windows paths", async () => {
+		const result = await buildHostFsEntries(
+			"D:\\repo\\src",
+			async (dirPath) => [createDirectoryEntry("nested", `${dirPath}\\nested`)],
+			"win32",
+		);
+
+		expect(result).toEqual({
+			path: "D:\\repo\\src",
+			entries: [createDirectoryEntry("nested", "D:\\repo\\src\\nested")],
+			segments: [
+				{
+					name: WINDOWS_HOST_ROOT_NAME,
+					path: WINDOWS_HOST_ROOT_PATH,
+					selectable: false,
+				},
+				{ name: "D:", path: "D:\\" },
+				{ name: "repo", path: "D:\\repo" },
+				{ name: "src", path: "D:\\repo\\src" },
+			],
+		});
+	});
+});

--- a/apps/mobvibe-cli/src/daemon/host-fs.ts
+++ b/apps/mobvibe-cli/src/daemon/host-fs.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import type {
+	FsEntriesResponse,
+	FsEntry,
+	FsPathSegment,
+	HostFsRootsResponse,
+} from "@mobvibe/shared";
+
+export const WINDOWS_HOST_ROOT_PATH = "__mobvibe_host_root__";
+export const WINDOWS_HOST_ROOT_NAME = "Computer";
+
+const WINDOWS_DRIVE_LETTERS = Array.from({ length: 26 }, (_value, index) =>
+	String.fromCharCode(65 + index),
+);
+
+const isWindowsPlatform = (platform: NodeJS.Platform = process.platform) =>
+	platform === "win32";
+
+const normalizeWindowsPath = (targetPath: string) =>
+	path.win32.normalize(targetPath);
+
+const listWindowsDrives = async (): Promise<FsEntry[]> => {
+	const entries: Array<FsEntry | undefined> = await Promise.all(
+		WINDOWS_DRIVE_LETTERS.map(async (letter): Promise<FsEntry | undefined> => {
+			const drivePath = `${letter}:\\`;
+			try {
+				await fs.access(drivePath);
+				return {
+					name: `${letter}:`,
+					path: drivePath,
+					type: "directory",
+					hidden: false,
+				};
+			} catch {
+				return undefined;
+			}
+		}),
+	);
+	return entries.filter((entry): entry is FsEntry => Boolean(entry));
+};
+
+export const buildHostFsRoots = async (
+	platform: NodeJS.Platform = process.platform,
+	homePath = homedir(),
+): Promise<HostFsRootsResponse> => {
+	if (isWindowsPlatform(platform)) {
+		return {
+			homePath,
+			roots: [{ name: WINDOWS_HOST_ROOT_NAME, path: WINDOWS_HOST_ROOT_PATH }],
+		};
+	}
+	return {
+		homePath,
+		roots: [{ name: "Home", path: homePath }],
+	};
+};
+
+export const buildWindowsPathSegments = (
+	targetPath: string,
+): FsPathSegment[] => {
+	const normalizedTarget = normalizeWindowsPath(targetPath);
+	const parsedTarget = path.win32.parse(normalizedTarget);
+	const driveRoot = parsedTarget.root;
+	if (!driveRoot) {
+		return [
+			{
+				name: WINDOWS_HOST_ROOT_NAME,
+				path: WINDOWS_HOST_ROOT_PATH,
+				selectable: false,
+			},
+		];
+	}
+
+	const segments: FsPathSegment[] = [
+		{
+			name: WINDOWS_HOST_ROOT_NAME,
+			path: WINDOWS_HOST_ROOT_PATH,
+			selectable: false,
+		},
+		{
+			name: driveRoot.replace(/[\\/]+$/, ""),
+			path: driveRoot,
+		},
+	];
+
+	const relativePath = normalizedTarget.slice(driveRoot.length);
+	if (!relativePath) {
+		return segments;
+	}
+
+	let currentPath = driveRoot;
+	for (const part of relativePath.split(/[\\/]+/).filter(Boolean)) {
+		currentPath = path.win32.join(currentPath, part);
+		segments.push({
+			name: part,
+			path: currentPath,
+		});
+	}
+
+	return segments;
+};
+
+export const buildHostFsEntries = async (
+	requestPath: string,
+	readDirectoryEntries: (dirPath: string) => Promise<FsEntry[]>,
+	platform: NodeJS.Platform = process.platform,
+	resolveWindowsDrives: () => Promise<FsEntry[]> = listWindowsDrives,
+): Promise<FsEntriesResponse> => {
+	if (!isWindowsPlatform(platform)) {
+		const entries = await readDirectoryEntries(requestPath);
+		return { path: requestPath, entries };
+	}
+
+	if (requestPath === WINDOWS_HOST_ROOT_PATH) {
+		return {
+			path: WINDOWS_HOST_ROOT_PATH,
+			entries: await resolveWindowsDrives(),
+		};
+	}
+
+	const normalizedPath = normalizeWindowsPath(requestPath);
+	const entries = await readDirectoryEntries(normalizedPath);
+	return {
+		path: normalizedPath,
+		entries,
+		segments: buildWindowsPathSegments(normalizedPath),
+	};
+};

--- a/apps/mobvibe-cli/src/daemon/socket-client.ts
+++ b/apps/mobvibe-cli/src/daemon/socket-client.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
 import type {
 	CliToGatewayEvents,
@@ -10,7 +9,6 @@ import type {
 	FsRoot,
 	GatewayToCliEvents,
 	GitBranchesForCwdResponse,
-	HostFsRootsResponse,
 	RpcResponse,
 	SessionEventsResponse,
 	SessionFsFilePreview,
@@ -45,6 +43,7 @@ import {
 	searchGitLog,
 } from "../lib/git-utils.js";
 import { logger } from "../lib/logger.js";
+import { buildHostFsEntries, buildHostFsRoots } from "./host-fs.js";
 import { resolveWithinCwd } from "./path-utils.js";
 
 type SocketClientOptions = {
@@ -157,14 +156,6 @@ const readDirectoryEntries = async (dirPath: string): Promise<FsEntry[]> => {
 
 const filterVisibleEntries = (entries: FsEntry[]) =>
 	entries.filter((entry) => !entry.hidden);
-
-const buildHostFsRoots = async (): Promise<HostFsRootsResponse> => {
-	const homePath = homedir();
-	return {
-		homePath,
-		roots: [{ name: "Home", path: homePath }],
-	};
-};
 
 /** Minimum interval between automatic discover calls (ms) */
 const DISCOVER_THROTTLE_MS = 60_000;
@@ -570,11 +561,10 @@ export class SocketClient extends EventEmitter {
 					{ requestId: request.requestId, machineId, path: requestPath },
 					"rpc_hostfs_entries",
 				);
-				const entries = await readDirectoryEntries(requestPath);
-				this.sendRpcResponse(request.requestId, {
-					path: requestPath,
-					entries: filterVisibleEntries(entries),
-				});
+				const result = await buildHostFsEntries(requestPath, async (dirPath) =>
+					filterVisibleEntries(await readDirectoryEntries(dirPath)),
+				);
+				this.sendRpcResponse(request.requestId, result);
 			} catch (error) {
 				logger.error(
 					{

--- a/apps/mobvibe-cli/src/lib/__tests__/git-project-context.test.ts
+++ b/apps/mobvibe-cli/src/lib/__tests__/git-project-context.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import {
+	getGitRepoRoot,
+	isGitRepo,
+	resolveGitProjectContext,
+} from "../git-utils.js";
+
+const execFileAsync = promisify(execFile);
+
+async function runGit(cwd: string, args: string[]): Promise<void> {
+	await execFileAsync("git", args, { cwd });
+}
+
+async function createRepoFixture(): Promise<{
+	rootDir: string;
+	repoDir: string;
+	worktreeDir: string;
+	subdir: string;
+}> {
+	const rootDir = await mkdtemp(path.join(tmpdir(), "mobvibe-git-utils-"));
+	const repoDir = path.join(rootDir, "project");
+	const subdir = path.join(repoDir, "apps", "webui");
+	const worktreeDir = path.join(rootDir, "worktrees", "feat-branch");
+
+	await mkdir(subdir, { recursive: true });
+	await writeFile(path.join(repoDir, "README.md"), "# test\n");
+	await writeFile(path.join(subdir, ".gitkeep"), "");
+
+	await execFileAsync("git", ["init", repoDir]);
+	await runGit(repoDir, ["config", "user.name", "Mobvibe Test"]);
+	await runGit(repoDir, ["config", "user.email", "test@mobvibe.local"]);
+	await runGit(repoDir, ["add", "."]);
+	await runGit(repoDir, ["commit", "-m", "init"]);
+
+	return {
+		rootDir,
+		repoDir,
+		worktreeDir,
+		subdir,
+	};
+}
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+	);
+});
+
+describe("git project context", () => {
+	it("returns true when directory is a git repo", async () => {
+		const fixture = await createRepoFixture();
+		tempDirs.push(fixture.rootDir);
+
+		const result = await isGitRepo(fixture.repoDir);
+
+		expect(result).toBe(true);
+	});
+
+	it("returns false when directory is not a git repo", async () => {
+		const rootDir = await mkdtemp(path.join(tmpdir(), "mobvibe-git-utils-"));
+		const dir = path.join(rootDir, "not-a-repo");
+		tempDirs.push(rootDir);
+		await mkdir(dir, { recursive: true });
+
+		const result = await isGitRepo(dir);
+
+		expect(result).toBe(false);
+	});
+
+	it("returns repo root for directories inside a git repo", async () => {
+		const fixture = await createRepoFixture();
+		tempDirs.push(fixture.rootDir);
+
+		const result = await getGitRepoRoot(fixture.subdir);
+
+		expect(result).toBe(fixture.repoDir);
+	});
+
+	it("returns undefined when cwd is not inside a git repo", async () => {
+		const rootDir = await mkdtemp(path.join(tmpdir(), "mobvibe-git-utils-"));
+		const dir = path.join(rootDir, "not-a-repo");
+		tempDirs.push(rootDir);
+		await mkdir(dir, { recursive: true });
+
+		const result = await getGitRepoRoot(dir);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("resolves repo root and relative cwd for subdirectories", async () => {
+		const fixture = await createRepoFixture();
+		tempDirs.push(fixture.rootDir);
+
+		const result = await resolveGitProjectContext(fixture.subdir);
+
+		expect(result).toEqual({
+			isGitRepo: true,
+			repoRoot: fixture.repoDir,
+			repoName: "project",
+			relativeCwd: path.join("apps", "webui"),
+			isRepoRoot: false,
+		});
+	});
+
+	it("marks repo root directories correctly", async () => {
+		const fixture = await createRepoFixture();
+		tempDirs.push(fixture.rootDir);
+
+		const result = await resolveGitProjectContext(fixture.repoDir);
+
+		expect(result).toEqual({
+			isGitRepo: true,
+			repoRoot: fixture.repoDir,
+			repoName: "project",
+			relativeCwd: undefined,
+			isRepoRoot: true,
+		});
+	});
+
+	it("normalizes linked worktrees back to the primary project root", async () => {
+		const fixture = await createRepoFixture();
+		tempDirs.push(fixture.rootDir);
+		await mkdir(path.dirname(fixture.worktreeDir), { recursive: true });
+		await runGit(fixture.repoDir, [
+			"worktree",
+			"add",
+			"-b",
+			"feat-branch",
+			fixture.worktreeDir,
+		]);
+
+		const result = await resolveGitProjectContext(
+			path.join(fixture.worktreeDir, "apps", "webui"),
+		);
+
+		expect(result).toEqual({
+			isGitRepo: true,
+			repoRoot: fixture.repoDir,
+			repoName: "project",
+			relativeCwd: path.join("apps", "webui"),
+			isRepoRoot: false,
+		});
+	});
+});

--- a/apps/mobvibe-cli/src/lib/__tests__/git-utils.test.ts
+++ b/apps/mobvibe-cli/src/lib/__tests__/git-utils.test.ts
@@ -18,14 +18,11 @@ mock.module("../git-io.js", () => ({
 }));
 
 const {
-	isGitRepo,
-	getGitRepoRoot,
 	getGitBranch,
 	getGitBranches,
 	getGitStatus,
 	getFileDiff,
 	aggregateDirStatus,
-	resolveGitProjectContext,
 	validateGitRef,
 } = await import("../git-utils.js");
 
@@ -34,126 +31,6 @@ describe("git-utils", () => {
 		mockExecFileAsync.mockClear();
 		execFileQueue.length = 0;
 		mockReadFile.mockClear();
-	});
-
-	describe("isGitRepo", () => {
-		it("returns true when directory is a git repo", async () => {
-			execFileQueue.push({ stdout: "true\n", stderr: "" });
-
-			const result = await isGitRepo("/home/user/project");
-
-			expect(result).toBe(true);
-			expect(mockExecFileAsync).toHaveBeenCalledWith(
-				"git",
-				["rev-parse", "--is-inside-work-tree"],
-				expect.objectContaining({ cwd: "/home/user/project" }),
-			);
-		});
-
-		it("returns false when directory is not a git repo", async () => {
-			execFileQueue.push(new Error("Not a git repository"));
-
-			const result = await isGitRepo("/home/user/not-a-repo");
-
-			expect(result).toBe(false);
-		});
-	});
-
-	describe("getGitRepoRoot", () => {
-		it("returns repo root for directories inside a git repo", async () => {
-			execFileQueue.push({
-				stdout: "/home/user/project\n",
-				stderr: "",
-			});
-
-			const result = await getGitRepoRoot("/home/user/project/apps/webui");
-
-			expect(result).toBe("/home/user/project");
-		});
-
-		it("returns undefined when cwd is not inside a git repo", async () => {
-			execFileQueue.push(new Error("not a git repo"));
-
-			const result = await getGitRepoRoot("/home/user/not-a-repo");
-
-			expect(result).toBeUndefined();
-		});
-	});
-
-	describe("resolveGitProjectContext", () => {
-		it("resolves repo root and relative cwd for subdirectories", async () => {
-			execFileQueue.push(
-				{
-					stdout: "/home/user/project\n",
-					stderr: "",
-				},
-				{
-					stdout: "worktree /home/user/project\n",
-					stderr: "",
-				},
-			);
-
-			const result = await resolveGitProjectContext(
-				"/home/user/project/apps/webui",
-			);
-
-			expect(result).toEqual({
-				isGitRepo: true,
-				repoRoot: "/home/user/project",
-				repoName: "project",
-				relativeCwd: "apps/webui",
-				isRepoRoot: false,
-			});
-		});
-
-		it("marks repo root directories correctly", async () => {
-			execFileQueue.push(
-				{
-					stdout: "/home/user/project\n",
-					stderr: "",
-				},
-				{
-					stdout: "worktree /home/user/project\n",
-					stderr: "",
-				},
-			);
-
-			const result = await resolveGitProjectContext("/home/user/project");
-
-			expect(result).toEqual({
-				isGitRepo: true,
-				repoRoot: "/home/user/project",
-				repoName: "project",
-				relativeCwd: undefined,
-				isRepoRoot: true,
-			});
-		});
-
-		it("normalizes linked worktrees back to the primary project root", async () => {
-			execFileQueue.push(
-				{
-					stdout: "/tmp/worktrees/project/feat-branch\n",
-					stderr: "",
-				},
-				{
-					stdout:
-						"worktree /home/user/project\nHEAD abc123\nbranch refs/heads/main\n\nworktree /tmp/worktrees/project/feat-branch\nHEAD def456\nbranch refs/heads/feat-branch\n",
-					stderr: "",
-				},
-			);
-
-			const result = await resolveGitProjectContext(
-				"/tmp/worktrees/project/feat-branch/apps/webui",
-			);
-
-			expect(result).toEqual({
-				isGitRepo: true,
-				repoRoot: "/home/user/project",
-				repoName: "project",
-				relativeCwd: "apps/webui",
-				isRepoRoot: false,
-			});
-		});
 	});
 
 	describe("getGitBranch", () => {

--- a/apps/webui/src/components/app/ColumnFileBrowser.tsx
+++ b/apps/webui/src/components/app/ColumnFileBrowser.tsx
@@ -16,26 +16,28 @@ import {
 import { useTranslation } from "react-i18next";
 import { FileTypeLabel } from "@/components/app/file-type-label";
 import { GitStatusIndicator } from "@/components/app/git-status-indicator";
-import type { FsEntriesResponse, FsEntry, GitFileStatus } from "@/lib/api";
+import type {
+	FsEntriesResponse,
+	FsEntry,
+	FsPathSegment,
+	GitFileStatus,
+} from "@/lib/api";
 import { createFallbackError, normalizeError } from "@/lib/error-utils";
 import { FuzzyHighlight, fuzzySearch } from "@/lib/fuzzy-search";
 import { cn } from "@/lib/utils";
 
 const normalizePath = (value: string) => value.replace(/\/+$/, "");
 
-type PathSegment = {
-	name: string;
-	path: string;
-};
-
 const buildPathSegments = (
 	rootPath: string,
 	targetPath: string,
 	rootLabel: string,
-): PathSegment[] => {
+): FsPathSegment[] => {
 	const normalizedRoot = normalizePath(rootPath);
 	const normalizedTarget = normalizePath(targetPath);
-	const segments: PathSegment[] = [{ name: rootLabel, path: normalizedRoot }];
+	const segments: FsPathSegment[] = [
+		{ name: rootLabel, path: normalizedRoot, selectable: true },
+	];
 	if (normalizedTarget === normalizedRoot) {
 		return segments;
 	}
@@ -56,12 +58,14 @@ export type ColumnFileBrowserColumn = {
 	name: string;
 	path: string;
 	entries: FsEntry[];
+	selectable?: boolean;
 };
 
 export type UseColumnFileBrowserOptions = {
 	open: boolean;
 	rootPath?: string;
 	rootLabel: string;
+	defaultPath?: string;
 	value: string | undefined;
 	onChange: (nextPath: string) => void;
 	onSelect?: (nextPath: string) => void;
@@ -89,6 +93,7 @@ export function useColumnFileBrowser({
 	open,
 	rootPath,
 	rootLabel,
+	defaultPath,
 	value,
 	onChange,
 	onSelect,
@@ -111,6 +116,34 @@ export function useColumnFileBrowser({
 		[errorMessage],
 	);
 
+	const buildColumnsFromResponse = useCallback(
+		async (
+			targetResponse: FsEntriesResponse,
+		): Promise<ColumnFileBrowserColumn[]> => {
+			if (!rootPath) {
+				return [];
+			}
+			const segments =
+				targetResponse.segments && targetResponse.segments.length > 0
+					? targetResponse.segments
+					: buildPathSegments(rootPath, targetResponse.path, rootLabel);
+			const responses = await Promise.all(
+				segments.map((segment) =>
+					segment.path === targetResponse.path
+						? Promise.resolve(targetResponse)
+						: fetchEntries({ path: segment.path }),
+				),
+			);
+			return segments.map((segment, index) => ({
+				name: segment.name,
+				path: responses[index].path,
+				entries: responses[index].entries,
+				selectable: segment.selectable,
+			}));
+		},
+		[fetchEntries, rootLabel, rootPath],
+	);
+
 	const buildColumnsForPath = useCallback(
 		async (targetPath: string, notifySelect = false, fallbackPath?: string) => {
 			if (!rootPath) {
@@ -120,23 +153,7 @@ export function useColumnFileBrowser({
 			setPathError(undefined);
 			try {
 				const targetResponse = await fetchEntries({ path: targetPath });
-				const segments = buildPathSegments(
-					rootPath,
-					targetResponse.path,
-					rootLabel,
-				);
-				const responses = await Promise.all(
-					segments.map((segment) =>
-						segment.path === targetResponse.path
-							? Promise.resolve(targetResponse)
-							: fetchEntries({ path: segment.path }),
-					),
-				);
-				const nextColumns = segments.map((segment, index) => ({
-					name: segment.name,
-					path: responses[index].path,
-					entries: responses[index].entries,
-				}));
+				const nextColumns = await buildColumnsFromResponse(targetResponse);
 				setColumns(nextColumns);
 				if (targetResponse.path !== value) {
 					onChange(targetResponse.path);
@@ -148,23 +165,7 @@ export function useColumnFileBrowser({
 				if (fallbackPath && fallbackPath !== targetPath) {
 					try {
 						const fbResponse = await fetchEntries({ path: fallbackPath });
-						const fbSegments = buildPathSegments(
-							rootPath,
-							fbResponse.path,
-							rootLabel,
-						);
-						const fbResponses = await Promise.all(
-							fbSegments.map((segment) =>
-								segment.path === fbResponse.path
-									? Promise.resolve(fbResponse)
-									: fetchEntries({ path: segment.path }),
-							),
-						);
-						const fbColumns = fbSegments.map((segment, index) => ({
-							name: segment.name,
-							path: fbResponses[index].path,
-							entries: fbResponses[index].entries,
-						}));
+						const fbColumns = await buildColumnsFromResponse(fbResponse);
 						setColumns(fbColumns);
 						if (fbResponse.path !== value) {
 							onChange(fbResponse.path);
@@ -184,18 +185,18 @@ export function useColumnFileBrowser({
 			}
 		},
 		[
+			buildColumnsFromResponse,
 			fetchEntries,
 			normalizeErrorMessage,
 			onChange,
 			onSelect,
-			rootLabel,
 			rootPath,
 			value,
 		],
 	);
 
 	const handleEntrySelect = useCallback(
-		async (entry: FsEntry, columnIndex: number) => {
+		async (entry: FsEntry, _columnIndex: number) => {
 			if (entry.type === "file") {
 				onFileSelect?.(entry);
 				return;
@@ -204,12 +205,7 @@ export function useColumnFileBrowser({
 			setPathError(undefined);
 			try {
 				const response = await fetchEntries({ path: entry.path });
-				const nextColumns = columns.slice(0, columnIndex + 1);
-				nextColumns.push({
-					name: entry.name,
-					path: response.path,
-					entries: response.entries,
-				});
+				const nextColumns = await buildColumnsFromResponse(response);
 				setColumns(nextColumns);
 				if (response.path !== value) {
 					onChange(response.path);
@@ -222,7 +218,7 @@ export function useColumnFileBrowser({
 			}
 		},
 		[
-			columns,
+			buildColumnsFromResponse,
 			fetchEntries,
 			normalizeErrorMessage,
 			onChange,
@@ -235,7 +231,7 @@ export function useColumnFileBrowser({
 	const handleColumnSelect = useCallback(
 		(columnIndex: number) => {
 			const column = columns[columnIndex];
-			if (!column) {
+			if (!column || column.selectable === false) {
 				return;
 			}
 			setColumns(columns.slice(0, columnIndex + 1));
@@ -295,14 +291,14 @@ export function useColumnFileBrowser({
 		if (!rootPath || initialized) {
 			return;
 		}
-		const initialPath = value ?? rootPath;
+		const initialPath = value ?? defaultPath ?? rootPath;
 		void buildColumnsForPath(
 			initialPath,
 			false,
 			initialPath !== rootPath ? rootPath : undefined,
 		);
 		setInitialized(true);
-	}, [buildColumnsForPath, initialized, open, rootPath, value]);
+	}, [buildColumnsForPath, defaultPath, initialized, open, rootPath, value]);
 
 	return {
 		columns,
@@ -509,9 +505,11 @@ function ColumnPanel({
 		>
 			<button
 				type="button"
+				disabled={column.selectable === false}
 				className={cn(
 					"text-muted-foreground border-input flex shrink-0 items-center gap-2 border-b px-2 py-1 text-xs",
 					isColumnSelected && "bg-muted text-foreground",
+					column.selectable === false && "cursor-default opacity-70",
 				)}
 				onClick={() => onColumnSelect(columnIndex)}
 			>

--- a/apps/webui/src/components/app/ColumnFileBrowser.tsx
+++ b/apps/webui/src/components/app/ColumnFileBrowser.tsx
@@ -196,7 +196,7 @@ export function useColumnFileBrowser({
 	);
 
 	const handleEntrySelect = useCallback(
-		async (entry: FsEntry, _columnIndex: number) => {
+		async (entry: FsEntry, columnIndex: number) => {
 			if (entry.type === "file") {
 				onFileSelect?.(entry);
 				return;
@@ -205,7 +205,17 @@ export function useColumnFileBrowser({
 			setPathError(undefined);
 			try {
 				const response = await fetchEntries({ path: entry.path });
-				const nextColumns = await buildColumnsFromResponse(response);
+				const nextColumns =
+					response.segments && response.segments.length > 0
+						? await buildColumnsFromResponse(response)
+						: [
+								...columns.slice(0, columnIndex + 1),
+								{
+									name: entry.name,
+									path: response.path,
+									entries: response.entries,
+								},
+							];
 				setColumns(nextColumns);
 				if (response.path !== value) {
 					onChange(response.path);
@@ -219,6 +229,7 @@ export function useColumnFileBrowser({
 		},
 		[
 			buildColumnsFromResponse,
+			columns,
 			fetchEntries,
 			normalizeErrorMessage,
 			onChange,

--- a/apps/webui/src/components/app/WorkingDirectoryPicker.tsx
+++ b/apps/webui/src/components/app/WorkingDirectoryPicker.tsx
@@ -53,7 +53,8 @@ export function WorkingDirectoryPicker({
 	});
 
 	const homePath = rootsQuery.data?.homePath;
-	const homeLabel =
+	const rootPath = rootsQuery.data?.roots[0]?.path ?? homePath;
+	const rootLabel =
 		rootsQuery.data?.roots[0]?.name ??
 		t("workingDirectory.homeLabel", {
 			defaultValue: HOME_LABEL_FALLBACK,
@@ -80,8 +81,9 @@ export function WorkingDirectoryPicker({
 		columnRefs,
 	} = useColumnFileBrowser({
 		open,
-		rootPath: homePath,
-		rootLabel: homeLabel,
+		rootPath,
+		rootLabel,
+		defaultPath: homePath,
 		value,
 		onChange,
 		onSelect,

--- a/apps/webui/src/components/app/__tests__/ColumnFileBrowser.test.tsx
+++ b/apps/webui/src/components/app/__tests__/ColumnFileBrowser.test.tsx
@@ -1,4 +1,10 @@
-import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import {
+	act,
+	render,
+	renderHook,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { FsEntriesResponse, FsEntry } from "@/lib/api";
 import { ColumnFileBrowser, useColumnFileBrowser } from "../ColumnFileBrowser";
@@ -151,6 +157,64 @@ describe("useColumnFileBrowser", () => {
 		});
 		expect(onChange).toHaveBeenCalledWith("C:\\Users\\tester");
 		expect(onChange).not.toHaveBeenCalledWith(WINDOWS_HOST_ROOT_PATH);
+	});
+
+	it("appends a child column when Windows session entries omit segments", async () => {
+		const fetchEntries = vi.fn(
+			async ({ path }: { path: string }): Promise<FsEntriesResponse> => {
+				switch (path) {
+					case "C:\\repo":
+						return {
+							path,
+							entries: [createDirectoryEntry("src", "C:\\repo\\src")],
+						};
+					case "C:\\repo\\src":
+						return {
+							path,
+							entries: [
+								createDirectoryEntry("nested", "C:\\repo\\src\\nested"),
+							],
+						};
+					default:
+						throw new Error(`Unexpected path: ${path}`);
+				}
+			},
+		);
+		const onChange = vi.fn();
+
+		const { result } = renderHook(() =>
+			useColumnFileBrowser({
+				open: true,
+				rootPath: "C:\\repo",
+				rootLabel: "repo",
+				value: "C:\\repo",
+				onChange,
+				fetchEntries,
+				errorMessage: "failed",
+			}),
+		);
+
+		await waitFor(() => {
+			expect(result.current.columns).toHaveLength(1);
+		});
+
+		await act(async () => {
+			await result.current.handleEntrySelect(
+				createDirectoryEntry("src", "C:\\repo\\src"),
+				0,
+			);
+		});
+
+		await waitFor(() => {
+			expect(result.current.columns).toHaveLength(2);
+		});
+
+		expect(result.current.columns.map((column) => column.name)).toEqual([
+			"repo",
+			"src",
+		]);
+		expect(result.current.columns[1]?.path).toBe("C:\\repo\\src");
+		expect(onChange).toHaveBeenCalledWith("C:\\repo\\src");
 	});
 });
 

--- a/apps/webui/src/components/app/__tests__/ColumnFileBrowser.test.tsx
+++ b/apps/webui/src/components/app/__tests__/ColumnFileBrowser.test.tsx
@@ -1,0 +1,178 @@
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { FsEntriesResponse, FsEntry } from "@/lib/api";
+import { ColumnFileBrowser, useColumnFileBrowser } from "../ColumnFileBrowser";
+
+vi.mock("react-i18next", () => ({
+	initReactI18next: { type: "3rdParty", init: () => {} },
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+const WINDOWS_HOST_ROOT_PATH = "__mobvibe_host_root__";
+
+const createDirectoryEntry = (name: string, entryPath: string): FsEntry => ({
+	name,
+	path: entryPath,
+	type: "directory",
+	hidden: false,
+});
+
+describe("useColumnFileBrowser", () => {
+	it("builds columns from backend segments for Windows host paths", async () => {
+		const fetchEntries = vi.fn(
+			async ({ path }: { path: string }): Promise<FsEntriesResponse> => {
+				switch (path) {
+					case WINDOWS_HOST_ROOT_PATH:
+						return {
+							path,
+							entries: [createDirectoryEntry("D:", "D:\\")],
+						};
+					case "D:\\":
+						return {
+							path,
+							entries: [createDirectoryEntry("repo", "D:\\repo")],
+						};
+					case "D:\\repo":
+						return {
+							path,
+							entries: [createDirectoryEntry("src", "D:\\repo\\src")],
+						};
+					case "D:\\repo\\src":
+						return {
+							path,
+							entries: [
+								createDirectoryEntry("nested", "D:\\repo\\src\\nested"),
+							],
+							segments: [
+								{
+									name: "Computer",
+									path: WINDOWS_HOST_ROOT_PATH,
+									selectable: false,
+								},
+								{ name: "D:", path: "D:\\" },
+								{ name: "repo", path: "D:\\repo" },
+								{ name: "src", path: "D:\\repo\\src" },
+							],
+						};
+					default:
+						throw new Error(`Unexpected path: ${path}`);
+				}
+			},
+		);
+		const onChange = vi.fn();
+
+		const { result } = renderHook(() =>
+			useColumnFileBrowser({
+				open: true,
+				rootPath: WINDOWS_HOST_ROOT_PATH,
+				rootLabel: "Computer",
+				defaultPath: "C:\\Users\\tester",
+				value: "D:\\repo\\src",
+				onChange,
+				fetchEntries,
+				errorMessage: "failed",
+			}),
+		);
+
+		await waitFor(() => {
+			expect(result.current.columns).toHaveLength(4);
+		});
+
+		expect(result.current.columns.map((column) => column.name)).toEqual([
+			"Computer",
+			"D:",
+			"repo",
+			"src",
+		]);
+		expect(result.current.columns[0]?.selectable).toBe(false);
+		expect(onChange).not.toHaveBeenCalledWith(WINDOWS_HOST_ROOT_PATH);
+	});
+
+	it("uses the provided default path instead of the fake root on first load", async () => {
+		const fetchEntries = vi.fn(
+			async ({ path }: { path: string }): Promise<FsEntriesResponse> => {
+				switch (path) {
+					case WINDOWS_HOST_ROOT_PATH:
+						return {
+							path,
+							entries: [createDirectoryEntry("C:", "C:\\")],
+						};
+					case "C:\\":
+						return {
+							path,
+							entries: [createDirectoryEntry("Users", "C:\\Users")],
+						};
+					case "C:\\Users":
+						return {
+							path,
+							entries: [createDirectoryEntry("tester", "C:\\Users\\tester")],
+						};
+					case "C:\\Users\\tester":
+						return {
+							path,
+							entries: [
+								createDirectoryEntry("repo", "C:\\Users\\tester\\repo"),
+							],
+							segments: [
+								{
+									name: "Computer",
+									path: WINDOWS_HOST_ROOT_PATH,
+									selectable: false,
+								},
+								{ name: "C:", path: "C:\\" },
+								{ name: "Users", path: "C:\\Users" },
+								{ name: "tester", path: "C:\\Users\\tester" },
+							],
+						};
+					default:
+						throw new Error(`Unexpected path: ${path}`);
+				}
+			},
+		);
+		const onChange = vi.fn();
+
+		renderHook(() =>
+			useColumnFileBrowser({
+				open: true,
+				rootPath: WINDOWS_HOST_ROOT_PATH,
+				rootLabel: "Computer",
+				defaultPath: "C:\\Users\\tester",
+				value: undefined,
+				onChange,
+				fetchEntries,
+				errorMessage: "failed",
+			}),
+		);
+
+		await waitFor(() => {
+			expect(fetchEntries).toHaveBeenCalledWith({ path: "C:\\Users\\tester" });
+		});
+		expect(onChange).toHaveBeenCalledWith("C:\\Users\\tester");
+		expect(onChange).not.toHaveBeenCalledWith(WINDOWS_HOST_ROOT_PATH);
+	});
+});
+
+describe("ColumnFileBrowser", () => {
+	it("disables non-selectable column headers", () => {
+		render(
+			<ColumnFileBrowser
+				columns={[
+					{
+						name: "Computer",
+						path: WINDOWS_HOST_ROOT_PATH,
+						entries: [],
+						selectable: false,
+					},
+				]}
+				onColumnSelect={() => {}}
+				onEntrySelect={() => {}}
+				scrollContainerRef={{ current: null }}
+				columnRefs={{ current: {} }}
+			/>,
+		);
+
+		expect(screen.getByRole("button", { name: "Computer" })).toBeDisabled();
+	});
+});

--- a/apps/webui/src/i18n/locales/en/translation.json
+++ b/apps/webui/src/i18n/locales/en/translation.json
@@ -85,7 +85,7 @@
 		"backendEmpty": "No backends available",
 		"backendPlaceholder": "Select backend",
 		"cwdLabel": "Working directory",
-		"cwdPlaceholder": "Enter or paste a Home path",
+		"cwdPlaceholder": "Enter or paste a path",
 		"browse": "Browse",
 		"targetMachine": "Target: {{name}}",
 		"projectDetection": {

--- a/apps/webui/src/i18n/locales/zh/translation.json
+++ b/apps/webui/src/i18n/locales/zh/translation.json
@@ -85,7 +85,7 @@
 		"backendEmpty": "暂无可用后端",
 		"backendPlaceholder": "选择后端",
 		"cwdLabel": "工作目录",
-		"cwdPlaceholder": "输入或粘贴 Home 内路径",
+		"cwdPlaceholder": "输入或粘贴路径",
 		"browse": "浏览",
 		"targetMachine": "目标机器：{{name}}",
 		"projectDetection": {

--- a/apps/webui/src/lib/api.ts
+++ b/apps/webui/src/lib/api.ts
@@ -6,6 +6,7 @@ export type {
 	ErrorDetail,
 	FsEntriesResponse,
 	FsEntry,
+	FsPathSegment,
 	GitFileStatus,
 	HostFsRootsResponse,
 	MachinesResponse,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -174,6 +174,7 @@ export type {
 	FsEntriesParams,
 	FsEntriesResponse,
 	FsFileParams,
+	FsPathSegment,
 	FsResourcesParams,
 	FsResourcesResponse,
 	FsRootsResponse,

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -212,9 +212,16 @@ export type FsRootsResponse = {
 	root: FsRoot;
 };
 
+export type FsPathSegment = {
+	name: string;
+	path: string;
+	selectable?: boolean;
+};
+
 export type FsEntriesResponse = {
 	path: string;
 	entries: FsEntry[];
+	segments?: FsPathSegment[];
 };
 
 export type FsResourcesResponse = {


### PR DESCRIPTION
## Summary
- model Windows host filesystem browsing as a single `Computer` root in the new-session cwd picker
- have the CLI return Windows path segments for real paths while keeping the frontend on a single-root model
- update the picker to prefer backend-provided segments and keep fake-root tokens out of the selected cwd

## Testing
- `pnpm -C apps/mobvibe-cli test -- src/daemon/__tests__/host-fs.test.ts`
- `pnpm -C apps/webui test:run -- src/components/app/__tests__/ColumnFileBrowser.test.tsx src/components/app/__tests__/FileExplorerDialog.test.tsx src/components/app/__tests__/CreateSessionDialog.test.tsx`
- `pnpm format`
- `pnpm lint`
- `pnpm build`