### PR TITLE
chore(cli): remove unused open dependency

### DIFF
--- a/apps/mobvibe-cli/package.json
+++ b/apps/mobvibe-cli/package.json
@@ -53,7 +53,6 @@
 		"@clack/prompts": "^1.0.1",
 		"commander": "^13.1.0",
 		"ignore": "^7.0.4",
-		"open": "^10.1.0",
 		"pino": "^9.6.0",
 		"pino-pretty": "^13.1.1",
 		"qrcode": "^1.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
       ignore:
         specifier: ^7.0.4
         version: 7.0.5
-      open:
-        specifier: ^10.1.0
-        version: 10.2.0
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -4642,10 +4639,6 @@ packages:
 
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==, tarball: https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz}
-
-  open@10.2.0:
-    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==, tarball: https://registry.npmjs.org/open/-/open-10.2.0.tgz}
-    engines: {node: '>=18'}
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==, tarball: https://registry.npmjs.org/open/-/open-11.0.0.tgz}
@@ -10151,13 +10144,6 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
-
-  open@10.2.0:
-    dependencies:
-      default-browser: 5.4.0
-      define-lazy-prop: 3.0.0
-      is-inside-container: 1.0.0
-      wsl-utils: 0.1.0
 
   open@11.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- remove the unused `open` dependency from `@mobvibe/cli`
- trim the workspace lockfile so the CLI no longer references `open@10.2.0`
- keep the change scoped to dependency metadata only

## Test Plan
- `pnpm -C apps/mobvibe-cli build`
- `pnpm -C apps/mobvibe-cli test`
- `pnpm -C apps/mobvibe-cli lint:check`
- `pnpm format && pnpm lint && pnpm build`